### PR TITLE
[audit] fix: prevent stale delegation revival via init_id check

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -76,11 +76,31 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Close a MultiDelegate PDA, returning rent to the user. */
+  /**
+   * Close a MultiDelegate PDA, returning rent to the user.
+   *
+   * Closing invalidates all existing delegations on re-initialization
+   * (init_id mismatch). This can serve as an emergency kill switch to
+   * immediately cut off all delegatees in a single transaction.
+   */
   async closeMultiDelegate(params: {
     user: TransactionSigner;
     tokenMint: Address;
   }): Promise<TransactionResult> {
+    try {
+      const delegations = await this.getDelegationsForWallet(
+        params.user.address,
+      );
+      if (delegations.length > 0) {
+        console.warn(
+          `Warning: ${delegations.length} active delegation(s) found across all mints. ` +
+            `Delegations for this mint will become permanently non-transferable if re-initialized.`,
+        );
+      }
+    } catch (e) {
+      console.warn('Could not check active delegations before closing:', e);
+    }
+
     const { instructions } = await buildCloseMultiDelegate(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
@@ -297,5 +317,37 @@ export class MultiDelegatorClient {
   /** Fetch all plans owned by the given address. */
   async getPlansForOwner(owner: Address): Promise<PlanWithAddress[]> {
     return fetchPlansForOwner(this.client.rpc, owner);
+  }
+
+  /**
+   * Returns a summary of active delegations and subscriptions for a wallet.
+   * Useful for checking outstanding commitments before closing a MultiDelegate.
+   */
+  async getActiveDelegationSummary(wallet: Address): Promise<{
+    fixed: number;
+    recurring: number;
+    subscriptions: number;
+    total: number;
+  }> {
+    const delegations = await fetchDelegationsByDelegator(
+      this.client.rpc,
+      wallet,
+    );
+
+    let fixed = 0;
+    let recurring = 0;
+    let subscriptions = 0;
+    for (const d of delegations) {
+      if (d.kind === 'fixed') fixed++;
+      else if (d.kind === 'recurring') recurring++;
+      else if (d.kind === 'subscription') subscriptions++;
+    }
+
+    return {
+      fixed,
+      recurring,
+      subscriptions,
+      total: delegations.length,
+    };
   }
 }

--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -12,7 +12,7 @@ export const ZERO_ADDRESS =
   '11111111111111111111111111111111' as import('gill').Address<'11111111111111111111111111111111'>;
 
 // Header struct layout offsets
-// Layout: discriminator (1 byte) + version (1 byte) + bump (1 byte) + delegator (32 bytes) + delegatee (32 bytes)
+// Layout: discriminator (1) + version (1) + bump (1) + delegator (32) + delegatee (32) + payer (32) + init_id (8) = 107 bytes
 // See: programs/multi_delegator/src/state/header.rs
 export const DISCRIMINATOR_OFFSET = 0;
 export const DELEGATOR_OFFSET = 3;
@@ -35,8 +35,8 @@ export const EVENT_AUTHORITY_SEED = 'event_authority';
 
 // Plan: discriminator(1) + owner(32) + bump(1) + status(1) + planData(448)
 export const PLAN_SIZE = 483;
-// Subscription: header(67) + amountPulledInPeriod(8) + currentPeriodStartTs(8) + expiresAtTs(8) + planPda(32)
-export const SUBSCRIPTION_SIZE = 123;
+// Subscription: header(107) + amountPulledInPeriod(8) + currentPeriodStartTs(8) + expiresAtTs(8)
+export const SUBSCRIPTION_SIZE = 131;
 
 export const PLAN_OWNER_OFFSET = 1;
 

--- a/docs/001-multi-delegator-architecture.md
+++ b/docs/001-multi-delegator-architecture.md
@@ -212,17 +212,18 @@ pub enum AccountDiscriminator {
 The MultiDelegate PDA stores the delegator and mint information:
 
 ```rust
-#[repr(C)]
+#[repr(C, packed)]
 pub struct MultiDelegate {
     pub discriminator: u8,    // 1 byte - AccountDiscriminator::MultiDelegate
     pub user: Address,        // 32 bytes - delegator key
     pub token_mint: Address,  // 32 bytes - mint this MDA controls
     pub bump: u8,             // 1 byte
+    pub init_id: i64,         // 8 bytes - slot-based generation identifier
 }
 
 impl MultiDelegate {
     pub const SEED: &[u8] = b"MultiDelegate";
-    pub const LEN: usize = 66;
+    pub const LEN: usize = 74;
 
     pub fn find_pda(user: &Address, token_mint: &Address) -> (Address, u8) {
         Address::find_program_address(
@@ -234,6 +235,13 @@ impl MultiDelegate {
 ```
 
 **PDA seeds**: `["MultiDelegate", delegator_key, mint_key]`
+
+> **Note (init_id):** The `init_id` field is set from `Clock::slot` when the account is created.
+> Every delegation header stores a copy of this value. On transfer, the program validates
+> `header.init_id == multidelegate.init_id`. If a user closes and re-initializes their
+> MultiDelegate, the new slot produces a different `init_id`, making all old delegations
+> non-transferable (error: `StaleMultiDelegate`). This prevents orphaned delegations from
+> being revived and also makes closing an effective emergency kill switch.
 
 ### Header
 
@@ -248,10 +256,11 @@ pub struct Header {
     pub delegator: Address, // 32 bytes - user granting delegation
     pub delegatee: Address, // 32 bytes - beneficiary
     pub payer: Address,     // 32 bytes - who paid for the delegation account
+    pub init_id: i64,       // 8 bytes - copied from MultiDelegate.init_id at creation
 }
 
 impl Header {
-    pub const LEN: usize = 99;
+    pub const LEN: usize = 107;
 }
 ```
 
@@ -262,6 +271,7 @@ Field offsets are defined as standalone constants in `state/header.rs`:
 - `DELEGATOR_OFFSET = 3`
 - `DELEGATEE_OFFSET = 35`
 - `PAYER_OFFSET = 67`
+- `INIT_ID_OFFSET = 99`
 
 ### FixedDelegation
 
@@ -416,6 +426,13 @@ Closes a MultiDelegate PDA and returns rent to the owner.
 1. Verify signer matches the MDA's `user` field
 2. Verify PDA derivation from `["MultiDelegate", user, token_mint]`
 3. Close account and transfer lamports to user
+
+> **Emergency kill switch:** Closing does not revoke existing delegation PDAs, but they
+> become non-transferable because the MultiDelegate account no longer exists. If the user
+> re-initializes, the new `init_id` invalidates all old delegations. This allows a user
+> to immediately cut off all delegatees in a single transaction without revoking each one
+> individually. The delegator can still call `revoke_delegation` on orphaned delegations
+> afterward to reclaim rent.
 
 ---
 

--- a/programs/multi_delegator/src/errors.rs
+++ b/programs/multi_delegator/src/errors.rs
@@ -50,6 +50,7 @@ impl TryFrom<u32> for MultiDelegatorError {
             132 => Ok(Self::AtaOwnerMismatch),
             133 => Ok(Self::DelegationVersionMismatch),
             134 => Ok(Self::MigrationRequired),
+            135 => Ok(Self::StaleMultiDelegate),
             // Fixed delegation errors (300-399)
             300 => Ok(Self::AmountExceedsLimit),
             301 => Ok(Self::FixedDelegationExpiryInPast),
@@ -172,6 +173,8 @@ pub enum MultiDelegatorError {
     DelegationVersionMismatch,
     #[error("Account requires explicit migration")]
     MigrationRequired,
+    #[error("Delegation init_id does not match current MultiDelegate")]
+    StaleMultiDelegate,
 
     // --- Fixed delegation errors (300--399) ---
     #[error("Transfer amount exceeds delegation limit")]

--- a/programs/multi_delegator/src/instructions/create_fixed_delegation.rs
+++ b/programs/multi_delegator/src/instructions/create_fixed_delegation.rs
@@ -62,7 +62,8 @@ pub fn process(accounts: &[AccountView], call_data: &CreateFixedDelegationData) 
 
     let accounts = CreateDelegationAccounts::try_from(accounts)?;
 
-    let bump = create_delegation_account(&accounts, call_data.nonce, FixedDelegation::LEN)?;
+    let (bump, init_id) =
+        create_delegation_account(&accounts, call_data.nonce, FixedDelegation::LEN)?;
 
     let binding = &mut accounts.delegation_account.try_borrow_mut()?;
     // Set discriminator before load_mut so validation passes on freshly created account
@@ -75,6 +76,7 @@ pub fn process(accounts: &[AccountView], call_data: &CreateFixedDelegationData) 
         accounts.delegator.address(),
         accounts.delegatee.address(),
         accounts.payer.address(),
+        init_id,
     );
     delegation.amount = call_data.amount;
     delegation.expiry_ts = call_data.expiry_ts;

--- a/programs/multi_delegator/src/instructions/create_recurring_delegation.rs
+++ b/programs/multi_delegator/src/instructions/create_recurring_delegation.rs
@@ -79,7 +79,8 @@ pub fn process(
 
     let accounts = CreateDelegationAccounts::try_from(accounts)?;
 
-    let bump = create_delegation_account(&accounts, call_data.nonce, RecurringDelegation::LEN)?;
+    let (bump, init_id) =
+        create_delegation_account(&accounts, call_data.nonce, RecurringDelegation::LEN)?;
 
     let binding = &mut accounts.delegation_account.try_borrow_mut()?;
     // Set discriminator before load_mut so validation passes on freshly created account
@@ -92,6 +93,7 @@ pub fn process(
         accounts.delegator.address(),
         accounts.delegatee.address(),
         accounts.payer.address(),
+        init_id,
     );
     delegation.current_period_start_ts = call_data.start_ts;
     delegation.period_length_s = call_data.period_length_s;

--- a/programs/multi_delegator/src/instructions/helpers/delegation.rs
+++ b/programs/multi_delegator/src/instructions/helpers/delegation.rs
@@ -60,16 +60,18 @@ impl<'a> TryFrom<&'a [AccountView]> for CreateDelegationAccounts<'a> {
 /// Creates and allocates a delegation PDA.
 ///
 /// Verifies the delegator owns the [`MultiDelegate`], derives the expected PDA,
-/// and creates the account via CPI. Returns the PDA bump on success.
+/// and creates the account via CPI. Returns `(bump, init_id)` on success.
 pub fn create_delegation_account(
     accounts: &CreateDelegationAccounts,
     nonce: u64,
     space: usize,
-) -> Result<u8, ProgramError> {
+) -> Result<(u8, i64), ProgramError> {
+    let init_id;
     {
         let md_data = accounts.multi_delegate.try_borrow()?;
         let multi_delegate = MultiDelegate::load(&md_data)?;
         multi_delegate.check_owner(accounts.delegator.address())?;
+        init_id = multi_delegate.init_id;
     }
 
     let nonce_bytes = nonce.to_le_bytes();
@@ -97,7 +99,7 @@ pub fn create_delegation_account(
 
     ProgramAccount::init::<()>(accounts.payer, accounts.delegation_account, &seeds, space)?;
 
-    Ok(bump)
+    Ok((bump, init_id))
 }
 
 /// Populates a delegation [`Header`] with the standard fields.
@@ -108,6 +110,7 @@ pub fn init_header(
     delegator: &Address,
     delegatee: &Address,
     payer: &Address,
+    init_id: i64,
 ) {
     header.version = CURRENT_VERSION;
     header.discriminator = discriminator.into();
@@ -115,6 +118,7 @@ pub fn init_header(
     header.delegator = *delegator;
     header.delegatee = *delegatee;
     header.payer = *payer;
+    header.init_id = init_id;
 }
 
 /// Authorization checker for delegation transfers.

--- a/programs/multi_delegator/src/instructions/helpers/transfer_utils.rs
+++ b/programs/multi_delegator/src/instructions/helpers/transfer_utils.rs
@@ -71,6 +71,7 @@ pub fn transfer_with_delegate(
     amount: u64,
     delegator: &Address,
     mint: &Address,
+    init_id: i64,
     accounts: &TransferAccounts,
 ) -> ProgramResult {
     let bump = {
@@ -83,6 +84,9 @@ pub fn transfer_with_delegate(
         // we can trust its data. If the data matches, it is the correct PDA.
         if multidelegate.user != *delegator || multidelegate.token_mint != *mint {
             return Err(MultiDelegatorError::InvalidDelegatePda.into());
+        }
+        if multidelegate.init_id != init_id {
+            return Err(MultiDelegatorError::StaleMultiDelegate.into());
         }
         multidelegate.bump
     };

--- a/programs/multi_delegator/src/instructions/initialize_multidelegate.rs
+++ b/programs/multi_delegator/src/instructions/initialize_multidelegate.rs
@@ -1,4 +1,9 @@
-use pinocchio::{cpi::Seed, error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{
+    cpi::Seed,
+    error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    AccountView, ProgramResult,
+};
 
 use pinocchio_token::instructions::Approve as ApproveSpl;
 use pinocchio_token_2022::instructions::Approve as Approve2022;
@@ -85,12 +90,14 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
             MultiDelegate::LEN,
         )?;
 
+        let init_id = Clock::get()?.slot as i64;
         let mut data = accounts.multi_delegate.try_borrow_mut()?;
         MultiDelegate::init(
             &mut data,
             accounts.user.address(),
             accounts.token_mint.address(),
             bump,
+            init_id,
         )?;
     }
 
@@ -168,6 +175,7 @@ mod tests {
         assert_eq!(multi_delegate.user.to_bytes(), user.pubkey().to_bytes());
         assert_eq!(multi_delegate.token_mint.to_bytes(), mint.to_bytes());
         assert_eq!(multi_delegate.bump, bump);
+        assert!(multi_delegate.init_id >= 0);
 
         // Verify delegation
         let ata_account = fetch_account::<spl_token_2022::state::Account>(litesvm, &user_ata);
@@ -247,6 +255,7 @@ mod tests {
                 assert_eq!(multi_delegate.user.to_bytes(), user.pubkey().to_bytes());
                 assert_eq!(multi_delegate.token_mint.to_bytes(), mint.to_bytes());
                 assert_eq!(multi_delegate.bump, bump);
+                assert!(multi_delegate.init_id >= 0);
 
                 // Verify delegation
                 let ata_account =
@@ -352,6 +361,7 @@ mod tests {
         assert_eq!(multi_delegate.user.to_bytes(), user.pubkey().to_bytes());
         assert_eq!(multi_delegate.token_mint.to_bytes(), mint.to_bytes());
         assert_eq!(multi_delegate.bump, bump);
+        assert!(multi_delegate.init_id >= 0);
 
         // Verify delegation
         let ata_account = fetch_account::<spl_token_2022::state::Account>(litesvm, &user_ata);

--- a/programs/multi_delegator/src/instructions/revoke_delegation.rs
+++ b/programs/multi_delegator/src/instructions/revoke_delegation.rs
@@ -545,12 +545,12 @@ mod tests {
 
     #[test]
     fn revoke_subscription_with_future_expires_at_ts_rejected() {
-        let (mut litesvm, alice, _merchant, _mint, plan_pda, _, _subscription_pda) =
+        let (mut litesvm, alice, _merchant, mint, plan_pda, _, _subscription_pda) =
             setup_with_subscription();
 
         // Manually inject a subscription with expires_at_ts in the future
         let subscription_pda =
-            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), current_ts())
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), mint, current_ts())
                 .expires_at_ts(current_ts() + days(1) as i64)
                 .execute();
 

--- a/programs/multi_delegator/src/instructions/subscribe.rs
+++ b/programs/multi_delegator/src/instructions/subscribe.rs
@@ -90,6 +90,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
     }
 
     // Validate MultiDelegate belongs to subscriber and matches plan mint
+    let init_id;
     {
         let md_data = accounts_struct.multi_delegate_pda.try_borrow()?;
         let multi_delegate = MultiDelegate::load(&md_data)?;
@@ -98,6 +99,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
         if multi_delegate.token_mint != plan_mint {
             return Err(MultiDelegatorError::MintMismatch.into());
         }
+        init_id = multi_delegate.init_id;
     }
 
     // Derive and verify subscription PDA
@@ -145,6 +147,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
             accounts_struct.subscriber.address(),
             accounts_struct.plan_pda.address(),
             accounts_struct.subscriber.address(),
+            init_id,
         );
 
         subscription.amount_pulled_in_period = 0;

--- a/programs/multi_delegator/src/instructions/transfer_fixed_delegation.rs
+++ b/programs/multi_delegator/src/instructions/transfer_fixed_delegation.rs
@@ -30,6 +30,7 @@ pub fn process(accounts: &[AccountView], transfer: &TransferData) -> ProgramResu
 
     let remaining_amount: u64;
     let delegatee_address: Address;
+    let init_id: i64;
     {
         let mut binding = accounts_struct.delegation_pda.try_borrow_mut()?;
         check_and_update_version(&mut binding)?;
@@ -58,6 +59,7 @@ pub fn process(accounts: &[AccountView], transfer: &TransferData) -> ProgramResu
             .ok_or(MultiDelegatorError::ArithmeticUnderflow)?;
 
         remaining_amount = delegation.amount;
+        init_id = delegation.header.init_id;
     }
 
     // Extract receiver owner from token account data
@@ -77,6 +79,7 @@ pub fn process(accounts: &[AccountView], transfer: &TransferData) -> ProgramResu
         transfer.amount,
         &transfer.delegator,
         &transfer.mint,
+        init_id,
         &TransferAccounts {
             delegator_ata: accounts_struct.delegator_ata,
             to_ata: accounts_struct.receiver_ata,
@@ -615,5 +618,101 @@ mod tests {
 
         result.assert_err(MultiDelegatorError::MigrationRequired);
         assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+    }
+
+    #[test]
+    fn test_fixed_transfer_stale_multidelegate() {
+        use crate::tests::utils::{move_clock_forward, CloseMultiDelegate, RevokeDelegation};
+
+        let amount: u64 = 50_000_000;
+        let expiry_ts: i64 = current_ts() + days(1) as i64;
+        let nonce = 0;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, alice_ata, bob_ata) =
+            setup_fixed_delegation(amount, expiry_ts, nonce);
+
+        CloseMultiDelegate::new(&mut litesvm, &alice, mint)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, 2);
+
+        initialize_multidelegate_action(&mut litesvm, &alice, mint)
+            .0
+            .assert_ok();
+
+        let result =
+            TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+                .amount(10_000_000)
+                .fixed();
+
+        result.assert_err(MultiDelegatorError::StaleMultiDelegate);
+        assert_eq!(get_ata_balance(&litesvm, &alice_ata), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+
+        RevokeDelegation::new(&mut litesvm, &alice, mint, bob.pubkey(), nonce)
+            .execute()
+            .assert_ok();
+    }
+
+    #[test]
+    fn test_close_multidelegate_blocks_all_transfers() {
+        use crate::tests::utils::{CloseMultiDelegate, RevokeDelegation};
+
+        let amount: u64 = 50_000_000;
+        let expiry_ts: i64 = current_ts() + days(1) as i64;
+
+        let (mut litesvm, alice) = setup();
+        let bob = Keypair::new();
+        let charlie = Keypair::new();
+        litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
+        litesvm.airdrop(&charlie.pubkey(), 10_000_000).unwrap();
+
+        let mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+        let alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+        let _bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
+        let _charlie_ata = init_ata(&mut litesvm, mint, charlie.pubkey(), 0);
+
+        initialize_multidelegate_action(&mut litesvm, &alice, mint)
+            .0
+            .assert_ok();
+
+        let (_, del_bob) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey())
+            .nonce(0)
+            .fixed(amount, expiry_ts);
+
+        let (_, del_charlie) = CreateDelegation::new(&mut litesvm, &alice, mint, charlie.pubkey())
+            .nonce(0)
+            .fixed(amount, expiry_ts);
+
+        CloseMultiDelegate::new(&mut litesvm, &alice, mint)
+            .execute()
+            .assert_ok();
+
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, del_bob)
+            .amount(10_000_000)
+            .fixed()
+            .assert_err(MultiDelegatorError::InvalidMultiDelegatePda);
+
+        TransferDelegation::new(&mut litesvm, &charlie, alice.pubkey(), mint, del_charlie)
+            .amount(10_000_000)
+            .fixed()
+            .assert_err(MultiDelegatorError::InvalidMultiDelegatePda);
+
+        assert_eq!(get_ata_balance(&litesvm, &alice_ata), 100_000_000);
+
+        RevokeDelegation::new(&mut litesvm, &alice, mint, bob.pubkey(), 0)
+            .execute()
+            .assert_ok();
+        RevokeDelegation::new(&mut litesvm, &alice, mint, charlie.pubkey(), 0)
+            .execute()
+            .assert_ok();
     }
 }

--- a/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
+++ b/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
@@ -33,6 +33,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
     let amount_pulled_in_period: u64;
     let period_length_s: u64;
     let delegatee_address: Address;
+    let init_id: i64;
     {
         let mut binding = accounts_struct.delegation_pda.try_borrow_mut()?;
         check_and_update_version(&mut binding)?;
@@ -64,6 +65,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
 
         period_start = ps;
         amount_pulled_in_period = pulled;
+        init_id = delegation_mut.header.init_id;
     }
 
     // Extract receiver owner from token account data
@@ -83,6 +85,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
         transfer_data.amount,
         &transfer_data.delegator,
         &transfer_data.mint,
+        init_id,
         &TransferAccounts {
             delegator_ata: accounts_struct.delegator_ata,
             to_ata: accounts_struct.receiver_ata,
@@ -911,6 +914,45 @@ mod tests {
                 .recurring();
 
         result.assert_err(MultiDelegatorError::MigrationRequired);
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+    }
+
+    #[test]
+    fn test_recurring_transfer_stale_multidelegate() {
+        use crate::tests::utils::{move_clock_forward, CloseMultiDelegate};
+
+        let amount_per_period: u64 = 50_000_000;
+        let period_length_s = days(1);
+        let start_ts = current_ts();
+        let expiry_ts = current_ts() + days(30) as i64;
+        let nonce = 0;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, alice_ata, bob_ata, _) =
+            setup_recurring_delegation(
+                amount_per_period,
+                period_length_s,
+                start_ts,
+                expiry_ts,
+                nonce,
+            );
+
+        CloseMultiDelegate::new(&mut litesvm, &alice, mint)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, 2);
+
+        initialize_multidelegate_action(&mut litesvm, &alice, mint)
+            .0
+            .assert_ok();
+
+        let result =
+            TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+                .amount(10_000_000)
+                .recurring();
+
+        result.assert_err(MultiDelegatorError::StaleMultiDelegate);
+        assert_eq!(get_ata_balance(&litesvm, &alice_ata), 100_000_000);
         assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
     }
 }

--- a/programs/multi_delegator/src/instructions/transfer_subscription.rs
+++ b/programs/multi_delegator/src/instructions/transfer_subscription.rs
@@ -64,6 +64,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
     // Load SubscriptionDelegation (mutable borrow)
     let period_start: i64;
     let amount_pulled_in_period: u64;
+    let init_id: i64;
     {
         let mut binding = accounts_struct.subscription_pda.try_borrow_mut()?;
         check_and_update_version(&mut binding)?;
@@ -104,6 +105,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
 
         period_start = ps;
         amount_pulled_in_period = pulled;
+        init_id = subscription.header.init_id;
     }
 
     // Execute transfer
@@ -111,6 +113,7 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
         transfer_data.amount,
         &transfer_data.delegator,
         &transfer_data.mint,
+        init_id,
         &TransferAccounts {
             delegator_ata: accounts_struct.delegator_ata,
             to_ata: accounts_struct.receiver_ata,
@@ -281,7 +284,7 @@ mod tests {
             .get_sysvar::<spl_associated_token_account::solana_program::clock::Clock>()
             .unix_timestamp;
         let subscription_pda =
-            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), svm_ts).execute();
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), mint, svm_ts).execute();
 
         let (_, plan_bump) = get_plan_pda(&merchant.pubkey(), 1);
 
@@ -555,7 +558,7 @@ mod tests {
         let period_start = current_ts() - hours(2) as i64;
         let expires_at = period_start + hours(1) as i64; // end of that period, which is in the past
         let subscription_pda =
-            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), period_start)
+            CreateSubscription::new(&mut litesvm, plan_pda, alice.pubkey(), mint, period_start)
                 .expires_at_ts(expires_at)
                 .execute();
 
@@ -764,7 +767,7 @@ mod tests {
 
         // Create subscription for plan 2
         let subscription_for_plan2 =
-            CreateSubscription::new(&mut litesvm, plan_pda_2, alice.pubkey(), current_ts())
+            CreateSubscription::new(&mut litesvm, plan_pda_2, alice.pubkey(), mint, current_ts())
                 .execute();
 
         // Try to use subscription for plan 2 with plan 1
@@ -1028,6 +1031,42 @@ mod tests {
         .execute();
 
         result.assert_err(MultiDelegatorError::MigrationRequired);
+        assert_eq!(get_ata_balance(&litesvm, &merchant_ata), 0);
+    }
+
+    #[test]
+    fn test_subscription_transfer_stale_multidelegate() {
+        use crate::tests::utils::{move_clock_forward, CloseMultiDelegate};
+
+        let amount_per_period = 50_000_000;
+        let period_hours = 24;
+        let end_ts = current_ts() + days(30) as i64;
+
+        let (mut litesvm, alice, merchant, mint, plan_pda, _, subscription_pda, _, merchant_ata) =
+            setup_plan_and_subscription(amount_per_period, period_hours, end_ts, vec![], vec![]);
+
+        CloseMultiDelegate::new(&mut litesvm, &alice, mint)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, 2);
+
+        initialize_multidelegate_action(&mut litesvm, &alice, mint)
+            .0
+            .assert_ok();
+
+        let result = TransferSubscription::new(
+            &mut litesvm,
+            &merchant,
+            alice.pubkey(),
+            mint,
+            subscription_pda,
+            plan_pda,
+        )
+        .amount(10_000_000)
+        .execute();
+
+        result.assert_err(MultiDelegatorError::StaleMultiDelegate);
         assert_eq!(get_ata_balance(&litesvm, &merchant_ata), 0);
     }
 }

--- a/programs/multi_delegator/src/state/header.rs
+++ b/programs/multi_delegator/src/state/header.rs
@@ -29,10 +29,15 @@ pub const DELEGATEE_OFFSET: usize = 35;
 /// Byte offset of the payer pubkey (who funded the account creation).
 pub const PAYER_OFFSET: usize = 67;
 
+/// Byte offset of the init_id field.
+pub const INIT_ID_OFFSET: usize = 99;
+
 /// Common header shared by all delegation account types.
 ///
-/// Occupies the first 99 bytes of every delegation PDA. The discriminator byte
-/// at offset 0 identifies the concrete delegation type.
+/// Occupies the first 107 bytes of every delegation PDA. The discriminator byte
+/// at offset 0 identifies the concrete delegation type. The `init_id` field
+/// is copied from the parent [`MultiDelegate`](super::multi_delegate::MultiDelegate)
+/// at creation time and validated on every transfer to detect stale delegations.
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy, CodamaType)]
 pub struct Header {
@@ -48,6 +53,8 @@ pub struct Header {
     pub delegatee: Address,
     /// The account that funded the PDA creation (receives rent on close).
     pub payer: Address,
+    /// Initialization identifier copied from the parent MultiDelegate's `init_id`.
+    pub init_id: i64,
 }
 
 impl Header {
@@ -61,6 +68,7 @@ impl Header {
         delegator: &Address,
         delegatee: &Address,
         payer: &Address,
+        init_id: i64,
     ) {
         self.version = CURRENT_VERSION;
         self.discriminator = discriminator.into();
@@ -68,5 +76,6 @@ impl Header {
         self.delegator = *delegator;
         self.delegatee = *delegatee;
         self.payer = *payer;
+        self.init_id = init_id;
     }
 }

--- a/programs/multi_delegator/src/state/multi_delegate.rs
+++ b/programs/multi_delegator/src/state/multi_delegate.rs
@@ -14,7 +14,7 @@ use crate::{state::common::AccountDiscriminator, MultiDelegatorError};
 /// actually transfer.
 ///
 /// **PDA seeds:** `["MultiDelegate", user, token_mint]`
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(CodamaAccount)]
 pub struct MultiDelegate {
     /// Account type discriminator ([`AccountDiscriminator::MultiDelegate`]).
@@ -25,6 +25,8 @@ pub struct MultiDelegate {
     pub token_mint: Address,
     /// PDA bump seed.
     pub bump: u8,
+    /// Initialization identifier set from `Clock::slot` when the account is created.
+    pub init_id: i64,
 }
 
 impl MultiDelegate {
@@ -43,6 +45,7 @@ impl MultiDelegate {
         user: &Address,
         token_mint: &Address,
         bump: u8,
+        init_id: i64,
     ) -> Result<&'a Self, ProgramError> {
         if bytes.len() != Self::LEN {
             return Err(MultiDelegatorError::InvalidAccountData.into());
@@ -52,6 +55,7 @@ impl MultiDelegate {
         account.user = *user;
         account.token_mint = *token_mint;
         account.bump = bump;
+        account.init_id = init_id;
         Ok(account)
     }
 

--- a/programs/multi_delegator/src/tests/utils.rs
+++ b/programs/multi_delegator/src/tests/utils.rs
@@ -72,6 +72,7 @@ pub fn current_ts() -> i64 {
 pub fn move_clock_forward(litesvm: &mut LiteSVM, seconds: u64) {
     let mut initial_clock = litesvm.get_sysvar::<Clock>();
     initial_clock.unix_timestamp += seconds as i64;
+    initial_clock.slot += seconds * 2;
     litesvm.set_sysvar::<Clock>(&initial_clock);
 }
 
@@ -878,6 +879,7 @@ pub struct CreateSubscription<'a> {
     litesvm: &'a mut LiteSVM,
     plan_pda: Pubkey,
     subscriber: Pubkey,
+    mint: Pubkey,
     period_start_ts: i64,
     amount_pulled: u64,
     expires_at_ts: i64,
@@ -888,12 +890,14 @@ impl<'a> CreateSubscription<'a> {
         litesvm: &'a mut LiteSVM,
         plan_pda: Pubkey,
         subscriber: Pubkey,
+        mint: Pubkey,
         period_start_ts: i64,
     ) -> Self {
         Self {
             litesvm,
             plan_pda,
             subscriber,
+            mint,
             period_start_ts,
             amount_pulled: 0,
             expires_at_ts: 0,
@@ -913,9 +917,14 @@ impl<'a> CreateSubscription<'a> {
     pub fn execute(self) -> Pubkey {
         use crate::{
             state::{common::AccountDiscriminator, versioning::CURRENT_VERSION},
-            tests::pda::get_subscription_pda,
-            Header, SubscriptionDelegation,
+            tests::pda::{get_multidelegate_pda, get_subscription_pda},
+            Header, MultiDelegate, SubscriptionDelegation,
         };
+
+        let (md_pda, _) = get_multidelegate_pda(&self.subscriber, &self.mint);
+        let md_account = self.litesvm.get_account(&md_pda).unwrap();
+        let md = MultiDelegate::load(&md_account.data).unwrap();
+        let init_id = md.init_id;
 
         let (subscription_pda, bump) = get_subscription_pda(&self.plan_pda, &self.subscriber);
 
@@ -927,6 +936,7 @@ impl<'a> CreateSubscription<'a> {
                 delegator: self.subscriber.to_bytes().into(),
                 delegatee: self.plan_pda.to_bytes().into(),
                 payer: self.subscriber.to_bytes().into(),
+                init_id,
             },
             amount_pulled_in_period: self.amount_pulled,
             current_period_start_ts: self.period_start_ts,


### PR DESCRIPTION
Closes audit issue 6  

- Add `init_id` (slot-based generation marker) to `MultiDelegate` and delegation `Header` structs to prevent orphaned delegations from being revived after a close-and-reinit.
- On every transfer, the program validates `delegation.header.init_id == multidelegate.init_id`, rejecting stale delegations with `StaleMultiDelegate` error.
- Add `getActiveDelegationSummary()` helper to the TS client
- Update case tests: init -> delegate -> close -> re-init -> transfer fails -> revoke succeeds
- Update docs 