### PR TITLE
[audit] fix: validate plan's end_ts to fall within one billing period

### DIFF
--- a/clients/typescript/test/setup.ts
+++ b/clients/typescript/test/setup.ts
@@ -220,6 +220,12 @@ export class IntegrationTest {
     return BigInt(blockTime);
   }
 
+  async minPlanEndTs(periodHours: bigint): Promise<bigint> {
+    const TX_PROPAGATION_BUFFER = 60n;
+    const now = await this.getValidatorTime();
+    return now + periodHours * 3600n + TX_PROPAGATION_BUFFER;
+  }
+
   async timeTravel(targetTimestampSec: number): Promise<void> {
     const res = await fetch(SURFPOOL_RPC_URL, {
       method: 'POST',

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -10,6 +10,7 @@ describe('Subscription Lifecycle', () => {
   test('full lifecycle: create, subscribe, pull, cancel, sunset, delete', async () => {
     const t = await initTestSuite();
     const planAmount = 500_000n;
+    const periodHours = 1n;
 
     // 1. Merchant creates a plan
     const { planPda } = await t.client.createPlan({
@@ -17,7 +18,7 @@ describe('Subscription Lifecycle', () => {
       planId: 1n,
       mint: t.tokenMint,
       amount: planAmount,
-      periodHours: 1n,
+      periodHours,
       endTs: 0n,
       destinations: [],
       pullers: [],
@@ -95,8 +96,7 @@ describe('Subscription Lifecycle', () => {
     expect(subAfterCancel.expiresAtTs).not.toBe(0n);
 
     // 5. Merchant sunsets the plan
-    const validatorTs = await t.getValidatorTime();
-    const endTs = validatorTs + 10n;
+    const endTs = await t.minPlanEndTs(periodHours);
 
     await t.client.updatePlan({
       owner: t.payerKeypair,
@@ -107,7 +107,7 @@ describe('Subscription Lifecycle', () => {
     });
 
     // 6. Time-travel past endTs, then delete the plan
-    await t.timeTravel(Number(endTs) + 5);
+    await t.timeTravel(Number(endTs) + 60);
 
     const { signature: deleteSig } = await t.client.deletePlan({
       owner: t.payerKeypair,

--- a/programs/multi_delegator/src/instructions/create_plan.rs
+++ b/programs/multi_delegator/src/instructions/create_plan.rs
@@ -9,7 +9,7 @@ use pinocchio::{
 use crate::{
     create_plan_account,
     state::{
-        common::{AccountDiscriminator, PlanStatus},
+        common::{validate_plan_end_ts, AccountDiscriminator, PlanStatus},
         plan::{self, Plan},
     },
     CreatePlanAccounts, MultiDelegatorError,
@@ -70,12 +70,7 @@ impl PlanData {
 
         // Destinations are not validated here; empty destinations means any destination is valid at transfer time.
         // Pullers are not validated here; empty pullers defaults to owner-only authorization in transfer.
-        if self.end_ts != 0 {
-            let period_secs = (self.period_hours as i64) * 3600;
-            if current_time + period_secs > self.end_ts {
-                return Err(MultiDelegatorError::InvalidEndTs);
-            }
-        }
+        validate_plan_end_ts(self.end_ts, self.period_hours, current_time)?;
 
         Ok(())
     }

--- a/programs/multi_delegator/src/instructions/update_plan.rs
+++ b/programs/multi_delegator/src/instructions/update_plan.rs
@@ -7,7 +7,10 @@ use pinocchio::{
 };
 
 use crate::{
-    state::{common::PlanStatus, plan::Plan},
+    state::{
+        common::{validate_plan_end_ts, PlanStatus},
+        plan::Plan,
+    },
     AccountCheck, MultiDelegatorError, ProgramAccount, SignerAccount, WritableAccount,
 };
 
@@ -96,6 +99,7 @@ pub fn process(accounts: &[AccountView], data: &UpdatePlanData) -> ProgramResult
 
     let current_ts = Clock::get()?.unix_timestamp;
     data.validate(current_ts)?;
+    validate_plan_end_ts(data.end_ts, plan.data.period_hours, current_ts)?;
 
     if plan.data.end_ts != 0 && current_ts > plan.data.end_ts {
         return Err(MultiDelegatorError::PlanExpired.into());
@@ -623,5 +627,30 @@ mod tests {
         for (i, p) in pullers.iter().enumerate() {
             assert_eq!(plan.data.pullers[i].to_bytes(), p.to_bytes());
         }
+    }
+
+    #[test]
+    fn update_plan_rejects_near_immediate_end_ts() {
+        let (litesvm, owner) = &mut setup();
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            None,
+            &[],
+        );
+
+        let (res, plan_pda) = CreatePlan::new(litesvm, owner, mint)
+            .plan_id(1)
+            .amount(1_000)
+            .period_hours(720)
+            .execute();
+        res.assert_ok();
+
+        let res = UpdatePlan::new(litesvm, owner, plan_pda)
+            .end_ts(current_ts() + 2)
+            .execute();
+        res.assert_err(crate::MultiDelegatorError::InvalidEndTs);
     }
 }

--- a/programs/multi_delegator/src/state/common.rs
+++ b/programs/multi_delegator/src/state/common.rs
@@ -148,6 +148,21 @@ pub fn find_plan_pda(owner: &Address, plan_id: u64) -> (Address, u8) {
     )
 }
 
+/// Rejects non-zero `end_ts` that falls within one billing period of `current_time`.
+pub fn validate_plan_end_ts(
+    end_ts: i64,
+    period_hours: u64,
+    current_time: i64,
+) -> Result<(), MultiDelegatorError> {
+    if end_ts != 0 {
+        let period_secs = (period_hours as i64) * 3600;
+        if current_time + period_secs > end_ts {
+            return Err(MultiDelegatorError::InvalidEndTs);
+        }
+    }
+    Ok(())
+}
+
 /// Finds the canonical subscription PDA and bump for a given plan and subscriber.
 pub fn find_subscription_pda(plan_pda: &Address, subscriber: &Address) -> (Address, u8) {
     Address::find_program_address(
@@ -158,4 +173,45 @@ pub fn find_subscription_pda(plan_pda: &Address, subscriber: &Address) -> (Addre
         ],
         &crate::ID,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn end_ts_zero_always_valid() {
+        assert!(validate_plan_end_ts(0, 720, 1_000_000).is_ok());
+        assert!(validate_plan_end_ts(0, 1, 0).is_ok());
+    }
+
+    #[test]
+    fn end_ts_exactly_one_period_ahead() {
+        let current = 1_000_000i64;
+        let period_hours = 720u64;
+        let end_ts = current + (period_hours as i64) * 3600;
+        assert!(validate_plan_end_ts(end_ts, period_hours, current).is_ok());
+    }
+
+    #[test]
+    fn end_ts_less_than_one_period_ahead() {
+        let current = 1_000_000i64;
+        let period_hours = 720u64;
+        let end_ts = current + (period_hours as i64) * 3600 - 1;
+        assert!(validate_plan_end_ts(end_ts, period_hours, current).is_err());
+    }
+
+    #[test]
+    fn end_ts_well_beyond_period() {
+        let current = 1_000_000i64;
+        let period_hours = 720u64;
+        let end_ts = current + (period_hours as i64) * 3600 * 2;
+        assert!(validate_plan_end_ts(end_ts, period_hours, current).is_ok());
+    }
+
+    #[test]
+    fn end_ts_near_immediate() {
+        let current = 1_000_000i64;
+        assert!(validate_plan_end_ts(current + 1, 720, current).is_err());
+    }
 }

--- a/programs/multi_delegator/src/state/mod.rs
+++ b/programs/multi_delegator/src/state/mod.rs
@@ -14,8 +14,8 @@ pub mod subscription_delegation;
 pub mod versioning;
 
 pub use common::{
-    find_plan_pda, find_subscription_pda, verify_delegation_pda, verify_plan_pda,
-    AccountDiscriminator, PlanStatus, DELEGATE_BASE_SEED,
+    find_plan_pda, find_subscription_pda, validate_plan_end_ts, verify_delegation_pda,
+    verify_plan_pda, AccountDiscriminator, PlanStatus, DELEGATE_BASE_SEED,
 };
 pub use fixed_delegation::FixedDelegation;
 pub use header::{Header, DISCRIMINATOR_OFFSET, VERSION_OFFSET};


### PR DESCRIPTION
Closes audit issue 11

- Add shared validate_plan_end_ts() to enforce minimum one-period-ahead guard on end_ts
- Apply guard in update_plan process, closing the bypass path
- Replace inline check in create_plan with shared function
- Add unit tests for boundary cases and integration test for rejection