### PR TITLE
[audit] fix: descriptive errors for duplicate pda creation

### DIFF
--- a/programs/multi_delegator/src/errors.rs
+++ b/programs/multi_delegator/src/errors.rs
@@ -50,6 +50,7 @@ impl TryFrom<u32> for MultiDelegatorError {
             132 => Ok(Self::AtaOwnerMismatch),
             133 => Ok(Self::DelegationVersionMismatch),
             134 => Ok(Self::MigrationRequired),
+            135 => Ok(Self::DelegationAlreadyExists),
             // Fixed delegation errors (300-399)
             300 => Ok(Self::AmountExceedsLimit),
             301 => Ok(Self::FixedDelegationExpiryInPast),
@@ -81,6 +82,7 @@ impl TryFrom<u32> for MultiDelegatorError {
             515 => Ok(Self::PlanNotExpired),
             516 => Ok(Self::PlanClosed),
             517 => Ok(Self::AlreadySubscribed),
+            518 => Ok(Self::PlanAlreadyExists),
             // Event errors (600-699)
             600 => Ok(Self::InvalidEventAuthority),
             601 => Ok(Self::InvalidEventData),
@@ -172,6 +174,8 @@ pub enum MultiDelegatorError {
     DelegationVersionMismatch,
     #[error("Account requires explicit migration")]
     MigrationRequired,
+    #[error("Delegation account already exists")]
+    DelegationAlreadyExists,
 
     // --- Fixed delegation errors (300--399) ---
     #[error("Transfer amount exceeds delegation limit")]
@@ -234,6 +238,8 @@ pub enum MultiDelegatorError {
     PlanClosed,
     #[error("Already subscribed to this plan")]
     AlreadySubscribed,
+    #[error("Plan account already exists")]
+    PlanAlreadyExists,
 
     // --- Event errors (600--699) ---
     #[error("Invalid event authority PDA")]

--- a/programs/multi_delegator/src/instructions/create_fixed_delegation.rs
+++ b/programs/multi_delegator/src/instructions/create_fixed_delegation.rs
@@ -365,7 +365,7 @@ mod tests {
         let (res2, _) = CreateDelegation::new(litesvm, payer, mint, delegatee)
             .nonce(0)
             .fixed(200, current_ts() + 2000);
-        assert!(res2.is_err());
+        res2.assert_err(MultiDelegatorError::DelegationAlreadyExists);
     }
 
     #[test]

--- a/programs/multi_delegator/src/instructions/create_plan.rs
+++ b/programs/multi_delegator/src/instructions/create_plan.rs
@@ -488,4 +488,34 @@ mod tests {
         assert_eq!(owner.to_bytes(), merchant.pubkey().to_bytes());
         assert_eq!(status, PlanStatus::Active as u8);
     }
+
+    #[test]
+    fn create_plan_duplicate_plan_id() {
+        let (litesvm, merchant) = &mut setup();
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            None,
+            &[],
+        );
+        let dest = Pubkey::new_unique();
+
+        let (res, _) = CreatePlan::new(litesvm, merchant, mint)
+            .plan_id(1)
+            .amount(1_000)
+            .period_hours(24)
+            .destinations(vec![dest])
+            .execute();
+        res.assert_ok();
+
+        let (res2, _) = CreatePlan::new(litesvm, merchant, mint)
+            .plan_id(1)
+            .amount(2_000)
+            .period_hours(48)
+            .destinations(vec![dest])
+            .execute();
+        res2.assert_err(crate::MultiDelegatorError::PlanAlreadyExists);
+    }
 }

--- a/programs/multi_delegator/src/instructions/helpers/delegation.rs
+++ b/programs/multi_delegator/src/instructions/helpers/delegation.rs
@@ -66,6 +66,10 @@ pub fn create_delegation_account(
     nonce: u64,
     space: usize,
 ) -> Result<u8, ProgramError> {
+    if accounts.delegation_account.data_len() > 0 {
+        return Err(MultiDelegatorError::DelegationAlreadyExists.into());
+    }
+
     {
         let md_data = accounts.multi_delegate.try_borrow()?;
         let multi_delegate = MultiDelegate::load(&md_data)?;

--- a/programs/multi_delegator/src/instructions/helpers/plan.rs
+++ b/programs/multi_delegator/src/instructions/helpers/plan.rs
@@ -48,6 +48,10 @@ pub fn create_plan_account(
     accounts: &CreatePlanAccounts,
     plan_id: u64,
 ) -> Result<u8, ProgramError> {
+    if accounts.plan_pda.data_len() > 0 {
+        return Err(MultiDelegatorError::PlanAlreadyExists.into());
+    }
+
     let (expected_pda, bump) = find_plan_pda(accounts.merchant.address(), plan_id);
 
     if expected_pda != *accounts.plan_pda.address() {


### PR DESCRIPTION
Closes audit issue 2

- Add pre-checks before `ProgramAccount::init` in delegation and plan creation to return `DelegationAlreadyExists` / `PlanAlreadyExists` custom errors.