### PR TITLE
chore: add CODEOWNERS with dev-jodee as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dev-jodee


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` designating `@dev-jodee` as the default code owner for all files
- GitHub will automatically request a review from `@dev-jodee` on all PRs

## Test plan
- [ ] Verify GitHub shows `@dev-jodee` as required reviewer after merge