### PR TITLE
[audit] fix:  apply TIME_DRIFT_ALLOWED_SECS tolerance to transfer expiry checks

### DIFF
--- a/programs/multi_delegator/src/instructions/helpers/transfer_validation.rs
+++ b/programs/multi_delegator/src/instructions/helpers/transfer_validation.rs
@@ -1,12 +1,13 @@
 use pinocchio::ProgramResult;
 
+use crate::constants::TIME_DRIFT_ALLOWED_SECS;
 use crate::MultiDelegatorError;
 
 /// Validates a fixed transfer against the delegation's remaining allowance and expiry.
 ///
 /// Returns an error if:
 /// - `transfer_amount` is zero
-/// - the delegation has expired (`expiry_ts != 0 && current_ts > expiry_ts`)
+/// - the delegation has expired (`expiry_ts != 0 && current_ts > expiry_ts + TIME_DRIFT_ALLOWED_SECS`)
 /// - `transfer_amount` exceeds the remaining allowance
 pub fn validate_fixed_transfer(
     transfer_amount: u64,
@@ -17,7 +18,7 @@ pub fn validate_fixed_transfer(
     if transfer_amount == 0 {
         return Err(MultiDelegatorError::InvalidAmount.into());
     }
-    if expiry_ts != 0 && current_ts > expiry_ts {
+    if expiry_ts != 0 && current_ts > expiry_ts.saturating_add(TIME_DRIFT_ALLOWED_SECS) {
         return Err(MultiDelegatorError::DelegationExpired.into());
     }
     if transfer_amount > remaining {
@@ -48,7 +49,7 @@ pub fn validate_recurring_transfer(
     if transfer_amount == 0 {
         return Err(MultiDelegatorError::InvalidAmount.into());
     }
-    if expiry_ts != 0 && current_ts > expiry_ts {
+    if expiry_ts != 0 && current_ts > expiry_ts.saturating_add(TIME_DRIFT_ALLOWED_SECS) {
         return Err(MultiDelegatorError::DelegationExpired.into());
     }
 

--- a/programs/multi_delegator/src/instructions/transfer_fixed_delegation.rs
+++ b/programs/multi_delegator/src/instructions/transfer_fixed_delegation.rs
@@ -616,4 +616,41 @@ mod tests {
         result.assert_err(MultiDelegatorError::MigrationRequired);
         assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
     }
+
+    #[test]
+    fn test_fixed_transfer_within_drift_window() {
+        let amount: u64 = 50_000_000;
+        let expiry_ts: i64 = current_ts() + 100;
+        let nonce = 0;
+        let transfer_amount = 10_000_000;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, _, _) =
+            setup_fixed_delegation(amount, expiry_ts, nonce);
+
+        move_clock_forward(&mut litesvm, 110);
+
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+            .amount(transfer_amount)
+            .fixed()
+            .assert_ok();
+    }
+
+    #[test]
+    fn test_fixed_transfer_past_drift_window() {
+        let amount: u64 = 50_000_000;
+        let expiry_ts: i64 = current_ts() + 100;
+        let nonce = 0;
+        let transfer_amount = 10_000_000;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, _, _) =
+            setup_fixed_delegation(amount, expiry_ts, nonce);
+
+        move_clock_forward(&mut litesvm, 221);
+
+        let result =
+            TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+                .amount(transfer_amount)
+                .fixed();
+        result.assert_err(MultiDelegatorError::DelegationExpired);
+    }
 }

--- a/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
+++ b/programs/multi_delegator/src/instructions/transfer_recurring_delegation.rs
@@ -913,4 +913,55 @@ mod tests {
         result.assert_err(MultiDelegatorError::MigrationRequired);
         assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
     }
+
+    #[test]
+    fn test_recurring_transfer_within_drift_window() {
+        let amount_per_period: u64 = 50_000_000;
+        let period_length_s: u64 = hours(1);
+        let start_ts: i64 = current_ts();
+        let expiry_ts: i64 = current_ts() + hours(1) as i64;
+        let nonce = 0;
+        let transfer_amount = 10_000_000;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, _, _, _) = setup_recurring_delegation(
+            amount_per_period,
+            period_length_s,
+            start_ts,
+            expiry_ts,
+            nonce,
+        );
+
+        move_clock_forward(&mut litesvm, hours(1) + 60);
+
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+            .amount(transfer_amount)
+            .recurring()
+            .assert_ok();
+    }
+
+    #[test]
+    fn test_recurring_transfer_past_drift_window() {
+        let amount_per_period: u64 = 50_000_000;
+        let period_length_s: u64 = hours(1);
+        let start_ts: i64 = current_ts();
+        let expiry_ts: i64 = current_ts() + hours(1) as i64;
+        let nonce = 0;
+        let transfer_amount = 10_000_000;
+
+        let (mut litesvm, alice, bob, delegation_pda, mint, _, _, _) = setup_recurring_delegation(
+            amount_per_period,
+            period_length_s,
+            start_ts,
+            expiry_ts,
+            nonce,
+        );
+
+        move_clock_forward(&mut litesvm, hours(1) + 121);
+
+        let result =
+            TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+                .amount(transfer_amount)
+                .recurring();
+        result.assert_err(MultiDelegatorError::DelegationExpired);
+    }
 }


### PR DESCRIPTION
Closes audit issue 17 

 - Add `TIME_DRIFT_ALLOWED_SECS` tolerance to expiry checks in `validate_fixed_transfer` and `validate_recurring_transfer`
  - Add drift window boundary tests for both delegation types