### PR TITLE
[audit] fix: add start time validation to prevent transfers before recurring delegation period begins

### DIFF
--- a/programs/multi_delegator/src/errors.rs
+++ b/programs/multi_delegator/src/errors.rs
@@ -62,6 +62,7 @@ impl TryFrom<u32> for MultiDelegatorError {
             404 => Ok(Self::RecurringDelegationStartTimeInPast),
             405 => Ok(Self::RecurringDelegationStartTimeGreaterThanExpiry),
             406 => Ok(Self::RecurringDelegationAmountZero),
+            407 => Ok(Self::DelegationNotStarted),
             // Plan and subscription errors (500-599)
             500 => Ok(Self::PlanSunset),
             501 => Ok(Self::PlanExpired),
@@ -196,6 +197,8 @@ pub enum MultiDelegatorError {
     RecurringDelegationStartTimeGreaterThanExpiry,
     #[error("zero amount specified")]
     RecurringDelegationAmountZero,
+    #[error("Delegation period has not started yet")]
+    DelegationNotStarted,
 
     // --- Plan and subscription errors (500--599) ---
     #[error("Plan is in sunset status")]

--- a/programs/multi_delegator/src/instructions/helpers/transfer_validation.rs
+++ b/programs/multi_delegator/src/instructions/helpers/transfer_validation.rs
@@ -35,6 +35,7 @@ pub fn validate_fixed_transfer(
 /// Returns an error if:
 /// - `transfer_amount` is zero
 /// - the delegation has expired
+/// - the delegation period has not started (`current_ts < current_period_start_ts`)
 /// - `transfer_amount` exceeds the remaining per-period budget
 pub fn validate_recurring_transfer(
     transfer_amount: u64,
@@ -56,6 +57,10 @@ pub fn validate_recurring_transfer(
         i64::try_from(period_length_s).map_err(|_| MultiDelegatorError::InvalidPeriodLength)?;
     if period_length == 0 {
         return Err(MultiDelegatorError::InvalidPeriodLength.into());
+    }
+
+    if current_ts < *current_period_start_ts {
+        return Err(MultiDelegatorError::DelegationNotStarted.into());
     }
 
     let time_since_start = current_ts.saturating_sub(*current_period_start_ts);

--- a/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
+++ b/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
@@ -913,4 +913,40 @@ mod tests {
         result.assert_err(MultiDelegatorError::MigrationRequired);
         assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
     }
+
+    #[test]
+    fn test_recurring_transfer_not_started() {
+        let amount_per_period: u64 = 50_000_000;
+        let period_length_s: u64 = hours(1);
+        let start_ts: i64 = current_ts() + hours(1) as i64;
+        let expiry_ts: i64 = current_ts() + days(1) as i64;
+        let nonce = 0;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, _, bob_ata, _) =
+            setup_recurring_delegation(
+                amount_per_period,
+                period_length_s,
+                start_ts,
+                expiry_ts,
+                nonce,
+            );
+
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+
+        let transfer_amount: u64 = 10_000_000;
+        let result =
+            TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+                .amount(transfer_amount)
+                .recurring();
+        result.assert_err(MultiDelegatorError::DelegationNotStarted);
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+
+        move_clock_forward(&mut litesvm, hours(1) + 1);
+
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+            .amount(transfer_amount)
+            .recurring()
+            .assert_ok();
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), transfer_amount);
+    }
 }


### PR DESCRIPTION
Closes audit issue 1

- Add `DelegationNotStarted` error variant
- Add guard `current_ts < current_period_start_ts` in `validate_recurring_transfer`
- Add `test_recurring_transfer_not_started` test