### PR TITLE
chore: ignore .vercel project config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ apps/web/test-results/
 # TypeScript incremental build cache
 apps/web/tsconfig.tsbuildinfo
 
+# Vercel project config
+.vercel
+


### PR DESCRIPTION
Adds `.vercel` to `.gitignore`. Missed from the PR #2 squash merge.