### PR TITLE
[audit] fix: Prevent merchants creating plans with same address and different terms

### DIFF
--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -33,10 +33,10 @@ export const PLAN_SEED = 'plan';
 export const SUBSCRIPTION_SEED = 'subscription';
 export const EVENT_AUTHORITY_SEED = 'event_authority';
 
-// Plan: discriminator(1) + owner(32) + bump(1) + status(1) + planData(448)
-export const PLAN_SIZE = 483;
-// Subscription: header(67) + amountPulledInPeriod(8) + currentPeriodStartTs(8) + expiresAtTs(8) + planPda(32)
-export const SUBSCRIPTION_SIZE = 123;
+// Plan: discriminator(1) + owner(32) + bump(1) + status(1) + planData(456)
+export const PLAN_SIZE = 491;
+// Subscription: header(99) + terms(24) + amountPulledInPeriod(8) + currentPeriodStartTs(8) + expiresAtTs(8)
+export const SUBSCRIPTION_SIZE = 147;
 
 export const PLAN_OWNER_OFFSET = 1;
 

--- a/clients/typescript/src/instructions/plan.ts
+++ b/clients/typescript/src/instructions/plan.ts
@@ -96,8 +96,11 @@ export async function buildCreatePlan(params: {
       planData: {
         planId,
         mint,
-        amount,
-        periodHours,
+        terms: {
+          amount,
+          periodHours,
+          createdAt: 0n,
+        },
         endTs,
         destinations: paddedDestinations,
         pullers: paddedPullers,

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   fetchMaybePlan,
+  fetchMaybeSubscriptionDelegation,
   fetchSubscriptionDelegation,
   PlanStatus,
 } from '../src/generated/index.ts';
@@ -180,5 +181,123 @@ describe('Subscription Lifecycle', () => {
 
     const balance = await t.rpc.getTokenAccountBalance(pullerAta).send();
     expect(balance.value.amount).toBe(pullAmount.toString());
+  });
+
+  test('ghost account attack is blocked and subscriber can recover', async () => {
+    const t = await initTestSuite();
+
+    // 1. Merchant creates plan
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 10n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    // 2. Subscriber subscribes
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 10n,
+      tokenMint: t.tokenMint,
+    });
+
+    // 3. Merchant sunsets, expires, and deletes the plan
+    const validatorTs = await t.getValidatorTime();
+    const endTs = validatorTs + 10n;
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Sunset,
+      endTs,
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await t.timeTravel(Number(endTs) + 5);
+
+    await t.client.deletePlan({
+      owner: t.payerKeypair,
+      planPda,
+    });
+
+    // 4. Merchant recreates plan with same planId but different terms (ghost)
+    const { planPda: ghostPlanPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 10n,
+      mint: t.tokenMint,
+      amount: 999_000_000n,
+      periodHours: 720n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/ghost.json',
+    });
+
+    expect(ghostPlanPda).toBe(planPda);
+
+    // 5. Transfer is blocked with PlanTermsMismatch
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    await expect(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 100_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+    ).rejects.toThrow();
+
+    // 6. Subscriber cancels (immediate expiry, no grace period)
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const subAfterCancel = (
+      await fetchSubscriptionDelegation(t.rpc, subscriptionPda)
+    ).data;
+    expect(subAfterCancel.expiresAtTs).not.toBe(0n);
+
+    // 7. Subscriber revokes delegation, getting rent back
+    const { signature: revokeSig } = await t.client.revokeDelegation({
+      authority: subscriber,
+      delegationAccount: subscriptionPda,
+    });
+    expect(revokeSig).toBeDefined();
+
+    // Subscription account should be closed
+    const subAfterRevoke = await fetchMaybeSubscriptionDelegation(
+      t.rpc,
+      subscriptionPda,
+    );
+    expect(subAfterRevoke.exists).toBe(false);
   });
 });

--- a/docs/002-subscriptions-architecture.md
+++ b/docs/002-subscriptions-architecture.md
@@ -79,7 +79,7 @@ graph TB
 1. **Add-On, Not Replacement**: ADR-002 extends ADR-001 without modifying core flows
 2. **Mutual Agreement**: Plans enable both parties to verify and agree on terms before commitment
 3. **Immutable Terms**: Once published, Plan terms cannot change (prevents mid-stream price hikes)
-4. **Separate Controls vs Terms**: `update_plan` can modify status, end_ts, pullers, metadata_uri - but NOT core terms (mint, amount, period_hours, destinations)
+4. **Separate Controls vs Terms**: `update_plan` can modify status, end_ts, pullers, metadata_uri - but NOT core terms (mint, terms.amount, terms.period_hours, terms.created_at, destinations)
 5. **Unified Execution**: Subscriptions and direct delegations share the same MDA and transfer flows
 6. **Coexistence**: Direct delegations (ADR-001) and subscriptions (ADR-002) operate simultaneously
 
@@ -117,7 +117,7 @@ ADR-001 provides the core delegation infrastructure. Plans add a subscription mo
       - Set end_ts (graceful discontinuation, or 0 to remove expiry; cannot be 0 when sunsetting)
       - Update pullers array (change authorized callers)
       - Update metadata_uri (change plan description/branding)
-   - Without modifying core terms (mint, amount, period_hours, destinations)
+   - Without modifying core terms (mint, terms, destinations)
    - `delete_plan` allows the owner to reclaim rent after a plan has expired (end_ts has passed)
 
 6. **Zero Breaking Changes to ADR-001**
@@ -138,7 +138,7 @@ ADR-001 provides the core delegation infrastructure. Plans add a subscription mo
 | **Creation** | Delegator initiates | Delegatee publishes, delegators subscribe |
 | **Terms Storage** | Embedded per delegation | Single Plan for all |
 | **Cost Structure** | Full cost per delegation | Plan cost (1x) + Delegation cost (Nx) |
-| **Term Mutability** | Per delegation | Core billing terms immutable; pullers, status, end_ts, metadata_uri mutable |
+| **Term Mutability** | Per delegation | Core billing terms (amount, period_hours, created_at) immutable and snapshotted per subscription; pullers, status, end_ts, metadata_uri mutable |
 | **Discoverability** | Manual PDA sharing | Plans can be discovered/marketplace |
 | **Use Cases** | P2P, custom, one-off | Subscription services, SaaS, platforms |
 | **Pull Authorization** | Delegatee-only (`transfer_fixed`/`transfer_recurring`) | Owner + configurable pullers array (`transfer_subscription`) |
@@ -148,31 +148,32 @@ ADR-001 provides the core delegation infrastructure. Plans add a subscription mo
 
 ADR-002 is built **on top of** ADR-001's core infrastructure with **zero changes to existing flows**:
 
-**Key Insight: Terms are Referenced, Not Copied**
+**Key Insight: Terms are Snapshotted at Subscribe Time**
 
-The Plan PDA is the **live source of truth** for subscription terms. When a subscriber subscribes, a lightweight `SubscriptionDelegation` PDA is created that **references** the Plan PDA (via `header.delegatee = plan_pda`). At transfer time, `transfer_subscription` loads the Plan PDA to read the current terms. This means:
+When a subscriber subscribes, the plan's `PlanTerms` (amount, period_hours, created_at) are copied into the `SubscriptionDelegation` PDA. At transfer time, `transfer_subscription` reads billing terms from the subscription's snapshot and validates them against the live plan via `check_plan_terms()`. This prevents ghost-account attacks where a merchant deletes and recreates a plan at the same PDA address with different terms.
 
 | Flow | Terms Storage | Transfer Reads From |
 |------|--------------|---------------------|
 | **Direct Delegation (ADR-001)** | Terms embedded in Delegation PDA | Delegation PDA only |
-| **Subscription (ADR-002)** | Terms stored in Plan PDA, Delegation tracks billing state | Plan PDA (terms) + Delegation PDA (state) |
+| **Subscription (ADR-002)** | Terms snapshotted in SubscriptionDelegation + stored in Plan PDA | Subscription PDA (billing terms) + Plan PDA (authorization, destinations, expiry) |
 
 **What SubscriptionDelegation Stores:**
 - `header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber)
+- `terms` - snapshot of plan's PlanTerms (amount, period_hours, created_at)
 - `amount_pulled_in_period` - tracking for the current billing period
 - `current_period_start_ts` - start of the current billing period
 - `expires_at_ts` - cancellation timestamp (0 = active)
 
 **What Plans Provide at Transfer Time:**
-- `amount` - the per-period limit
-- `period_hours` - billing period length
+- `terms` - validated against subscription's snapshot via `check_plan_terms()`
 - `destinations` - whitelisted receiver addresses
 - `pullers` - authorized caller addresses
 - `mint` - token mint for validation
+- `end_ts` - plan expiration
 
 **The Plan is Just a Reusable container for terms:**
 - Plan = Published, reusable terms that delegators can subscribe to
-- Subscribe = Create a Delegation PDA with a reference to the Plan's terms
+- Subscribe = Create a Delegation PDA with a snapshot of the Plan's terms
 - After subscription, the Delegation works exactly like ADR-001 delegations
 
 **Subscription Uses a Dedicated Transfer Instruction:**
@@ -218,13 +219,20 @@ Top-level account structure:
 - `status`: 1 byte - `PlanStatus` enum (Sunset=0, Active=1)
 - `data`: PlanData (see below)
 
-### PlanData (448 bytes)
+### PlanTerms (24 bytes)
+
+Immutable billing terms snapshotted into each SubscriptionDelegation at subscribe time. The `created_at` field acts as a unique fingerprint for the plan's lifecycle, preventing ghost-account attacks.
+
+- `amount`: 8 bytes (`u64`) - Amount per period
+- `period_hours`: 8 bytes (`u64`) - Hours in each billing period
+- `created_at`: 8 bytes (`i64`) - Unix timestamp set by the program at plan creation time
+
+### PlanData (456 bytes)
 
 Embedded payload within the Plan PDA:
 - `plan_id`: 8 bytes (`u64`) - Unique identifier
 - `mint`: 32 bytes (`Address`) - Token mint
-- `amount`: 8 bytes (`u64`) - Amount per period
-- `period_hours`: 8 bytes (`u64`) - Hours in each billing period
+- `terms`: 24 bytes (`PlanTerms`) - Immutable billing terms (amount, period_hours, created_at)
 - `end_ts`: 8 bytes (`i64`) - Plan expiration timestamp (0 = no expiry)
 - `destinations`: 128 bytes (`[Address; 4]`) - Up to 4 fund recipients (all zeros = any destination valid at transfer time)
 - `pullers`: 128 bytes (`[Address; 4]`) - Up to 4 authorized pullers
@@ -249,11 +257,12 @@ The `destinations` array controls where pulled funds can be sent. If the array i
 Per-subscriber billing state linked to a Plan:
 
 - `header`: 99 bytes - shared `Header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber)
+- `terms`: 24 bytes (`PlanTerms`) - snapshot of the plan's billing terms at subscribe time
 - `amount_pulled_in_period`: 8 bytes (`u64`) - tokens transferred in the current billing period
 - `current_period_start_ts`: 8 bytes (`i64`) - start of the current billing period
 - `expires_at_ts`: 8 bytes (`i64`) - cancellation timestamp (0 = active, non-zero = cancelled)
 
-**Total size**: 123 bytes
+**Total size**: 147 bytes
 
 **PDA seeds**: `["subscription", plan_pda, subscriber]`
 
@@ -278,17 +287,16 @@ Merchant publishes a Plan with subscription terms.
 **Parameters (PlanData):**
 - `plan_id: u64` - Unique identifier
 - `mint: Address` - Token mint
-- `amount: u64` - Amount per period
-- `period_hours: u64` - Hours per billing period
+- `terms: PlanTerms` - Billing terms (amount, period_hours, created_at). `created_at` is overwritten on-chain.
 - `end_ts: i64` - Plan expiration (0 = no expiry)
 - `destinations: [Address; 4]` - Fund recipients, optional (all zeros = any destination valid at transfer time)
 - `pullers: [Address; 4]` - Authorized pullers (optional, plan owner always authorized by default)
 - `metadata_uri: [u8; 128]` - Optional metadata URI
 
 **Validation:**
-1. `amount > 0` (else `InvalidAmount`)
-2. `0 < period_hours <= 8760` (else `InvalidPeriodLength`)
-3. `end_ts == 0` or `end_ts > current_time` (else `InvalidEndTs`)
+1. `terms.amount > 0` (else `InvalidAmount`)
+2. `0 < terms.period_hours <= 8760` (else `InvalidPeriodLength`)
+3. `end_ts == 0` or `end_ts >= current_time + (terms.period_hours * 3600)` (else `InvalidEndTs`)
 
 **Process:**
 1. Validate PlanData fields (see above)
@@ -296,10 +304,11 @@ Merchant publishes a Plan with subscription terms.
 3. Create Plan account via CPI to System Program (handles pre-funded accounts)
 4. Set `discriminator = Plan (1)`, `owner = merchant`, `bump`, `status = Active (1)`
 5. Copy PlanData into the account
+6. Set `terms.created_at = Clock::get()?.unix_timestamp` (overwrites client value)
 
 ### `update_plan` (Discriminator: 8)
 
-Plan owner updates mutable admin fields (status, end_ts, pullers, metadata_uri). Core terms (mint, amount, period_hours, destinations, plan_id) are immutable.
+Plan owner updates mutable admin fields (status, end_ts, pullers, metadata_uri). Core terms (mint, terms, destinations, plan_id) are immutable.
 
 | Account | Type     | Description        |
 | ------- | -------- | ------------------ |
@@ -322,7 +331,7 @@ Plan owner updates mutable admin fields (status, end_ts, pullers, metadata_uri).
 7. Write status, end_ts, pullers, and metadata_uri from input data
 
 **Immutable fields (never modified by update_plan):**
-`plan_id`, `owner`, `bump`, `mint`, `amount`, `period_hours`, `destinations`
+`plan_id`, `owner`, `bump`, `mint`, `terms` (amount, period_hours, created_at), `destinations`
 
 ### `delete_plan` (Discriminator: 9)
 
@@ -372,6 +381,7 @@ Subscriber subscribes to a Plan, creating a lightweight `SubscriptionDelegation`
 5. Check subscription doesn't already exist (else `AlreadySubscribed`)
 6. Create SubscriptionDelegation account with:
    - `header.delegator = subscriber`, `header.delegatee = plan_pda`, `header.payer = subscriber`
+   - `terms = plan.data.terms` (snapshot of plan's billing terms)
    - `amount_pulled_in_period = 0`, `current_period_start_ts = current_ts`, `expires_at_ts = 0`
 7. Emit `SubscriptionCreatedEvent` via self-CPI
 
@@ -404,13 +414,14 @@ Authorized caller (plan owner or whitelisted puller) pulls tokens from a subscri
 3. Check plan not expired: `end_ts == 0` or `current_ts <= end_ts` (else `PlanExpired`)
 4. Authorize caller: must be plan owner or listed in `pullers` array (else `Unauthorized`)
 5. Validate destination: if plan has non-zero destinations, receiver ATA owner must match one (else `UnauthorizedDestination`); if all destinations are zero, any receiver is valid
-6. Load SubscriptionDelegation and verify `delegatee == plan_pda` (else `SubscriptionPlanMismatch`)
-7. Verify `delegator` matches `transfer_data.delegator` (else `Unauthorized`)
-8. Check subscription not cancelled: if `expires_at_ts != 0 && current_ts >= expires_at_ts`, block the transfer (else `SubscriptionCancelled`)
-9. Validate recurring transfer: amount within period limit, handle period rollover
-10. Update subscription state (`current_period_start_ts`, `amount_pulled_in_period`)
-11. Execute transfer via MultiDelegate PDA (CPI to Token Program)
-12. Emit `SubscriptionTransferEvent` via self-CPI
+6. Load SubscriptionDelegation and verify plan terms match via `check_plan_terms()` (else `PlanTermsMismatch`)
+7. Verify `delegatee == plan_pda` (else `SubscriptionPlanMismatch`)
+8. Verify `delegator` matches `transfer_data.delegator` (else `Unauthorized`)
+9. Check subscription not cancelled: if `expires_at_ts != 0 && current_ts >= expires_at_ts`, block the transfer (else `SubscriptionCancelled`)
+10. Validate recurring transfer using subscription's snapshotted terms: amount within period limit, handle period rollover
+11. Update subscription state (`current_period_start_ts`, `amount_pulled_in_period`)
+12. Execute transfer via MultiDelegate PDA (CPI to Token Program)
+13. Emit `SubscriptionTransferEvent` via self-CPI
 
 **Authorization Logic:**
 - Direct delegations (ADR-001): Only delegatee can call transfer
@@ -420,7 +431,12 @@ Authorized caller (plan owner or whitelisted puller) pulls tokens from a subscri
 
 ### `cancel_subscription` (Discriminator: 12)
 
-Subscriber cancels their subscription. Computes `expires_at_ts` as the end of the current billing period, allowing the merchant to pull for the remainder of that period (grace period). If the plan account is closed, `expires_at_ts` is set to the current timestamp (immediate expiration). After `expires_at_ts` passes, pulls are blocked. The subscriber can then call `revoke_delegation` to close the account and reclaim rent.
+Subscriber cancels their subscription. Three paths based on plan state:
+- **Plan exists, terms match:** grace period (expires at end of current billing period)
+- **Plan exists, terms mismatch (ghost plan):** immediate expiration (`expires_at_ts = current_ts`)
+- **Plan closed:** immediate expiration (`expires_at_ts = current_ts`)
+
+After `expires_at_ts` passes, pulls are blocked. The subscriber can then call `revoke_delegation` to close the account and reclaim rent.
 
 | Account | Type             | Description                      |
 | ------- | ---------------- | -------------------------------- |
@@ -438,9 +454,10 @@ Subscriber cancels their subscription. Computes `expires_at_ts` as the end of th
 3. Verify subscription's delegatee matches the plan PDA (else `SubscriptionPlanMismatch`)
 
 **Process:**
-1. If plan is valid (program-owned): compute `expires_at_ts = current_period_start + (periods_elapsed + 1) * period_length`
-2. If plan is closed (not program-owned): set `expires_at_ts = current_ts`
-3. Emit `SubscriptionCancelled` event via self-CPI
+1. If plan is valid (program-owned) and `check_plan_terms()` passes: compute `expires_at_ts = current_period_start + (periods_elapsed + 1) * period_length` using subscription's snapshotted `terms.period_hours`
+2. If plan is valid but `check_plan_terms()` fails (ghost plan): set `expires_at_ts = current_ts` (immediate, no grace period)
+3. If plan is closed (not program-owned): set `expires_at_ts = current_ts`
+4. Emit `SubscriptionCancelled` event via self-CPI
 
 **Two-step revocation flow:**
 - `cancel_subscription` → pre-computes `expires_at_ts` (end of current period), allows pulls until then
@@ -507,7 +524,7 @@ sequenceDiagram
 ### Delegator Cancels and Revokes Subscription
 
 Cancellation is a two-step process:
-1. **`cancel_subscription`** — Sets `expires_at_ts` to the end of the current billing period. The merchant can still pull for the remainder of that period (grace period). If the plan is closed, `expires_at_ts` is set to the current timestamp (immediate).
+1. **`cancel_subscription`** — Sets `expires_at_ts`. Three paths: terms match (grace period until end of billing period), terms mismatch/ghost plan (immediate), plan closed (immediate).
 2. **`revoke_delegation`** — Closes the subscription account and reclaims rent. Only allowed after `expires_at_ts` is in the past.
 
 ```mermaid
@@ -529,6 +546,28 @@ sequenceDiagram
 
     D->>P: revoke_delegation(subscription_pda)
     Note over P: expires_at_ts in the past → Close account<br/>Return rent to payer
+```
+
+### Ghost Account Recovery
+
+When a merchant deletes an expired plan and recreates it with the same `plan_id`, the new plan occupies the same PDA. Existing subscriptions detect this via `check_plan_terms()`.
+
+```mermaid
+sequenceDiagram
+    participant M as Merchant
+    participant P as Program
+    participant D as Alice (Subscriber)
+
+    Note over M,P: Merchant deletes expired plan,<br/>recreates with same plan_id<br/>but different terms
+
+    M->>P: transfer_subscription(amount, alice, mint)
+    Note over P: check_plan_terms() fails:<br/>subscription.terms.created_at ≠ plan.terms.created_at<br/>Rejected (PlanTermsMismatch)
+
+    D->>P: cancel_subscription(plan_pda, subscription_pda)
+    Note over P: check_plan_terms() fails:<br/>Ghost plan detected<br/>expires_at_ts = current_ts (immediate)
+
+    D->>P: revoke_delegation(subscription_pda)
+    Note over P: expires_at_ts in the past → Close account<br/>Return rent to Alice
 ```
 
 ### Merchant Sunsets and Deletes Plan
@@ -557,7 +596,8 @@ sequenceDiagram
 
 | Attack | Prevention |
 |--------|------------|
-| Merchant changes terms mid-subscription | `update_plan` only modifies status, end_ts, pullers, metadata_uri; core billing terms (mint, amount, period_hours, destinations) are immutable |
+| Merchant changes terms mid-subscription | `update_plan` only modifies status, end_ts, pullers, metadata_uri; core billing terms (mint, terms, destinations) are immutable |
+| Ghost account (merchant deletes/recreates plan at same PDA) | `PlanTerms` (amount, period_hours, created_at) are snapshotted into each SubscriptionDelegation at subscribe time. `transfer_subscription` calls `check_plan_terms()` to compare the snapshot against the live plan; mismatch returns `PlanTermsMismatch`. `cancel_subscription` detects mismatch and expires immediately (no grace period). Subscriber then calls `revoke_delegation` to close the account. |
 | Delegator can't verify terms | Terms stored in immutable Plan PDA; delegator verifies before subscribing |
 | Unauthorized pull on Plans | Owner is always authorized, plus explicit pullers array (`Unauthorized`) |
 | Plan closed/deleted before pull | `transfer_subscription` checks plan ownership before loading; returns `PlanClosed` if account is no longer program-owned |

--- a/programs/multi_delegator/src/errors.rs
+++ b/programs/multi_delegator/src/errors.rs
@@ -81,6 +81,7 @@ impl TryFrom<u32> for MultiDelegatorError {
             515 => Ok(Self::PlanNotExpired),
             516 => Ok(Self::PlanClosed),
             517 => Ok(Self::AlreadySubscribed),
+            518 => Ok(Self::PlanTermsMismatch),
             // Event errors (600-699)
             600 => Ok(Self::InvalidEventAuthority),
             601 => Ok(Self::InvalidEventData),
@@ -234,6 +235,8 @@ pub enum MultiDelegatorError {
     PlanClosed,
     #[error("Already subscribed to this plan")]
     AlreadySubscribed,
+    #[error("Subscription plan terms do not match the current plan")]
+    PlanTermsMismatch,
 
     // --- Event errors (600--699) ---
     #[error("Invalid event authority PDA")]

--- a/programs/multi_delegator/src/instructions/cancel_subscription.rs
+++ b/programs/multi_delegator/src/instructions/cancel_subscription.rs
@@ -305,13 +305,14 @@ mod tests {
         let svm_ts = litesvm
             .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
             .unix_timestamp;
-        let subscription_pda = CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts)
-            .terms(PlanTerms {
-                amount: 50_000_000,
-                period_hours: 1,
-                created_at: svm_ts,
-            })
-            .execute();
+        let subscription_pda =
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts)
+                .terms(PlanTerms {
+                    amount: 50_000_000,
+                    period_hours: 1,
+                    created_at: svm_ts,
+                })
+                .execute();
 
         move_clock_forward(&mut litesvm, hours(1) + minutes(5));
 
@@ -369,13 +370,14 @@ mod tests {
         let svm_ts = litesvm
             .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
             .unix_timestamp;
-        let subscription_pda = CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts)
-            .terms(PlanTerms {
-                amount: 50_000_000,
-                period_hours: 1,
-                created_at: svm_ts,
-            })
-            .execute();
+        let subscription_pda =
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts)
+                .terms(PlanTerms {
+                    amount: 50_000_000,
+                    period_hours: 1,
+                    created_at: svm_ts,
+                })
+                .execute();
 
         move_clock_forward(&mut litesvm, hours(3));
 

--- a/programs/multi_delegator/src/instructions/cancel_subscription.rs
+++ b/programs/multi_delegator/src/instructions/cancel_subscription.rs
@@ -51,20 +51,28 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
 
         // Compute expires_at_ts based on plan state
         if accounts_struct.plan_pda.owned_by(&crate::ID) {
-            // Plan is valid — load it and compute end of current period
+            // Plan is valid — load it and verify terms match
             let plan_data = accounts_struct.plan_pda.try_borrow()?;
             let plan = Plan::load(&plan_data)?;
-            let period_length_s = (plan.data.period_hours as i64)
-                .checked_mul(3600)
-                .ok_or::<ProgramError>(MultiDelegatorError::ArithmeticOverflow.into())?;
-            let period_start = subscription.current_period_start_ts;
-            let elapsed = current_ts.saturating_sub(period_start);
-            let periods_elapsed = elapsed / period_length_s;
-            expires_at_ts = periods_elapsed
-                .checked_add(1)
-                .and_then(|p| p.checked_mul(period_length_s))
-                .and_then(|offset| period_start.checked_add(offset))
-                .ok_or::<ProgramError>(MultiDelegatorError::ArithmeticOverflow.into())?;
+
+            if subscription.check_plan_terms(&plan.data.terms).is_err() {
+                // Plan terms mismatch (ghost plan) — expire immediately
+                expires_at_ts = current_ts;
+            } else {
+                // Terms match — compute end of current period
+                let period_length_s =
+                    (subscription.terms.period_hours as i64)
+                        .checked_mul(3600)
+                        .ok_or::<ProgramError>(MultiDelegatorError::ArithmeticOverflow.into())?;
+                let period_start = subscription.current_period_start_ts;
+                let elapsed = current_ts.saturating_sub(period_start);
+                let periods_elapsed = elapsed / period_length_s;
+                expires_at_ts = periods_elapsed
+                    .checked_add(1)
+                    .and_then(|p| p.checked_mul(period_length_s))
+                    .and_then(|offset| period_start.checked_add(offset))
+                    .ok_or::<ProgramError>(MultiDelegatorError::ArithmeticOverflow.into())?;
+            }
         } else {
             // Plan is closed (not owned by our program) — expire immediately
             expires_at_ts = current_ts;

--- a/programs/multi_delegator/src/instructions/cancel_subscription.rs
+++ b/programs/multi_delegator/src/instructions/cancel_subscription.rs
@@ -136,7 +136,10 @@ mod tests {
         state::subscription_delegation::SubscriptionDelegation,
         tests::{
             asserts::TransactionResultExt,
-            utils::{init_wallet, setup_with_subscription, CancelSubscription},
+            utils::{
+                current_ts, days, init_wallet, move_clock_forward, setup_with_subscription,
+                CancelSubscription, CreatePlan, DeletePlan, UpdatePlan,
+            },
         },
         MultiDelegatorError,
     };
@@ -196,5 +199,60 @@ mod tests {
         CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda)
             .execute()
             .assert_err(MultiDelegatorError::MigrationRequired);
+    }
+
+    #[test]
+    fn cancel_subscription_ghost_plan_expires_immediately() {
+        use crate::state::common::PlanStatus;
+
+        let (mut litesvm, alice, merchant, mint, plan_pda, _plan_bump, subscription_pda) =
+            setup_with_subscription();
+
+        // Get current time before any clock manipulation
+        let ts_before = litesvm
+            .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
+            .unix_timestamp;
+
+        // Sunset, expire, and delete the plan
+        let end_ts = current_ts() + days(2) as i64;
+        UpdatePlan::new(&mut litesvm, &merchant, plan_pda)
+            .status(PlanStatus::Sunset)
+            .end_ts(end_ts)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, days(3));
+
+        DeletePlan::new(&mut litesvm, &merchant, plan_pda)
+            .execute()
+            .assert_ok();
+
+        // Recreate plan with same plan_id but different terms
+        let new_end_ts = current_ts() + days(60) as i64;
+        let (res, new_plan_pda) = CreatePlan::new(&mut litesvm, &merchant, mint)
+            .plan_id(1)
+            .amount(999_000_000)
+            .period_hours(720)
+            .end_ts(new_end_ts)
+            .execute();
+        res.assert_ok();
+        assert_eq!(plan_pda, new_plan_pda);
+
+        // Cancel should succeed but expire immediately (no grace period)
+        CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda)
+            .execute()
+            .assert_ok();
+
+        let sub_account = litesvm.get_account(&subscription_pda).unwrap();
+        let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
+        let expires = sub.expires_at_ts;
+        // Should be immediate (current_ts), not end-of-period
+        assert!(expires > ts_before);
+        // Verify it's NOT a grace period (which would be period_start + period_length)
+        // Ghost plan expires at current_ts, which is much less than period_start + 720h
+        let svm_ts = litesvm
+            .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
+            .unix_timestamp;
+        assert_eq!(expires, svm_ts);
     }
 }

--- a/programs/multi_delegator/src/instructions/create_plan.rs
+++ b/programs/multi_delegator/src/instructions/create_plan.rs
@@ -24,6 +24,18 @@ pub const MAX_DESTINATIONS: usize = 4;
 /// Maximum number of puller addresses a plan can authorize.
 pub const MAX_PULLERS: usize = 4;
 
+/// Immutable billing terms snapshotted into each [`SubscriptionDelegation`] at subscribe time.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, CodamaType)]
+pub struct PlanTerms {
+    /// Maximum token amount that can be pulled per billing period.
+    pub amount: u64,
+    /// Billing period length in hours (must be > 0 and <= [`MAX_PLAN_PERIOD_HOURS`]).
+    pub period_hours: u64,
+    /// Unix timestamp when the plan was created on-chain. Set by the program at plan creation time.
+    pub created_at: i64,
+}
+
 /// Configuration data embedded in a [`Plan`] account and supplied when creating one.
 #[repr(C, packed)]
 #[derive(Debug, Clone, CodamaType)]
@@ -32,10 +44,8 @@ pub struct PlanData {
     pub plan_id: u64,
     /// SPL token mint that subscriptions under this plan operate on.
     pub mint: Address,
-    /// Maximum token amount that can be pulled per billing period.
-    pub amount: u64,
-    /// Billing period length in hours (must be > 0 and <= [`MAX_PLAN_PERIOD_HOURS`]).
-    pub period_hours: u64,
+    /// Immutable plan terms
+    pub terms: PlanTerms,
     /// Optional unix timestamp after which the plan expires. `0` means no end.
     pub end_ts: i64,
     /// Whitelisted destination wallets for transfers. All-zero entries are ignored.
@@ -61,17 +71,17 @@ impl PlanData {
 
     /// Validates plan data against the current clock time.
     pub fn validate(&self, current_time: i64) -> Result<(), MultiDelegatorError> {
-        if self.amount == 0 {
+        if self.terms.amount == 0 {
             return Err(MultiDelegatorError::InvalidAmount);
         }
-        if self.period_hours == 0 || self.period_hours > MAX_PLAN_PERIOD_HOURS {
+        if self.terms.period_hours == 0 || self.terms.period_hours > MAX_PLAN_PERIOD_HOURS {
             return Err(MultiDelegatorError::InvalidPeriodLength);
         }
 
         // Destinations are not validated here; empty destinations means any destination is valid at transfer time.
         // Pullers are not validated here; empty pullers defaults to owner-only authorization in transfer.
         if self.end_ts != 0 {
-            let period_secs = (self.period_hours as i64) * 3600;
+            let period_secs = (self.terms.period_hours as i64) * 3600;
             if current_time + period_secs > self.end_ts {
                 return Err(MultiDelegatorError::InvalidEndTs);
             }
@@ -89,7 +99,8 @@ pub const DISCRIMINATOR: &u8 = &7;
 /// Validates the plan data, creates the plan account via CPI, and initializes
 /// its fields including owner, status, and the embedded [`PlanData`].
 pub fn process(accounts: &[AccountView], data: &PlanData) -> ProgramResult {
-    data.validate(Clock::get()?.unix_timestamp)?;
+    let current_ts = Clock::get()?.unix_timestamp;
+    data.validate(current_ts)?;
 
     let accounts = CreatePlanAccounts::try_from(accounts)?;
 
@@ -113,6 +124,7 @@ pub fn process(accounts: &[AccountView], data: &PlanData) -> ProgramResult {
             PlanData::LEN,
         );
     }
+    plan.data.terms.created_at = current_ts;
 
     Ok(())
 }
@@ -168,8 +180,8 @@ mod tests {
         let status = plan.status;
         let id = plan.data.plan_id;
         let plan_mint = plan.data.mint;
-        let amt = plan.data.amount;
-        let ph = plan.data.period_hours;
+        let amt = plan.data.terms.amount;
+        let ph = plan.data.terms.period_hours;
         let ets = plan.data.end_ts;
         let dests = plan.data.destinations;
         let pulls = plan.data.pullers;
@@ -384,7 +396,7 @@ mod tests {
         use solana_instruction::{AccountMeta, Instruction};
 
         use crate::{
-            instructions::create_plan::{PlanData, MAX_DESTINATIONS, MAX_PULLERS},
+            instructions::create_plan::{PlanData, PlanTerms, MAX_DESTINATIONS, MAX_PULLERS},
             tests::{
                 constants::{PROGRAM_ID, SYSTEM_PROGRAM_ID},
                 pda::get_plan_pda,
@@ -415,8 +427,11 @@ mod tests {
         let plan_data = PlanData {
             plan_id,
             mint: malicious_mint.to_bytes().into(),
-            amount: 1_000,
-            period_hours: 24,
+            terms: PlanTerms {
+                amount: 1_000,
+                period_hours: 24,
+                created_at: 0,
+            },
             end_ts: 0,
             destinations,
             pullers: [zero_addr; MAX_PULLERS],

--- a/programs/multi_delegator/src/instructions/subscribe.rs
+++ b/programs/multi_delegator/src/instructions/subscribe.rs
@@ -70,6 +70,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
 
     // Load and validate Plan
     let plan_mint;
+    let plan_terms;
     {
         let plan_data = accounts_struct.plan_pda.try_borrow()?;
         let plan = Plan::load(&plan_data)?;
@@ -87,6 +88,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
         }
 
         plan_mint = plan.data.mint;
+        plan_terms = plan.data.terms;
     }
 
     // Validate MultiDelegate belongs to subscriber and matches plan mint
@@ -147,6 +149,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
             accounts_struct.subscriber.address(),
         );
 
+        subscription.terms = plan_terms;
         subscription.amount_pulled_in_period = 0;
         subscription.current_period_start_ts = current_ts;
         subscription.expires_at_ts = 0;

--- a/programs/multi_delegator/src/instructions/transfer_subscription.rs
+++ b/programs/multi_delegator/src/instructions/transfer_subscription.rs
@@ -33,8 +33,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
     let current_ts = Clock::get()?.unix_timestamp;
 
     // Load Plan (immutable borrow) — extract needed data, then drop borrow
-    let amount_per_period: u64;
-    let period_length_s: u64;
+    let plan_terms: crate::instructions::create_plan::PlanTerms;
     let plan_end_ts: i64;
     let receiver_owner: Address;
     {
@@ -57,17 +56,20 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
         receiver_owner = get_token_account_owner(&receiver_data)?;
         plan.check_destination(&receiver_owner)?;
 
-        amount_per_period = plan.data.amount;
-        period_length_s = plan.data.period_hours * 3600;
+        plan_terms = plan.data.terms;
     }
 
     // Load SubscriptionDelegation (mutable borrow)
+    let amount_per_period: u64;
+    let period_length_s: u64;
     let period_start: i64;
     let amount_pulled_in_period: u64;
     {
         let mut binding = accounts_struct.subscription_pda.try_borrow_mut()?;
         check_and_update_version(&mut binding)?;
         let subscription = SubscriptionDelegation::load_mut(&mut binding)?;
+
+        subscription.check_plan_terms(&plan_terms)?;
 
         let delegator = subscription.header.delegator;
 
@@ -86,6 +88,9 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
         if expires_at_ts != 0 && current_ts >= expires_at_ts {
             return Err(MultiDelegatorError::SubscriptionCancelled.into());
         }
+
+        amount_per_period = subscription.terms.amount;
+        period_length_s = subscription.terms.period_hours * 3600;
 
         // Validate recurring transfer
         let mut ps = subscription.current_period_start_ts;
@@ -208,7 +213,7 @@ impl<'a> TryFrom<&'a [AccountView]> for TransferSubscriptionAccounts<'a> {
 mod tests {
     use crate::{
         event_engine::event_authority_pda,
-        state::subscription_delegation::SubscriptionDelegation,
+        state::{plan::Plan, subscription_delegation::SubscriptionDelegation},
         tests::{
             asserts::TransactionResultExt,
             constants::{MINT_DECIMALS, PROGRAM_ID, TOKEN_PROGRAM_ID},
@@ -216,7 +221,8 @@ mod tests {
             utils::{
                 build_and_send_transaction, current_ts, days, get_ata_balance, hours, init_ata,
                 init_mint, init_wallet, initialize_multidelegate_action, move_clock_forward, setup,
-                CancelSubscription, CreatePlan, CreateSubscription, TransferSubscription,
+                CancelSubscription, CreatePlan, CreateSubscription, DeletePlan,
+                TransferSubscription, UpdatePlan,
             },
         },
         MultiDelegatorError,
@@ -280,8 +286,13 @@ mod tests {
         let svm_ts = litesvm
             .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
             .unix_timestamp;
+        let plan_account = litesvm.get_account(&plan_pda).unwrap();
+        let plan = Plan::load(&plan_account.data).unwrap();
+        let plan_terms = plan.data.terms;
         let subscription_pda =
-            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts).execute();
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts)
+                .terms(plan_terms)
+                .execute();
 
         let (_, plan_bump) = get_plan_pda(&merchant.pubkey(), 1);
 
@@ -554,8 +565,12 @@ mod tests {
         // Create subscription with expires_at_ts set to end of a past period
         let period_start = current_ts() - hours(2) as i64;
         let expires_at = period_start + hours(1) as i64; // end of that period, which is in the past
+        let plan_account = litesvm.get_account(&plan_pda).unwrap();
+        let plan = Plan::load(&plan_account.data).unwrap();
+        let plan_terms = plan.data.terms;
         let subscription_pda =
             CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), period_start)
+                .terms(plan_terms)
                 .expires_at_ts(expires_at)
                 .execute();
 
@@ -763,8 +778,12 @@ mod tests {
         res.assert_ok();
 
         // Create subscription for plan 2
+        let plan2_account = litesvm.get_account(&plan_pda_2).unwrap();
+        let plan2 = Plan::load(&plan2_account.data).unwrap();
+        let plan2_terms = plan2.data.terms;
         let subscription_for_plan2 =
             CreateSubscription::new(&mut litesvm, plan_pda_2, alice.pubkey(), current_ts())
+                .terms(plan2_terms)
                 .execute();
 
         // Try to use subscription for plan 2 with plan 1
@@ -1029,5 +1048,52 @@ mod tests {
 
         result.assert_err(MultiDelegatorError::MigrationRequired);
         assert_eq!(get_ata_balance(&litesvm, &merchant_ata), 0);
+    }
+
+    #[test]
+    fn test_transfer_subscription_ghost_plan_rejected() {
+        use crate::state::common::PlanStatus;
+
+        let amount_per_period = 50_000_000u64;
+        let period_hours = 1u64;
+        let end_ts = current_ts() + days(2) as i64;
+
+        let (mut litesvm, alice, merchant, mint, plan_pda, _, subscription_pda, _, _) =
+            setup_plan_and_subscription(amount_per_period, period_hours, end_ts, vec![], vec![]);
+
+        UpdatePlan::new(&mut litesvm, &merchant, plan_pda)
+            .status(PlanStatus::Sunset)
+            .end_ts(end_ts)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, days(3));
+
+        DeletePlan::new(&mut litesvm, &merchant, plan_pda)
+            .execute()
+            .assert_ok();
+
+        let new_end_ts = current_ts() + days(60) as i64;
+        let (res, new_plan_pda) = CreatePlan::new(&mut litesvm, &merchant, mint)
+            .plan_id(1)
+            .amount(999_000_000)
+            .period_hours(720)
+            .end_ts(new_end_ts)
+            .execute();
+        res.assert_ok();
+        assert_eq!(plan_pda, new_plan_pda);
+
+        let result = TransferSubscription::new(
+            &mut litesvm,
+            &merchant,
+            alice.pubkey(),
+            mint,
+            subscription_pda,
+            plan_pda,
+        )
+        .amount(10_000_000)
+        .execute();
+
+        result.assert_err(MultiDelegatorError::PlanTermsMismatch);
     }
 }

--- a/programs/multi_delegator/src/instructions/update_plan.rs
+++ b/programs/multi_delegator/src/instructions/update_plan.rs
@@ -189,8 +189,8 @@ mod tests {
 
         let account_before = litesvm.get_account(&plan_pda).unwrap();
         let plan_before = Plan::load(&account_before.data).unwrap();
-        let amount_before = plan_before.data.amount;
-        let period_before = plan_before.data.period_hours;
+        let amount_before = plan_before.data.terms.amount;
+        let period_before = plan_before.data.terms.period_hours;
         let mint_before = plan_before.data.mint;
         let dests_before = plan_before.data.destinations;
         let id_before = plan_before.data.plan_id;
@@ -205,8 +205,8 @@ mod tests {
 
         let account_after = litesvm.get_account(&plan_pda).unwrap();
         let plan_after = Plan::load(&account_after.data).unwrap();
-        let amount_after = plan_after.data.amount;
-        let period_after = plan_after.data.period_hours;
+        let amount_after = plan_after.data.terms.amount;
+        let period_after = plan_after.data.terms.period_hours;
         let mint_after = plan_after.data.mint;
         let dests_after = plan_after.data.destinations;
         let id_after = plan_after.data.plan_id;

--- a/programs/multi_delegator/src/state/subscription_delegation.rs
+++ b/programs/multi_delegator/src/state/subscription_delegation.rs
@@ -5,8 +5,9 @@ use core::mem::{size_of, transmute};
 use pinocchio::error::ProgramError;
 
 use crate::{
-    check_min_account_size, state::common::AccountDiscriminator,
-    state::header::DISCRIMINATOR_OFFSET, Header, MultiDelegatorError,
+    check_min_account_size, instructions::create_plan::PlanTerms,
+    state::common::AccountDiscriminator, state::header::DISCRIMINATOR_OFFSET, Header,
+    MultiDelegatorError,
 };
 
 /// A subscriber's delegation linked to a specific [`Plan`](super::plan::Plan).
@@ -25,6 +26,8 @@ pub struct SubscriptionDelegation {
     ///
     /// In this context, `delegator` is the subscriber and `delegatee` is the plan PDA.
     pub header: Header,
+    /// Snapshot of the plan's billing terms at subscribe time.
+    pub terms: PlanTerms,
     /// Token amount already transferred in the current billing period.
     pub amount_pulled_in_period: u64,
     /// Unix timestamp marking the start of the current billing period.
@@ -84,5 +87,15 @@ impl SubscriptionDelegation {
             return Err(MultiDelegatorError::InvalidAccountDiscriminator.into());
         }
         Ok(unsafe { &mut *transmute::<*mut u8, *mut Self>(bytes.as_mut_ptr()) })
+    }
+
+    pub fn check_plan_terms(&self, plan_terms: &PlanTerms) -> Result<(), ProgramError> {
+        if self.terms.created_at != plan_terms.created_at
+            || self.terms.amount != plan_terms.amount
+            || self.terms.period_hours != plan_terms.period_hours
+        {
+            return Err(MultiDelegatorError::PlanTermsMismatch.into());
+        }
+        Ok(())
     }
 }

--- a/programs/multi_delegator/src/tests/utils.rs
+++ b/programs/multi_delegator/src/tests/utils.rs
@@ -31,7 +31,7 @@ use solana_instruction::AccountMeta;
 
 use crate::{
     event_engine::event_authority_pda,
-    instructions::create_plan::{PlanData, MAX_DESTINATIONS, MAX_PULLERS},
+    instructions::create_plan::{PlanData, PlanTerms, MAX_DESTINATIONS, MAX_PULLERS},
     instructions::update_plan::UpdatePlanData,
     instructions::{
         cancel_subscription, close_multidelegate, create_fixed_delegation, create_plan,
@@ -637,8 +637,11 @@ impl<'a> CreatePlan<'a> {
             data: PlanData {
                 plan_id: 0,
                 mint: mint.to_bytes().into(),
-                amount: 0,
-                period_hours: 0,
+                terms: PlanTerms {
+                    amount: 0,
+                    period_hours: 0,
+                    created_at: 0,
+                },
                 end_ts: 0,
                 destinations: [zero_addr; MAX_DESTINATIONS],
                 pullers: [zero_addr; MAX_PULLERS],
@@ -656,12 +659,12 @@ impl<'a> CreatePlan<'a> {
     }
 
     pub fn amount(mut self, amount: u64) -> Self {
-        self.data.amount = amount;
+        self.data.terms.amount = amount;
         self
     }
 
     pub fn period_hours(mut self, period_hours: u64) -> Self {
-        self.data.period_hours = period_hours;
+        self.data.terms.period_hours = period_hours;
         self
     }
 
@@ -881,6 +884,7 @@ pub struct CreateSubscription<'a> {
     period_start_ts: i64,
     amount_pulled: u64,
     expires_at_ts: i64,
+    terms: PlanTerms,
 }
 
 impl<'a> CreateSubscription<'a> {
@@ -897,6 +901,11 @@ impl<'a> CreateSubscription<'a> {
             period_start_ts,
             amount_pulled: 0,
             expires_at_ts: 0,
+            terms: PlanTerms {
+                amount: 0,
+                period_hours: 0,
+                created_at: 0,
+            },
         }
     }
 
@@ -907,6 +916,11 @@ impl<'a> CreateSubscription<'a> {
 
     pub fn expires_at_ts(mut self, expires_at_ts: i64) -> Self {
         self.expires_at_ts = expires_at_ts;
+        self
+    }
+
+    pub fn terms(mut self, terms: PlanTerms) -> Self {
+        self.terms = terms;
         self
     }
 
@@ -928,6 +942,7 @@ impl<'a> CreateSubscription<'a> {
                 delegatee: self.plan_pda.to_bytes().into(),
                 payer: self.subscriber.to_bytes().into(),
             },
+            terms: self.terms,
             amount_pulled_in_period: self.amount_pulled,
             current_period_start_ts: self.period_start_ts,
             expires_at_ts: self.expires_at_ts,

--- a/webapp/src/components/dashboard/summary-cards.tsx
+++ b/webapp/src/components/dashboard/summary-cards.tsx
@@ -22,7 +22,7 @@ export function SummaryCards() {
     let totalAmount = 0
     for (const sub of active) {
       if (sub.plan) {
-        totalAmount += Number(sub.plan.data.amount) / USDC_MULTIPLIER
+        totalAmount += Number(sub.plan.data.terms.amount) / USDC_MULTIPLIER
       }
     }
     

--- a/webapp/src/components/plan/collect-payments-panel.tsx
+++ b/webapp/src/components/plan/collect-payments-panel.tsx
@@ -57,7 +57,7 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
   const meta = useMemo(() => parsePlanMeta(plan.data.metadataUri), [plan.data.metadataUri])
   const planName = meta.n || `Plan ${ellipsify(plan.address)}`
   const PlanIcon = (meta.i && ICON_MAP[meta.i]) || Star
-  const amountUsd = Number(plan.data.amount) / USDC_MULTIPLIER
+  const amountUsd = Number(plan.data.terms.amount) / USDC_MULTIPLIER
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const history = useMemo(() => getCollectionHistory(plan.address), [plan.address, historyVersion])
@@ -70,8 +70,8 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
       const ts = await getBlockTimestamp(rpcUrl)
       const eligible = computeEligibleSubscribers(
         subscribers,
-        plan.data.amount,
-        plan.data.periodHours,
+        plan.data.terms.amount,
+        plan.data.terms.periodHours,
         ts,
       )
 

--- a/webapp/src/components/plan/enhanced-collect-payments.tsx
+++ b/webapp/src/components/plan/enhanced-collect-payments.tsx
@@ -127,7 +127,7 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const subscribers = await fetchPlanSubscriptions(rpcUrl, pd.plan.address, progAddr!)
         const eligible = computeEligibleSubscribers(
-          subscribers, pd.plan.data.amount, pd.plan.data.periodHours, ts,
+          subscribers, pd.plan.data.terms.amount, pd.plan.data.terms.periodHours, ts,
         )
         if (eligible.length === 0) continue
         plans.push({
@@ -157,7 +157,7 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
-        const amountUsd = Number(pd.plan.data.amount) / USDC_MULTIPLIER
+        const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
         addCollectionRecord(createSuccessRecord(
           pd.plan.address, planName, res, pd.subscribers.length, amountUsd,
         ))
@@ -168,7 +168,7 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
-        const amountUsd = Number(pd.plan.data.amount) / USDC_MULTIPLIER
+        const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
         addCollectionRecord(createFailureRecord(
           pd.plan.address, planName, pd.subscribers.length, amountUsd, err,
         ))
@@ -212,7 +212,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
   const meta = useMemo(() => parsePlanMeta(plan.data.metadataUri), [plan.data.metadataUri])
   const planName = meta.n || `Plan ${ellipsify(plan.address)}`
   const PlanIcon = (meta.i && ICON_MAP[meta.i]) || Star
-  const amountUsd = Number(plan.data.amount) / USDC_MULTIPLIER
+  const amountUsd = Number(plan.data.terms.amount) / USDC_MULTIPLIER
   const pendingUsd = Number(planData.totalPending) / USDC_MULTIPLIER
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -223,7 +223,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
     try {
       const subs = await fetchPlanSubscriptions(rpcUrl, plan.address, progAddr!)
       const ts = await getBlockTimestamp(rpcUrl)
-      const elig = computeEligibleSubscribers(subs, plan.data.amount, plan.data.periodHours, ts)
+      const elig = computeEligibleSubscribers(subs, plan.data.terms.amount, plan.data.terms.periodHours, ts)
 
       if (elig.length === 0) {
         toast.info('All payments already collected this period')
@@ -265,7 +265,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
     }
   }, [rpcUrl, progAddr, plan, planName, amountUsd, subscribers.length, collectSubscriptionPayments])
 
-  const periodHoursSec = Number(plan.data.periodHours) * 3600
+  const periodHoursSec = Number(plan.data.terms.periodHours) * 3600
 
   return (
     <div className="border border-emerald-500/15 bg-slate-900/60 rounded-xl overflow-hidden">

--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -83,7 +83,7 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
   const selectedIconEntry = PLAN_ICONS.find((i) => i.name === selectedIcon)
   const SelectedIconComponent = selectedIconEntry?.icon
 
-  const amount = Number(plan.data.amount) / USDC_MULTIPLIER
+  const amount = Number(plan.data.terms.amount) / USDC_MULTIPLIER
   const activeDestinations = plan.data.destinations.filter((d) => d !== ZERO_ADDRESS)
 
   const metadataJson = useMemo(() => {
@@ -218,7 +218,7 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
             </div>
 
             <ImmutableField label="Amount (USDC)" value={`$${amount}`} />
-            <ImmutableField label="Billing Period" value={formatPeriodLabel(plan.data.periodHours)} />
+            <ImmutableField label="Billing Period" value={formatPeriodLabel(plan.data.terms.periodHours)} />
 
             <div className="sm:col-span-2 grid gap-2">
               <Label>End Date/Time</Label>
@@ -404,7 +404,7 @@ function SubscribeDialog({ plan, meta, open, onOpenChange }: {
   const { subscribe, initMultiDelegate } = useMultiDelegatorMutations()
   const { isInitialized, isLoading: statusLoading, refetch: refetchStatus } = useMultiDelegateStatus(plan.data.mint)
   const { account } = useWalletUi()
-  const amount = Number(plan.data.amount) / USDC_MULTIPLIER
+  const amount = Number(plan.data.terms.amount) / USDC_MULTIPLIER
 
   const handleInit = async () => {
     if (!account?.address) return
@@ -427,7 +427,7 @@ function SubscribeDialog({ plan, meta, open, onOpenChange }: {
         <DialogHeader>
           <DialogTitle className="text-emerald-400">Subscribe to: {meta.n || 'Unnamed'}</DialogTitle>
           <DialogDescription>
-            ${amount} / {formatPeriod(plan.data.periodHours)} from merchant {ellipsify(plan.owner, 4)}
+            ${amount} / {formatPeriod(plan.data.terms.periodHours)} from merchant {ellipsify(plan.owner, 4)}
           </DialogDescription>
         </DialogHeader>
 
@@ -547,7 +547,7 @@ function PlanExpandedDetails({ plan, isExpanded }: { plan: PlanItem; isExpanded:
           </div>
           <div className="flex items-center justify-between bg-slate-800/40 rounded-lg px-3 py-2 border border-emerald-500/8 hover:border-emerald-500/20 transition-colors">
             <p className="text-[11px] text-gray-500 uppercase tracking-wider">Period</p>
-            <p className="font-mono text-sm text-white">{formatPeriodLabel(plan.data.periodHours)}</p>
+            <p className="font-mono text-sm text-white">{formatPeriodLabel(plan.data.terms.periodHours)}</p>
           </div>
         </div>
       </div>
@@ -572,8 +572,8 @@ export function PlanCard({ plan, variant = 'owner', isExpanded = false, onToggle
   const meta = useMemo(() => parsePlanMeta(plan.data.metadataUri), [plan.data.metadataUri])
 
   const Icon = (meta.i && ICON_MAP[meta.i]) || Star
-  const amount = Number(plan.data.amount) / USDC_MULTIPLIER
-  const period = formatPeriod(plan.data.periodHours)
+  const amount = Number(plan.data.terms.amount) / USDC_MULTIPLIER
+  const period = formatPeriod(plan.data.terms.periodHours)
   const activeDestinations = plan.data.destinations.filter((d) => d !== ZERO_ADDRESS).length
   const activePullers = plan.data.pullers.filter((p) => p !== ZERO_ADDRESS).length
   const { data: subscriberCount } = useSubscriberCount(variant === 'owner' ? plan.address : null)

--- a/webapp/src/components/subscription/my-subscriptions-panel.tsx
+++ b/webapp/src/components/subscription/my-subscriptions-panel.tsx
@@ -160,8 +160,8 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
 
   const planDeleted = !item.plan
   const planName = meta.n || 'Unknown Plan'
-  const amount = item.plan ? Number(item.plan.data.amount) / USDC_MULTIPLIER : null
-  const period = item.plan ? formatPeriod(item.plan.data.periodHours) : null
+  const amount = item.plan ? Number(item.plan.data.terms.amount) / USDC_MULTIPLIER : null
+  const period = item.plan ? formatPeriod(item.plan.data.terms.periodHours) : null
   const pulled = Number(item.subscription.amountPulledInPeriod) / USDC_MULTIPLIER
 
   return (

--- a/webapp/src/hooks/use-plan-subscribers.ts
+++ b/webapp/src/hooks/use-plan-subscribers.ts
@@ -46,8 +46,8 @@ export function useAllPlanSubscribers() {
           const subscribers = await fetchPlanSubscriptions(rpcUrl, plan.address, progAddr!)
           const eligible = computeEligibleSubscribers(
             subscribers,
-            plan.data.amount,
-            plan.data.periodHours,
+            plan.data.terms.amount,
+            plan.data.terms.periodHours,
             blockTimestamp,
           )
           const totalPending = eligible.reduce((sum, e) => sum + e.collectAmount, 0n)


### PR DESCRIPTION
Closes audit issues: 13 and 8 

 - Prevent ghost account attack where a merchant deletes and recreates a plan at the same PDA to exploit existing subscribers
  - Add `PlanTerms` struct snapshotted into each subscription at subscribe time, validated via `check_plan_terms()` on transfer and cancel.
  - Transfers are blocked with `PlanTermsMismatch` error, cancellation expires immediately with no grace period, allowing the subscriber to revoke and reclaim rent immediately. 

Also for completeness:

- Updated TypeScript client code
- Updated web app
- Updated documentation


