### PR TITLE
[webapp] fix: audit compliance and delegation UX improvements

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -13,15 +13,45 @@ import { Setup } from '@/routes/setup'
 import { useNetworkConfig } from '@/hooks/use-token-config'
 import { clusterIdToNetwork } from '@/lib/api-client'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
+import { useQuery } from '@tanstack/react-query'
+import { createSolanaRpc } from 'gill'
+
+function useRpcReachable() {
+  const { id, url } = useClusterConfig()
+  const isLocalnet = id === 'solana:localnet'
+
+  return useQuery({
+    queryKey: ['rpc-health', id],
+    queryFn: async () => {
+      try {
+        const rpc = createSolanaRpc(url)
+        await rpc.getVersion().send()
+        return true
+      } catch {
+        return false
+      }
+    },
+    enabled: isLocalnet,
+    staleTime: 10_000,
+    retry: false,
+  })
+}
 
 function useIsSetupValid(): { ready: boolean; loading: boolean } {
   const { id } = useClusterConfig()
   const network = clusterIdToNetwork(id)
+  const isLocalnet = id === 'solana:localnet'
   const lsComplete = localStorage.getItem(`setup-complete-${network}`) === 'true'
   const { data, isLoading } = useNetworkConfig()
+  const { data: rpcReachable, isLoading: rpcLoading } = useRpcReachable()
 
   if (!lsComplete) return { ready: false, loading: false }
-  if (isLoading) return { ready: true, loading: true }
+  if (isLoading || (isLocalnet && rpcLoading)) return { ready: true, loading: true }
+
+  if (isLocalnet && rpcReachable === false) {
+    localStorage.removeItem(`setup-complete-${network}`)
+    return { ready: false, loading: false }
+  }
 
   const hasProgram = !!data?.programAddress
   const hasTokens = (data?.tokens?.length ?? 0) > 0

--- a/webapp/src/components/account/account-ui.tsx
+++ b/webapp/src/components/account/account-ui.tsx
@@ -17,7 +17,8 @@ import {
   useAirdropUsdc,
 } from './account-data-access'
 import { useDelegations, useIncomingDelegations } from '@/hooks/use-delegations'
-import { useUsdcMint } from '@/hooks/use-token-config'
+import { useUsdcMint, useUsdcMintRaw } from '@/hooks/use-token-config'
+import { useMultiDelegateStatus } from '@/hooks/use-multi-delegate-status'
 import { USDC_MULTIPLIER, recurringAvailable } from '@/lib/utils'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
@@ -108,6 +109,10 @@ export function WalletBalanceCards({ address: addr }: { address: Address }) {
 
   const usdcBalance = usdcAccount?.account?.data?.parsed?.info?.tokenAmount?.uiAmount ?? 0
 
+  const { mint: usdcMintRaw } = useUsdcMintRaw()
+  const { data: statusData } = useMultiDelegateStatus(usdcMintRaw)
+  const delegationId = statusData?.data?.initId ?? null
+
   const [spinning, setSpinning] = useState(false)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const isFetching = solQuery.isFetching || tokenQuery.isFetching
@@ -139,6 +144,12 @@ export function WalletBalanceCards({ address: addr }: { address: Address }) {
               {copiedField === 'program' ? <Check className="h-3 w-3 text-emerald-400" /> : <Copy className="h-3 w-3" />}
             </button>
           </div>
+          {delegationId != null && (
+            <div className="flex items-center gap-1.5 text-xs text-gray-500">
+              <span>Delegation ID:</span>
+              <span className="text-gray-400">{delegationId.toString()}</span>
+            </div>
+          )}
         </div>
         <Button
           variant="outline"

--- a/webapp/src/components/delegation/active-delegations.tsx
+++ b/webapp/src/components/delegation/active-delegations.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, FileX, Coins, ShieldAlert } from 'lucide-react'
+import { RefreshCw, FileX, Coins, ShieldAlert, Power } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -29,10 +29,12 @@ import { CreateDelegationDialog } from './create-delegation-dialog'
 import type { TokenAccountEntry } from '@/lib/types'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
+import { useMySubscriptions } from '@/hooks/use-subscriptions'
 
 interface ActiveDelegationsProps {
   tokenMint: string
   isApproved: boolean
+  multiDelegateInitId?: bigint | null
   onInitSuccess?: () => void
 }
 
@@ -255,9 +257,10 @@ interface DelegationTableProps {
   showExpired?: boolean
   tokenMint: string
   blockTime?: number
+  multiDelegateInitId?: bigint | null
 }
 
-function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, blockTime }: DelegationTableProps) {
+function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, blockTime, multiDelegateInitId }: DelegationTableProps) {
   if (delegations.length === 0) return null
   const isOutgoing = mode === 'outgoing'
   const partyLabel = isOutgoing ? 'Delegatee' : 'Delegator'
@@ -283,11 +286,13 @@ function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, block
           <TableBody>
             {delegations.map((d) => {
               const rowExpired = showExpired || (!isOutgoing && isExpired(d.data.expiryTs, blockTime))
+              const isStale = multiDelegateInitId != null && d.data.header.initId !== multiDelegateInitId
               return (
-                <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired ? 'opacity-60' : ''}`}>
+                <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired || isStale ? 'opacity-60' : ''}`}>
                   <TableCell className="font-mono text-[15px] text-gray-300 py-5 text-center">
                     {formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}
                     <span className="ml-1.5 text-xs font-bold text-blue-400/60 font-sans">v{d.data.header.version}</span>
+                    {isStale && <span className="ml-1.5 text-xs font-bold text-amber-400 font-sans" title="Delegation init_id does not match current MultiDelegate. Transfers will fail.">Stale</span>}
                   </TableCell>
                   <TableCell className="text-emerald-400 py-5 font-medium text-[15px] text-center">
                     {formatAmount(d.data.amount)} USDC
@@ -309,7 +314,7 @@ function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, block
                     {isOutgoing ? (
                       <RevokeDelegationButton delegation={d} />
                     ) : (
-                      <TransferDelegationButton delegation={d} tokenMint={tokenMint} disabled={rowExpired} blockTime={blockTime} />
+                      <TransferDelegationButton delegation={d} tokenMint={tokenMint} disabled={rowExpired || isStale} blockTime={blockTime} />
                     )}
                   </TableCell>
                 </TableRow>
@@ -322,7 +327,7 @@ function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, block
   )
 }
 
-function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, blockTime }: DelegationTableProps) {
+function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, blockTime, multiDelegateInitId }: DelegationTableProps) {
   if (delegations.length === 0) return null
   const isOutgoing = mode === 'outgoing'
   const partyLabel = isOutgoing ? 'Delegatee' : 'Delegator'
@@ -348,12 +353,14 @@ function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, b
           <TableBody>
             {delegations.map((d) => {
               const rowExpired = showExpired || (!isOutgoing && isExpired(d.data.expiryTs, blockTime))
+              const isStale = multiDelegateInitId != null && d.data.header.initId !== multiDelegateInitId
               const available = recurringAvailable(d.data.amountPerPeriod, d.data.amountPulledInPeriod, d.data.currentPeriodStartTs, d.data.periodLengthS, blockTime)
               return (
-                <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired ? 'opacity-60' : ''}`}>
+                <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired || isStale ? 'opacity-60' : ''}`}>
                   <TableCell className="font-mono text-[15px] text-gray-300 py-5 text-center">
                     {formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}
                     <span className="ml-1.5 text-xs font-bold text-blue-400/60 font-sans">v{d.data.header.version}</span>
+                    {isStale && <span className="ml-1.5 text-xs font-bold text-amber-400 font-sans" title="Delegation init_id does not match current MultiDelegate. Transfers will fail.">Stale</span>}
                   </TableCell>
                   <TableCell className="text-emerald-400 py-5 font-medium text-[15px] text-center">
                     {formatAmount(available)} USDC
@@ -378,7 +385,7 @@ function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, b
                     {isOutgoing ? (
                       <RevokeDelegationButton delegation={d} />
                     ) : (
-                      <TransferDelegationButton delegation={d} tokenMint={tokenMint} disabled={rowExpired} blockTime={blockTime} />
+                      <TransferDelegationButton delegation={d} tokenMint={tokenMint} disabled={rowExpired || isStale} blockTime={blockTime} />
                     )}
                   </TableCell>
                 </TableRow>
@@ -503,9 +510,97 @@ function InitPrompt({ tokenMint, onSuccess }: { tokenMint: string; onSuccess?: (
   )
 }
 
-export function ActiveDelegations({ tokenMint, isApproved, onInitSuccess }: ActiveDelegationsProps) {
+function CloseMultiDelegateDialog({ tokenMint, open, onOpenChange }: {
+  tokenMint: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { closeMultiDelegate } = useMultiDelegatorMutations()
+  const outgoing = useDelegations()
+  const incoming = useIncomingDelegations()
+  const { data: subscriptions } = useMySubscriptions()
+  const { url: rpcUrl } = useClusterConfig()
+  const { data: blockTime } = useQuery({
+    queryKey: ['blockTime', 'closeDialog', rpcUrl],
+    queryFn: () => getBlockTimestamp(rpcUrl),
+    enabled: open,
+  })
+  const [confirmText, setConfirmText] = useState('')
+
+  const activeFixed = outgoing.fixed.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
+  const activeRecurring = outgoing.recurring.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
+  const activeIncoming = incoming.all.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
+  const activeSubscriptions = subscriptions?.filter((s) => Number(s.subscription.expiresAtTs) === 0).length ?? 0
+  const totalActive = activeFixed + activeRecurring + activeIncoming + activeSubscriptions
+  const hasActive = totalActive > 0
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setConfirmText('')
+    onOpenChange(nextOpen)
+  }
+
+  const handleClose = async () => {
+    try {
+      await closeMultiDelegate.mutateAsync({ tokenMint })
+      handleOpenChange(false)
+    } catch {
+      // error handled by toast
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="border-red-500/30 bg-slate-950">
+        <DialogHeader>
+          <DialogTitle className="text-red-400">Disable Delegations</DialogTitle>
+          <DialogDescription>
+            {hasActive
+              ? 'You have active delegations. Closing the MultiDelegate account will invalidate them all.'
+              : 'Close your MultiDelegate account and return the rent to your wallet.'}
+          </DialogDescription>
+        </DialogHeader>
+        {hasActive && (
+          <div className="space-y-2 text-sm">
+            <div className="p-3 rounded-lg border border-amber-500/20 bg-amber-500/5 space-y-1">
+              {activeFixed > 0 && <p className="text-amber-400">{activeFixed} active fixed delegation{activeFixed > 1 ? 's' : ''}</p>}
+              {activeRecurring > 0 && <p className="text-amber-400">{activeRecurring} active recurring delegation{activeRecurring > 1 ? 's' : ''}</p>}
+              {activeIncoming > 0 && <p className="text-amber-400">{activeIncoming} incoming delegation{activeIncoming > 1 ? 's' : ''}</p>}
+              {activeSubscriptions > 0 && <p className="text-amber-400">{activeSubscriptions} active subscription{activeSubscriptions > 1 ? 's' : ''}</p>}
+            </div>
+            <p className="text-gray-400 text-xs">
+              Delegatees will no longer be able to transfer tokens. If you re-initialize later, old delegations will remain stale. This acts as an emergency kill switch.
+            </p>
+            <div className="space-y-1 pt-2">
+              <label className="text-xs text-gray-400">Type CLOSE to confirm</label>
+              <input
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder="CLOSE"
+                className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm"
+              />
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>Cancel</Button>
+          <Button
+            variant="destructive"
+            onClick={handleClose}
+            disabled={closeMultiDelegate.isPending || (hasActive && confirmText !== 'CLOSE')}
+          >
+            {closeMultiDelegate.isPending ? 'Closing...' : 'Disable Delegations'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function ActiveDelegations({ tokenMint, isApproved, multiDelegateInitId, onInitSuccess }: ActiveDelegationsProps) {
   const [activeTab, setActiveTab] = useState<TabType>('outgoing')
   const [outgoingSubTab, setOutgoingSubTab] = useState<OutgoingSubTab>('active')
+  const [closeDialogOpen, setCloseDialogOpen] = useState(false)
   const queryClient = useQueryClient()
   const { url: rpcUrl } = useClusterConfig()
   const { data: blockTime } = useQuery({
@@ -570,8 +665,8 @@ export function ActiveDelegations({ tokenMint, isApproved, onInitSuccess }: Acti
 
     return (
       <div className="space-y-6">
-        <FixedDelegationTable delegations={data.fixed} mode="outgoing" showExpired={showExpired} tokenMint={tokenMint} blockTime={blockTime} />
-        <RecurringDelegationTable delegations={data.recurring} mode="outgoing" showExpired={showExpired} tokenMint={tokenMint} blockTime={blockTime} />
+        <FixedDelegationTable delegations={data.fixed} mode="outgoing" showExpired={showExpired} tokenMint={tokenMint} blockTime={blockTime} multiDelegateInitId={multiDelegateInitId} />
+        <RecurringDelegationTable delegations={data.recurring} mode="outgoing" showExpired={showExpired} tokenMint={tokenMint} blockTime={blockTime} multiDelegateInitId={multiDelegateInitId} />
       </div>
     )
   }
@@ -589,7 +684,18 @@ export function ActiveDelegations({ tokenMint, isApproved, onInitSuccess }: Acti
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-end gap-2">
+        {isApproved && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCloseDialogOpen(true)}
+            className="text-red-400 border-red-500/20 hover:bg-red-500/10 hover:text-red-300"
+          >
+            <Power className="h-4 w-4 mr-1.5" />
+            Disable
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
@@ -645,6 +751,7 @@ export function ActiveDelegations({ tokenMint, isApproved, onInitSuccess }: Acti
       <div className="flex justify-end">
         <CreateDelegationDialog tokenMint={tokenMint} disabled={!isApproved} />
       </div>
+      <CloseMultiDelegateDialog tokenMint={tokenMint} open={closeDialogOpen} onOpenChange={setCloseDialogOpen} />
     </div>
   )
 }

--- a/webapp/src/components/delegation/active-delegations.tsx
+++ b/webapp/src/components/delegation/active-delegations.tsx
@@ -289,10 +289,14 @@ function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, block
               const isStale = multiDelegateInitId != null && d.data.header.initId !== multiDelegateInitId
               return (
                 <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired || isStale ? 'opacity-60' : ''}`}>
-                  <TableCell className="font-mono text-[15px] text-gray-300 py-5 text-center">
-                    {formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}
-                    <span className="ml-1.5 text-xs font-bold text-blue-400/60 font-sans">v{d.data.header.version}</span>
-                    {isStale && <span className="ml-1.5 text-xs font-bold text-amber-400 font-sans" title="Delegation init_id does not match current MultiDelegate. Transfers will fail.">Stale</span>}
+                  <TableCell className="py-5 text-center">
+                    <div className="font-mono text-[15px] text-gray-300">{formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}</div>
+                    <div className="flex items-center justify-center gap-2 mt-0.5 text-[11px] font-sans">
+                      <span className="text-blue-400/50 font-bold">V{d.data.header.version}</span>
+                      <span className="text-gray-700">|</span>
+                      <span className="text-teal-400/40 font-bold">ID: {d.data.header.initId.toString()}</span>
+                      {isStale && <><span className="text-gray-700">|</span><span className="text-amber-400 font-semibold">Stale</span></>}
+                    </div>
                   </TableCell>
                   <TableCell className="text-emerald-400 py-5 font-medium text-[15px] text-center">
                     {formatAmount(d.data.amount)} USDC
@@ -301,6 +305,8 @@ function FixedDelegationTable({ delegations, mode, showExpired, tokenMint, block
                   <TableCell className="py-5 text-gray-300 text-[15px] text-center">
                     {rowExpired ? (
                       <span className="text-red-400 font-medium">Expired</span>
+                    ) : d.data.expiryTs === 0n ? (
+                      <span className="text-gray-500 text-sm">No expiry</span>
                     ) : (
                       <div>
                         <div>{formatDelegationDateTime(d.data.expiryTs)}</div>
@@ -357,10 +363,14 @@ function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, b
               const available = recurringAvailable(d.data.amountPerPeriod, d.data.amountPulledInPeriod, d.data.currentPeriodStartTs, d.data.periodLengthS, blockTime)
               return (
                 <TableRow key={d.address} className={`border-none hover:bg-white/[0.03] transition-colors ${rowExpired || isStale ? 'opacity-60' : ''}`}>
-                  <TableCell className="font-mono text-[15px] text-gray-300 py-5 text-center">
-                    {formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}
-                    <span className="ml-1.5 text-xs font-bold text-blue-400/60 font-sans">v{d.data.header.version}</span>
-                    {isStale && <span className="ml-1.5 text-xs font-bold text-amber-400 font-sans" title="Delegation init_id does not match current MultiDelegate. Transfers will fail.">Stale</span>}
+                  <TableCell className="py-5 text-center">
+                    <div className="font-mono text-[15px] text-gray-300">{formatAddress(isOutgoing ? d.data.header.delegatee : d.data.header.delegator)}</div>
+                    <div className="flex items-center justify-center gap-2 mt-0.5 text-[11px] font-sans">
+                      <span className="text-blue-400/50 font-bold">V{d.data.header.version}</span>
+                      <span className="text-gray-700">|</span>
+                      <span className="text-teal-400/40 font-bold">ID: {d.data.header.initId.toString()}</span>
+                      {isStale && <><span className="text-gray-700">|</span><span className="text-amber-400 font-semibold">Stale</span></>}
+                    </div>
                   </TableCell>
                   <TableCell className="text-emerald-400 py-5 font-medium text-[15px] text-center">
                     {formatAmount(available)} USDC
@@ -372,6 +382,8 @@ function RecurringDelegationTable({ delegations, mode, showExpired, tokenMint, b
                   <TableCell className="py-5 text-gray-300 text-[15px] text-center">
                     {rowExpired ? (
                       <span className="text-red-400 font-medium">Expired</span>
+                    ) : d.data.expiryTs === 0n ? (
+                      <span className="text-gray-500 text-sm">No expiry</span>
                     ) : (
                       <div>
                         <div>{formatDelegationDateTime(d.data.expiryTs)}</div>

--- a/webapp/src/components/delegation/active-delegations.tsx
+++ b/webapp/src/components/delegation/active-delegations.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, FileX, Coins, ShieldAlert, Power } from 'lucide-react'
+import { RefreshCw, FileX, Coins, ShieldAlert, Power, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Table,
@@ -478,7 +478,16 @@ function InitPrompt({ tokenMint, onSuccess }: { tokenMint: string; onSuccess?: (
     address: walletAddress ? address(walletAddress) : address('11111111111111111111111111111111'),
   })
 
-  if (!walletAddress) return null
+  if (!walletAddress) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center space-y-3">
+        <ShieldAlert className="h-10 w-10 text-amber-500/60" />
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Connect your wallet to manage delegations</p>
+        </div>
+      </div>
+    )
+  }
 
   const userAta = (tokenAccounts as TokenAccountEntry[] | undefined)?.find((entry) => {
     return entry.account?.data?.parsed?.info?.mint === tokenMint
@@ -529,7 +538,6 @@ function CloseMultiDelegateDialog({ tokenMint, open, onOpenChange }: {
 }) {
   const { closeMultiDelegate } = useMultiDelegatorMutations()
   const outgoing = useDelegations()
-  const incoming = useIncomingDelegations()
   const { data: subscriptions } = useMySubscriptions()
   const { url: rpcUrl } = useClusterConfig()
   const { data: blockTime } = useQuery({
@@ -541,9 +549,8 @@ function CloseMultiDelegateDialog({ tokenMint, open, onOpenChange }: {
 
   const activeFixed = outgoing.fixed.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
   const activeRecurring = outgoing.recurring.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
-  const activeIncoming = incoming.all.filter((d) => !isExpired(d.data.expiryTs, blockTime)).length
   const activeSubscriptions = subscriptions?.filter((s) => Number(s.subscription.expiresAtTs) === 0).length ?? 0
-  const totalActive = activeFixed + activeRecurring + activeIncoming + activeSubscriptions
+  const totalActive = activeFixed + activeRecurring + activeSubscriptions
   const hasActive = totalActive > 0
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -567,20 +574,19 @@ function CloseMultiDelegateDialog({ tokenMint, open, onOpenChange }: {
           <DialogTitle className="text-red-400">Disable Delegations</DialogTitle>
           <DialogDescription>
             {hasActive
-              ? 'You have active delegations. Closing the MultiDelegate account will invalidate them all.'
+              ? 'You have active outgoing delegations. Closing the MultiDelegate account will invalidate them.'
               : 'Close your MultiDelegate account and return the rent to your wallet.'}
           </DialogDescription>
         </DialogHeader>
         {hasActive && (
           <div className="space-y-2 text-sm">
             <div className="p-3 rounded-lg border border-amber-500/20 bg-amber-500/5 space-y-1">
-              {activeFixed > 0 && <p className="text-amber-400">{activeFixed} active fixed delegation{activeFixed > 1 ? 's' : ''}</p>}
-              {activeRecurring > 0 && <p className="text-amber-400">{activeRecurring} active recurring delegation{activeRecurring > 1 ? 's' : ''}</p>}
-              {activeIncoming > 0 && <p className="text-amber-400">{activeIncoming} incoming delegation{activeIncoming > 1 ? 's' : ''}</p>}
+              {activeFixed > 0 && <p className="text-amber-400">{activeFixed} outgoing fixed delegation{activeFixed > 1 ? 's' : ''}</p>}
+              {activeRecurring > 0 && <p className="text-amber-400">{activeRecurring} outgoing recurring delegation{activeRecurring > 1 ? 's' : ''}</p>}
               {activeSubscriptions > 0 && <p className="text-amber-400">{activeSubscriptions} active subscription{activeSubscriptions > 1 ? 's' : ''}</p>}
             </div>
             <p className="text-gray-400 text-xs">
-              Delegatees will no longer be able to transfer tokens. If you re-initialize later, old delegations will remain stale. This acts as an emergency kill switch.
+              Delegatees will no longer be able to transfer from your outgoing delegations. Incoming delegations from others are not affected. If you re-initialize later, old delegations will remain stale.
             </p>
             <div className="space-y-1 pt-2">
               <label className="text-xs text-gray-400">Type CLOSE to confirm</label>
@@ -648,6 +654,22 @@ export function ActiveDelegations({ tokenMint, isApproved, multiDelegateInitId, 
     }
   }, [incoming.all])
 
+  const staleDelegations = useMemo(() => {
+    if (multiDelegateInitId == null) return []
+    return outgoing.all.filter((d) => d.data.header.initId !== multiDelegateInitId)
+  }, [outgoing.all, multiDelegateInitId])
+
+  const { revokeMultipleDelegations } = useMultiDelegatorMutations()
+
+  const handleRevokeAllStale = async () => {
+    if (staleDelegations.length === 0) return
+    await revokeMultipleDelegations.mutateAsync({
+      delegationAccounts: staleDelegations.map((d) => d.address),
+      tokenMint,
+    })
+    onInitSuccess?.()
+  }
+
   const isLoading = activeTab === 'outgoing' ? outgoing.isLoading : incoming.isLoading
   const isFetching = outgoing.isFetching || incoming.isFetching
   const [spinning, setSpinning] = useState(false)
@@ -697,6 +719,18 @@ export function ActiveDelegations({ tokenMint, isApproved, multiDelegateInitId, 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-end gap-2">
+        {staleDelegations.length > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRevokeAllStale}
+            disabled={revokeMultipleDelegations.isPending}
+            className="text-amber-400 border-amber-500/20 hover:bg-amber-500/10 hover:text-amber-300"
+          >
+            <Trash2 className="h-4 w-4 mr-1.5" />
+            {revokeMultipleDelegations.isPending ? 'Revoking...' : `Revoke ${staleDelegations.length} Stale`}
+          </Button>
+        )}
         {isApproved && (
           <Button
             variant="outline"

--- a/webapp/src/components/delegation/create-delegation-dialog.tsx
+++ b/webapp/src/components/delegation/create-delegation-dialog.tsx
@@ -60,6 +60,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
   // Form states
   const [delegatee, setDelegatee] = useState('')
   const [amount, setAmount] = useState('')
+  const [noExpiry, setNoExpiry] = useState(false)
   const [expiryDate, setExpiryDate] = useState('')
   const [expiryHour, setExpiryHour] = useState('12')
   const [periodDays, setPeriodDays] = useState('')
@@ -79,6 +80,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
   const resetForm = () => {
     setDelegatee('')
     setAmount('')
+    setNoExpiry(false)
     setExpiryDate('')
     setExpiryHour('12')
     setPeriodDays('')
@@ -111,9 +113,12 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
 
   const handleSubmit = async () => {
     const nonce = generateNonce()
-    const expiryDateTime = new Date(`${expiryDate}T${expiryHour.padStart(2, '0')}:00:00`)
-    const expiryTimestamp = Math.floor(expiryDateTime.getTime() / 1000)
-    if (Number.isNaN(expiryTimestamp) || expiryTimestamp <= 0) return
+    let expiryTimestamp = 0
+    if (!noExpiry) {
+      const expiryDateTime = new Date(`${expiryDate}T${expiryHour.padStart(2, '0')}:00:00`)
+      expiryTimestamp = Math.floor(expiryDateTime.getTime() / 1000)
+      if (Number.isNaN(expiryTimestamp) || expiryTimestamp <= 0) return
+    }
     const amountInSmallestUnits = BigInt(Math.round(Number(amount) * USDC_MULTIPLIER))
 
     if (selectedKind === 'fixed') {
@@ -155,6 +160,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
   const isPending = createFixedDelegation.isPending || createRecurringDelegation.isPending
 
   const isExpiryValid = () => {
+    if (noExpiry) return true
     if (!expiryDate) return false
     const expiryDateTime = new Date(`${expiryDate}T${expiryHour.padStart(2, '0')}:00:00`)
     return expiryDateTime > blockDate
@@ -165,7 +171,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
     delegatee.length <= 44 &&
     amount.length > 0 &&
     Number(amount) > 0 &&
-    expiryDate.length > 0 &&
+    (noExpiry || expiryDate.length > 0) &&
     isExpiryValid() &&
     (selectedKind === 'fixed' || (periodDays.length > 0 && Number(periodDays) > 0))
 
@@ -257,37 +263,56 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
               )}
 
               <div className="grid gap-2">
-                <Label htmlFor="expiry-date">Expiry Date & Time</Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="expiry-date"
-                    type="date"
-                    value={expiryDate}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExpiryDate(e.target.value)}
-                    min={blockDate.toLocaleDateString('en-CA')}
-                    className="flex-1"
-                  />
-                  <select
-                    id="expiry-hour"
-                    value={expiryHour}
-                    onChange={(e) => setExpiryHour(e.target.value)}
-                    className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                  >
-                    {Array.from({ length: 24 }, (_, i) => (
-                      <option key={i} value={i.toString()}>
-                        {i.toString().padStart(2, '0')}:00
-                      </option>
-                    ))}
-                  </select>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="expiry-date">Expiry</Label>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <span className="text-xs text-muted-foreground">No expiry</span>
+                    <input
+                      type="checkbox"
+                      checked={noExpiry}
+                      onChange={(e) => { setNoExpiry(e.target.checked); if (e.target.checked) setExpiryDate('') }}
+                      className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-emerald-500 focus:ring-emerald-500/30"
+                    />
+                  </label>
                 </div>
-                {expiryDate && !isExpiryValid() && (
-                  <p className="text-xs text-destructive">
-                    Expiry date must be in the future
-                  </p>
+                {noExpiry ? (
+                  <div className="flex items-center gap-2 rounded-md border border-gray-700/50 bg-gray-900/50 px-3 py-2.5">
+                    <span className="text-sm text-gray-400">This delegation will not have an expiration time</span>
+                  </div>
+                ) : (
+                  <>
+                    <div className="flex gap-2">
+                      <Input
+                        id="expiry-date"
+                        type="date"
+                        value={expiryDate}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExpiryDate(e.target.value)}
+                        min={blockDate.toLocaleDateString('en-CA')}
+                        className="flex-1"
+                      />
+                      <select
+                        id="expiry-hour"
+                        value={expiryHour}
+                        onChange={(e) => setExpiryHour(e.target.value)}
+                        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      >
+                        {Array.from({ length: 24 }, (_, i) => (
+                          <option key={i} value={i.toString()}>
+                            {i.toString().padStart(2, '0')}:00
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    {expiryDate && !isExpiryValid() && (
+                      <p className="text-xs text-destructive">
+                        Expiry date must be in the future
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      The delegation will expire and become invalid after this date
+                    </p>
+                  </>
                 )}
-                <p className="text-xs text-muted-foreground">
-                  The delegation will expire and become invalid after this date
-                </p>
               </div>
             </div>
 

--- a/webapp/src/components/delegation/create-delegation-dialog.tsx
+++ b/webapp/src/components/delegation/create-delegation-dialog.tsx
@@ -113,7 +113,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
     const nonce = generateNonce()
     const expiryDateTime = new Date(`${expiryDate}T${expiryHour.padStart(2, '0')}:00:00`)
     const expiryTimestamp = Math.floor(expiryDateTime.getTime() / 1000)
-    if (Number.isNaN(expiryTimestamp)) return
+    if (Number.isNaN(expiryTimestamp) || expiryTimestamp <= 0) return
     const amountInSmallestUnits = BigInt(Math.round(Number(amount) * USDC_MULTIPLIER))
 
     if (selectedKind === 'fixed') {

--- a/webapp/src/components/delegation/delegation-management-panel.tsx
+++ b/webapp/src/components/delegation/delegation-management-panel.tsx
@@ -69,6 +69,14 @@ export function DelegationManagementPanel() {
 
   return (
     <div className="w-full">
+      {multiDelegateInitId != null && (
+        <div className="flex items-center gap-2 mb-4 text-xs text-gray-500 tracking-wide">
+          <div className="h-px flex-1 bg-gradient-to-r from-transparent via-gray-700/40 to-transparent" />
+          <span className="uppercase">Current Delegation ID</span>
+          <span className="text-gray-400">{multiDelegateInitId.toString()}</span>
+          <div className="h-px flex-1 bg-gradient-to-r from-transparent via-gray-700/40 to-transparent" />
+        </div>
+      )}
       <ActiveDelegations tokenMint={usdcMint} isApproved={isApproved} multiDelegateInitId={multiDelegateInitId} onInitSuccess={refetchStatus} />
     </div>
   )

--- a/webapp/src/components/delegation/delegation-management-panel.tsx
+++ b/webapp/src/components/delegation/delegation-management-panel.tsx
@@ -51,7 +51,7 @@ function StatusError({ onRetry }: { onRetry: () => void }) {
 
 export function DelegationManagementPanel() {
   const { mint: usdcMint, isLoading: isMintLoading } = useUsdcMintRaw()
-  const { isLoading: statusLoading, isError, isApproved, refetch: refetchStatus } = useMultiDelegateStatus(usdcMint)
+  const { isLoading: statusLoading, isError, isApproved, data: statusData, refetch: refetchStatus } = useMultiDelegateStatus(usdcMint)
 
   if (isMintLoading || statusLoading) {
     return <LoadingState />
@@ -65,9 +65,11 @@ export function DelegationManagementPanel() {
     return <TokenConfigError />
   }
 
+  const multiDelegateInitId = statusData?.data?.initId ?? null
+
   return (
     <div className="w-full">
-      <ActiveDelegations tokenMint={usdcMint} isApproved={isApproved} onInitSuccess={refetchStatus} />
+      <ActiveDelegations tokenMint={usdcMint} isApproved={isApproved} multiDelegateInitId={multiDelegateInitId} onInitSuccess={refetchStatus} />
     </div>
   )
 }

--- a/webapp/src/components/plan/create-plan-dialog.tsx
+++ b/webapp/src/components/plan/create-plan-dialog.tsx
@@ -36,6 +36,7 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
   const [amount, setAmount] = useState('')
   const [periodValue, setPeriodValue] = useState('')
   const [periodUnit, setPeriodUnit] = useState<'hours' | 'days' | 'weeks' | 'months'>('days')
+  const [noEndDate, setNoEndDate] = useState(true)
   const [endDate, setEndDate] = useState('')
   const [endHour, setEndHour] = useState('12')
   const [destinations, setDestinations] = useState<string[]>([])
@@ -78,6 +79,7 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
     setAmount('')
     setPeriodValue('')
     setPeriodUnit('days')
+    setNoEndDate(true)
     setEndDate('')
     setEndHour('12')
     setDestinations([])
@@ -354,33 +356,51 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
             </div>
 
             <div className="sm:col-span-2 grid gap-2">
-              <Label>End Date/Time <span className="text-muted-foreground font-normal">(optional)</span></Label>
-              <div className="flex gap-2">
-                <Input
-                  type="date"
-                  value={endDate}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEndDate(e.target.value)}
-                  min={new Date(minEndTs * 1000).toLocaleDateString('en-CA')}
-                  className="flex-1"
-                />
-                <select
-                  value={endHour}
-                  onChange={(e) => setEndHour(e.target.value)}
-                  className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                >
-                  {Array.from({ length: 24 }, (_, i) => (
-                    <option key={i} value={i.toString()}>
-                      {i.toString().padStart(2, '0')}:00
-                    </option>
-                  ))}
-                </select>
+              <div className="flex items-center justify-between">
+                <Label>End Date/Time</Label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <span className="text-xs text-muted-foreground">No end date</span>
+                  <input
+                    type="checkbox"
+                    checked={noEndDate}
+                    onChange={(e) => { setNoEndDate(e.target.checked); if (e.target.checked) setEndDate('') }}
+                    className="h-4 w-4 rounded border-gray-600 bg-gray-800 text-emerald-500 focus:ring-emerald-500/30"
+                  />
+                </label>
               </div>
-              {endDate && !isEndDateValid && (
-                <p className="text-xs text-destructive">
-                  End date must be at least one billing period ({periodHours}h) from now
-                </p>
+              {noEndDate ? (
+                <div className="flex items-center gap-2 rounded-md border border-gray-700/50 bg-gray-900/50 px-3 py-2.5">
+                  <span className="text-sm text-gray-400">This plan will not have an end date</span>
+                </div>
+              ) : (
+                <>
+                  <div className="flex gap-2">
+                    <Input
+                      type="date"
+                      value={endDate}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEndDate(e.target.value)}
+                      min={new Date(minEndTs * 1000).toLocaleDateString('en-CA')}
+                      className="flex-1"
+                    />
+                    <select
+                      value={endHour}
+                      onChange={(e) => setEndHour(e.target.value)}
+                      className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                    >
+                      {Array.from({ length: 24 }, (_, i) => (
+                        <option key={i} value={i.toString()}>
+                          {i.toString().padStart(2, '0')}:00
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {endDate && !isEndDateValid && (
+                    <p className="text-xs text-destructive">
+                      End date must be at least one billing period ({periodHours}h) from now
+                    </p>
+                  )}
+                </>
               )}
-              <p className="text-xs text-muted-foreground">Leave empty for no end date (endTs = 0)</p>
             </div>
 
             <div className="sm:col-span-2">

--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -55,8 +55,6 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
     if (open) getCurrentTimestamp().then(setBlockTime).catch((err) => console.error('Failed to fetch block timestamp:', err))
   }, [open, getCurrentTimestamp])
 
-  const blockDate = blockTime ? new Date(blockTime * 1000) : new Date()
-
   const [planName, setPlanName] = useState(meta.n || '')
   const [description, setDescription] = useState(meta.d || '')
   const [selectedIcon, setSelectedIcon] = useState(meta.i || '')
@@ -98,10 +96,14 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
     [metadataJson],
   )
 
+  const endTsComputed = endDate
+    ? Math.floor(new Date(`${endDate}T${endHour.padStart(2, '0')}:00:00`).getTime() / 1000)
+    : 0
+  const minEndTs = (blockTime ?? 0) + Number(plan.data.terms.periodHours) * 3600
+  const isEndDateValid = endTsComputed === 0 || endTsComputed > minEndTs
+
   const handleUpdate = () => {
-    const endTs = endDate
-      ? Math.floor(new Date(`${endDate}T${endHour.padStart(2, '0')}:00:00`).getTime() / 1000)
-      : 0
+    const endTs = endTsComputed
     const status = sunsetMode ? PlanStatus.Sunset : PlanStatus.Active
 
     const filteredPullers = pullers.filter((p) => p.length > 0)
@@ -119,7 +121,9 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
     planName.length > 0 &&
     description.length > 0 &&
     metadataBytes <= 128 &&
-    !(sunsetMode && !endDate)
+    !(sunsetMode && !endDate) &&
+    isEndDateValid &&
+    (endTsComputed === 0 || blockTime !== undefined)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -227,7 +231,7 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
                   type="date"
                   value={endDate}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEndDate(e.target.value)}
-                  min={blockDate.toLocaleDateString('en-CA')}
+                  min={new Date(minEndTs * 1000).toLocaleDateString('en-CA')}
                   className="flex-1"
                   disabled={isSunset}
                 />
@@ -244,6 +248,11 @@ function EditPlanDialog({ plan, meta, open, onOpenChange }: {
                   ))}
                 </select>
               </div>
+              {endDate && !isEndDateValid && (
+                <p className="text-xs text-destructive">
+                  End date must be at least one billing period from now
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">Leave empty for no end date</p>
             </div>
 

--- a/webapp/src/components/solana/solana-provider.tsx
+++ b/webapp/src/components/solana/solana-provider.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 import {
   createSolanaDevnet,
-  createSolanaLocalnet,
   createSolanaTestnet,
   createWalletUiConfig,
   WalletUi,
@@ -12,12 +11,12 @@ import { WalletSignerProvider } from './use-wallet-ui-signer'
 
 export { WalletUiDropdown as WalletButton, WalletUiClusterDropdown as ClusterButton }
 
-const defaultClusterId = import.meta.env.VITE_DEFAULT_CLUSTER ?? 'solana:localnet'
+const defaultClusterId = localStorage.getItem('setup-cluster') || import.meta.env.VITE_DEFAULT_CLUSTER || 'solana:localnet'
 
 const allClusters = [
   createSolanaDevnet(),
   createSolanaTestnet(),
-  createSolanaLocalnet(),
+  { id: 'solana:localnet' as const, label: 'Localnet', url: '/rpc' },
 ]
 
 const config = createWalletUiConfig({

--- a/webapp/src/components/solana/use-wallet-ui-signer.tsx
+++ b/webapp/src/components/solana/use-wallet-ui-signer.tsx
@@ -32,6 +32,7 @@ export function WalletSignerProvider({ children }: { children: ReactNode }) {
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useWalletUiSigner() {
   return useContext(WalletSignerContext)
 }

--- a/webapp/src/components/subscription/my-subscriptions-panel.tsx
+++ b/webapp/src/components/subscription/my-subscriptions-panel.tsx
@@ -160,8 +160,12 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
 
   const planDeleted = !item.plan
   const planName = meta.n || 'Unknown Plan'
-  const amount = item.plan ? Number(item.plan.data.terms.amount) / USDC_MULTIPLIER : null
-  const period = item.plan ? formatPeriod(item.plan.data.terms.periodHours) : null
+  const amount = Number(item.subscription.terms.amount) / USDC_MULTIPLIER
+  const period = formatPeriod(item.subscription.terms.periodHours)
+  const termsChanged = item.plan && (
+    item.plan.data.terms.amount !== item.subscription.terms.amount ||
+    item.plan.data.terms.periodHours !== item.subscription.terms.periodHours
+  )
   const pulled = Number(item.subscription.amountPulledInPeriod) / USDC_MULTIPLIER
 
   return (
@@ -188,11 +192,12 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
           </div>
 
           <div className="flex items-baseline gap-1.5">
-            {amount !== null && period && (
-              <>
-                <span className="text-base sm:text-lg lg:text-xl font-bold text-teal-400">${amount}</span>
-                <span className="text-sm text-teal-400/60">/{period.toLowerCase()}</span>
-              </>
+            <span className="text-base sm:text-lg lg:text-xl font-bold text-teal-400">${amount}</span>
+            <span className="text-sm text-teal-400/60">/{period.toLowerCase()}</span>
+            {termsChanged && (
+              <span className="text-xs text-amber-400 ml-1" title="Plan terms have changed since you subscribed">
+                (terms changed)
+              </span>
             )}
           </div>
 

--- a/webapp/src/components/subscription/my-subscriptions-panel.tsx
+++ b/webapp/src/components/subscription/my-subscriptions-panel.tsx
@@ -8,6 +8,8 @@ import {
 } from '@/components/ui/dialog'
 import { useMySubscriptions, type EnrichedSubscription } from '@/hooks/use-subscriptions'
 import { useMultiDelegatorMutations } from '@/hooks/use-multi-delegator'
+import { useMultiDelegateStatus } from '@/hooks/use-multi-delegate-status'
+import { useUsdcMintRaw } from '@/hooks/use-token-config'
 import { useTimeTravel } from '@/hooks/use-time-travel'
 import { cn, USDC_MULTIPLIER, ellipsify, fmtDate, fmtDateTime, formatPeriod } from '@/lib/utils'
 import { parsePlanMeta } from '@/lib/plan-constants'
@@ -97,8 +99,9 @@ function RevokeSubscriptionDialog({ item, open, onOpenChange }: {
   )
 }
 
-function CancelAndRevokeDialog({ item, open, onOpenChange }: {
+function CancelAndRevokeDialog({ item, isGhostPlan, open, onOpenChange }: {
   item: EnrichedSubscription
+  isGhostPlan?: boolean
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
@@ -110,7 +113,9 @@ function CancelAndRevokeDialog({ item, open, onOpenChange }: {
         <DialogHeader>
           <DialogTitle className="text-red-400">Unsubscribe & Delete</DialogTitle>
           <DialogDescription>
-            The plan for this subscription has been deleted. This will cancel and immediately delete the subscription, returning rent to your wallet.
+            {isGhostPlan
+              ? 'The plan terms have changed since you subscribed (ghost plan). Payments cannot be collected. This will cancel and immediately delete the subscription, returning rent to your wallet.'
+              : 'The plan for this subscription has been deleted. This will cancel and immediately delete the subscription, returning rent to your wallet.'}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -132,10 +137,11 @@ function CancelAndRevokeDialog({ item, open, onOpenChange }: {
   )
 }
 
-function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
+function SubscriptionCard({ item, multiDelegateInitId }: { item: EnrichedSubscription; multiDelegateInitId: bigint | null }) {
   const [cancelOpen, setCancelOpen] = useState(false)
   const [revokeOpen, setRevokeOpen] = useState(false)
   const [cancelAndRevokeOpen, setCancelAndRevokeOpen] = useState(false)
+  const { cancelSubscription } = useMultiDelegatorMutations()
   const { getCurrentTimestamp } = useTimeTravel()
   const isActive = Number(item.subscription.expiresAtTs) === 0
   const isCancelled = !isActive
@@ -162,11 +168,14 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
   const planName = meta.n || 'Unknown Plan'
   const amount = Number(item.subscription.terms.amount) / USDC_MULTIPLIER
   const period = formatPeriod(item.subscription.terms.periodHours)
-  const termsChanged = item.plan && (
+  const isGhostPlan = item.plan != null && (
     item.plan.data.terms.amount !== item.subscription.terms.amount ||
-    item.plan.data.terms.periodHours !== item.subscription.terms.periodHours
+    item.plan.data.terms.periodHours !== item.subscription.terms.periodHours ||
+    item.plan.data.terms.createdAt !== item.subscription.terms.createdAt
   )
   const pulled = Number(item.subscription.amountPulledInPeriod) / USDC_MULTIPLIER
+  const subInitId = item.subscription.header.initId
+  const isStale = multiDelegateInitId != null && subInitId !== multiDelegateInitId
 
   return (
     <>
@@ -184,6 +193,8 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
             <p className="font-semibold text-white truncate">{planName}</p>
             {planDeleted ? (
               <Badge variant="outline" className="text-red-400 border-red-400/30 text-xs shrink-0">Plan Deleted</Badge>
+            ) : isGhostPlan ? (
+              <Badge variant="outline" className="text-amber-400 border-amber-400/30 text-xs shrink-0">Ghost Plan</Badge>
             ) : isActive ? (
               <Badge variant="outline" className="text-teal-400 border-teal-400/30 text-xs shrink-0">Active</Badge>
             ) : (
@@ -194,17 +205,15 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
           <div className="flex items-baseline gap-1.5">
             <span className="text-base sm:text-lg lg:text-xl font-bold text-teal-400">${amount}</span>
             <span className="text-sm text-teal-400/60">/{period.toLowerCase()}</span>
-            {termsChanged && (
-              <span className="text-xs text-amber-400 ml-1" title="Plan terms have changed since you subscribed">
-                (terms changed)
-              </span>
-            )}
           </div>
 
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400">
             <span className="font-mono">{ellipsify(item.address, 4)}</span>
             <span className="text-teal-800">|</span>
-            <span className="text-xs font-bold text-blue-400/60">v{item.subscription.header.version}</span>
+            <span className="font-bold text-blue-400/50">V{item.subscription.header.version}</span>
+            <span className="text-teal-800">|</span>
+            <span className="font-bold text-teal-400/40">ID: {subInitId.toString()}</span>
+            {isStale && <><span className="text-teal-800">|</span><span className="font-semibold text-amber-400">Stale</span></>}
             <span className="text-teal-800">|</span>
             <span>Pulled: ${pulled.toFixed(2)}</span>
             {isCancelled && !planDeleted && (
@@ -219,7 +228,7 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
           </div>
 
           <div className={cn('pt-2 border-t', planDeleted ? 'border-red-500/10' : 'border-teal-500/10')}>
-            {planDeleted && isActive ? (
+            {(planDeleted || isGhostPlan) && isActive ? (
               <Button
                 variant="outline"
                 size="sm"
@@ -233,10 +242,14 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setCancelOpen(true)}
+                onClick={() => isStale
+                  ? cancelSubscription.mutate({ planPda: item.subscription.header.delegatee, subscriptionPda: item.address })
+                  : setCancelOpen(true)
+                }
+                disabled={cancelSubscription.isPending}
                 className="w-full border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
               >
-                Unsubscribe
+                {cancelSubscription.isPending ? 'Unsubscribing...' : 'Unsubscribe'}
               </Button>
             ) : (
               <Button
@@ -260,13 +273,16 @@ function SubscriptionCard({ item }: { item: EnrichedSubscription }) {
       </Card>
       <CancelSubscriptionDialog item={item} open={cancelOpen} onOpenChange={setCancelOpen} />
       <RevokeSubscriptionDialog item={item} open={revokeOpen} onOpenChange={setRevokeOpen} />
-      <CancelAndRevokeDialog item={item} open={cancelAndRevokeOpen} onOpenChange={setCancelAndRevokeOpen} />
+      <CancelAndRevokeDialog item={item} isGhostPlan={isGhostPlan} open={cancelAndRevokeOpen} onOpenChange={setCancelAndRevokeOpen} />
     </>
   )
 }
 
 export function MySubscriptionsPanel() {
   const { data: subscriptions, isLoading } = useMySubscriptions()
+  const { mint: usdcMint } = useUsdcMintRaw()
+  const { data: statusData } = useMultiDelegateStatus(usdcMint)
+  const multiDelegateInitId = statusData?.data?.initId ?? null
 
   if (isLoading) {
     return (
@@ -299,7 +315,7 @@ export function MySubscriptionsPanel() {
           {hasSubs ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {subscriptions.map((item) => (
-                <SubscriptionCard key={item.address} item={item} />
+                <SubscriptionCard key={item.address} item={item} multiDelegateInitId={multiDelegateInitId} />
               ))}
             </div>
           ) : (

--- a/webapp/src/components/time-travel/time-travel-button.tsx
+++ b/webapp/src/components/time-travel/time-travel-button.tsx
@@ -20,8 +20,7 @@ const QUICK_JUMPS = [
   { label: '+30d', seconds: 2592000 },
 ] as const
 
-const DRIFT_THRESHOLD_SEC = 30
-
+const TIME_TRAVELED_KEY = 'time-traveled'
 
 function TimeTravelButtonInner() {
   const { timeTravel, getCurrentTimestamp } = useTimeTravel()
@@ -31,22 +30,21 @@ function TimeTravelButtonInner() {
   const [loading, setLoading] = useState(false)
   const [date, setDate] = useState('')
   const [hour, setHour] = useState('12')
-  const [timeTraveled, setTimeTraveled] = useState(false)
+  const [timeTraveled, setTimeTraveled] = useState(() => sessionStorage.getItem(TIME_TRAVELED_KEY) === 'true')
 
-  const updateDrift = useCallback((blockTime: number) => {
-    const wallTime = Math.floor(Date.now() / 1000)
-    setTimeTraveled(Math.abs(blockTime - wallTime) > DRIFT_THRESHOLD_SEC)
+  const markTimeTraveled = useCallback(() => {
+    sessionStorage.setItem(TIME_TRAVELED_KEY, 'true')
+    setTimeTraveled(true)
   }, [])
 
   const fetchTime = useCallback(async () => {
     try {
       const ts = await getCurrentTimestamp()
       setCurrentTime(ts)
-      updateDrift(ts)
     } catch (e) {
       console.warn('[TimeTravel] Failed to fetch clock:', e)
     }
-  }, [getCurrentTimestamp, updateDrift])
+  }, [getCurrentTimestamp])
 
   useEffect(() => { fetchTime() }, [fetchTime])
 
@@ -93,7 +91,7 @@ function TimeTravelButtonInner() {
         animRef.current = 0
         setLoading(true)
         timeTravel(endTs)
-          .then(() => fetchTime())
+          .then(() => { markTimeTraveled(); return fetchTime() })
           .then(() => {
             queryClient.invalidateQueries()
             setTimeout(() => queryClient.invalidateQueries(), 500)
@@ -119,6 +117,7 @@ function TimeTravelButtonInner() {
         return
       }
       await timeTravel(ts)
+      markTimeTraveled()
       await fetchTime()
       queryClient.invalidateQueries()
       setTimeout(() => queryClient.invalidateQueries(), 500)

--- a/webapp/src/hooks/use-delegations.ts
+++ b/webapp/src/hooks/use-delegations.ts
@@ -13,7 +13,9 @@ export interface DelegationData {
   header: {
     delegator: string
     delegatee: string
+    payer: string
     version: number
+    initId: bigint
   }
   amount: bigint
   amountPerPeriod: bigint
@@ -88,6 +90,8 @@ function useDelegationsByRole(role: DelegationRole) {
       return fetchDelegationsByRole(clusterConfig.url, account.address, role, progAddr!)
     },
     enabled: !!account?.address && !!progAddr,
+    staleTime: 15_000,
+    retry: 1,
   })
 
   const refetch = async () => {

--- a/webapp/src/hooks/use-multi-delegate-status.ts
+++ b/webapp/src/hooks/use-multi-delegate-status.ts
@@ -1,18 +1,16 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useWalletUi } from '@wallet-ui/react'
-import { createSolanaRpc, address, type Address } from 'gill'
-import { TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS } from 'gill/programs/token'
+import { createSolanaRpc, address } from 'gill'
+import { TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS, findAssociatedTokenPda } from 'gill/programs/token'
 import { getMultiDelegatePDA, fetchMaybeMultiDelegate } from '@multidelegator/client'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
-import type { TokenAccountEntry } from '@/lib/types'
-
-const TOKEN_PROGRAMS: Address[] = [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]
 
 export interface MultiDelegateData {
   owner: string
   tokenMint: string
   bump: number
+  initId: bigint
 }
 
 export interface MultiDelegateStatus {
@@ -52,25 +50,25 @@ export function useMultiDelegateStatus(tokenMint: string | null) {
       let approved = false
       if (exists) {
         try {
-          const tokenAccounts = await Promise.all(
-            TOKEN_PROGRAMS.map((programId) =>
-              rpc
-                .getTokenAccountsByOwner(address(account.address), { programId }, { encoding: 'jsonParsed', commitment: 'confirmed' })
-                .send()
-                .then((res) => (res.value ?? []) as unknown as TokenAccountEntry[])
-                .catch(() => [] as TokenAccountEntry[])
-            )
-          ).then((results) => results.flat())
+          const mint = address(tokenMint)
+          const owner = address(account.address)
+          const tokenPrograms = [TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS]
 
-          const matchingAccount = tokenAccounts.find((entry) => {
-            const info = entry.account?.data?.parsed?.info
-            return info?.mint === tokenMint
-          })
+          for (const tokenProgram of tokenPrograms) {
+            const [ata] = await findAssociatedTokenPda({ mint, owner, tokenProgram })
+            const ataAccount = await rpc
+              .getAccountInfo(ata, { encoding: 'jsonParsed', commitment: 'confirmed' })
+              .send()
 
-          const delegate = matchingAccount?.account?.data?.parsed?.info?.delegate ?? null
-          approved = delegate === pda
+            if (ataAccount.value) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const delegate = (ataAccount.value.data as any)?.parsed?.info?.delegate ?? null
+              approved = delegate === pda
+              break
+            }
+          }
         } catch (err) {
-          console.error('Failed to fetch token accounts:', err)
+          console.error('Failed to check delegate status:', err)
         }
       }
 

--- a/webapp/src/hooks/use-multi-delegator.ts
+++ b/webapp/src/hooks/use-multi-delegator.ts
@@ -684,6 +684,47 @@ export function useMultiDelegatorMutations() {
     onError: (error) => toast.onError(error),
   });
 
+  const revokeMultipleDelegations = useMutation({
+    mutationFn: async ({ delegationAccounts, tokenMint }: { delegationAccounts: string[]; tokenMint: string }) => {
+      if (!signer) throw new Error("Wallet not connected");
+      if (!progId) throw new Error("Program address not configured");
+
+      const revokeIxs = delegationAccounts.map((account) => {
+        const { instructions } = buildRevokeDelegation({
+          authority: signer,
+          delegationAccount: address(account),
+          programAddress: progId,
+        });
+        return instructions[0];
+      });
+
+      const { instructions: closeIxs } = await buildCloseMultiDelegate({
+        user: signer,
+        tokenMint: address(tokenMint),
+        programAddress: progId,
+      });
+
+      const allIxs = [...revokeIxs, ...closeIxs];
+      const batches = packInstructionBatches(allIxs, signer);
+      const signatures: string[] = [];
+
+      for (const batch of batches) {
+        signatures.push(await signAndSend(batch, signer));
+      }
+
+      return { signatures, revoked: delegationAccounts.length };
+    },
+    onSuccess: (res) => {
+      toast.onSuccess(res.signatures[0]);
+      invalidateWithDelay(queryClient, [
+        ["delegations"],
+        ["multiDelegateStatus"],
+        ["get-token-accounts"],
+      ]);
+    },
+    onError: (error) => toast.onError(error),
+  });
+
   return {
     initMultiDelegate,
     closeMultiDelegate,
@@ -701,5 +742,6 @@ export function useMultiDelegatorMutations() {
     cancelAndRevokeSubscription,
     collectSubscriptionPayments,
     collectAllPlanPayments,
+    revokeMultipleDelegations,
   };
 }

--- a/webapp/src/hooks/use-multi-delegator.ts
+++ b/webapp/src/hooks/use-multi-delegator.ts
@@ -7,6 +7,7 @@ import {
 } from "gill/programs/token";
 import {
   buildInitMultiDelegate,
+  buildCloseMultiDelegate,
   buildCreateFixedDelegation,
   buildCreateRecurringDelegation,
   buildRevokeDelegation,
@@ -71,6 +72,31 @@ export function useMultiDelegatorMutations() {
         ["multiDelegateStatus"],
         ["get-token-accounts"],
         ["delegations"],
+      ]);
+    },
+    onError: (error) => toast.onError(error),
+  });
+
+  const closeMultiDelegate = useMutation({
+    mutationFn: async ({ tokenMint }: { tokenMint: string }) => {
+      if (!signer) throw new Error("Wallet not connected");
+      if (!progId) throw new Error("Program address not configured");
+
+      const { instructions } = await buildCloseMultiDelegate({
+        user: signer,
+        tokenMint: address(tokenMint),
+        programAddress: progId,
+      });
+
+      const signature = await signAndSend(instructions, signer);
+      return { signature };
+    },
+    onSuccess: (res) => {
+      toast.onSuccess(res.signature);
+      invalidateWithDelay(queryClient, [
+        ["multiDelegateStatus"],
+        ["delegations"],
+        ["get-token-accounts"],
       ]);
     },
     onError: (error) => toast.onError(error),
@@ -660,6 +686,7 @@ export function useMultiDelegatorMutations() {
 
   return {
     initMultiDelegate,
+    closeMultiDelegate,
     createFixedDelegation,
     createRecurringDelegation,
     revokeDelegation,

--- a/webapp/src/hooks/use-subscriptions.ts
+++ b/webapp/src/hooks/use-subscriptions.ts
@@ -18,6 +18,7 @@ import { useProgramAddress } from '@/hooks/use-token-config'
 export interface PlanSubscriber {
   subscriptionAddress: string
   delegator: string
+  terms: { amount: bigint; periodHours: bigint; createdAt: bigint }
   amountPulledInPeriod: bigint
   currentPeriodStartTs: bigint
   expiresAtTs: bigint
@@ -84,6 +85,7 @@ export async function fetchPlanSubscriptions(rpcUrl: string, planAddress: string
       subscribers.push({
         subscriptionAddress: entry.pubkey as string,
         delegator: sub.header.delegator,
+        terms: sub.terms,
         amountPulledInPeriod: sub.amountPulledInPeriod,
         currentPeriodStartTs: sub.currentPeriodStartTs,
         expiresAtTs: sub.expiresAtTs,

--- a/webapp/src/hooks/use-subscriptions.ts
+++ b/webapp/src/hooks/use-subscriptions.ts
@@ -71,7 +71,6 @@ export async function fetchPlanSubscriptions(rpcUrl: string, planAddress: string
     } as any)
     .send()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const accounts = response as unknown as RawProgramAccount[]
   if (accounts.length === 0) return []
 

--- a/webapp/src/lib/collect-utils.ts
+++ b/webapp/src/lib/collect-utils.ts
@@ -18,6 +18,7 @@ export function computeEligibleSubscribers(
 
   for (const sub of subscribers) {
     if (sub.expiresAtTs !== 0n && currentTs >= Number(sub.expiresAtTs)) continue
+    if (sub.terms.amount !== planAmount || sub.terms.periodHours !== periodHours) continue
 
     const periodEnd = Number(sub.currentPeriodStartTs) + Number(periodHours) * 3600
     const collectAmount = currentTs >= periodEnd

--- a/webapp/src/lib/utils.ts
+++ b/webapp/src/lib/utils.ts
@@ -7,9 +7,11 @@ export const USDC_DECIMALS = 6
 export const USDC_MULTIPLIER = 10 ** USDC_DECIMALS
 export const SECONDS_PER_DAY = 86400
 
+const TIME_DRIFT_ALLOWED_SECS = 120
+
 export function isExpired(expiryTs: bigint, nowSec?: number): boolean {
   const now = nowSec ?? Math.floor(Date.now() / 1000)
-  return Number(expiryTs) < now
+  return Number(expiryTs) + TIME_DRIFT_ALLOWED_SECS < now
 }
 
 export function cn(...inputs: ClassValue[]) {

--- a/webapp/src/lib/utils.ts
+++ b/webapp/src/lib/utils.ts
@@ -10,6 +10,7 @@ export const SECONDS_PER_DAY = 86400
 const TIME_DRIFT_ALLOWED_SECS = 120
 
 export function isExpired(expiryTs: bigint, nowSec?: number): boolean {
+  if (expiryTs === 0n) return false
   const now = nowSec ?? Math.floor(Date.now() / 1000)
   return Number(expiryTs) + TIME_DRIFT_ALLOWED_SECS < now
 }

--- a/webapp/src/routes/dashboard.tsx
+++ b/webapp/src/routes/dashboard.tsx
@@ -5,7 +5,6 @@ import { SummaryCards } from '@/components/dashboard/summary-cards'
 
 function DashboardConnected() {
   const { account } = useWalletUi()
-
   return (
     <div className="space-y-8 max-w-5xl mx-auto">
       {account && <WalletBalanceCards address={address(account.address)} />}

--- a/webapp/src/routes/setup.tsx
+++ b/webapp/src/routes/setup.tsx
@@ -453,7 +453,7 @@ function DevnetWizard({ onComplete, onBack }: { onComplete: () => void; onBack: 
       log('error', `Deploy failed: ${msg}`)
       markStepError('deploy-program', msg)
     }
-  }, [programStatus.data, programDeploy, markStepDone, markStepError, markStepRunning, log])
+  }, [programStatus.data, programDeploy, markStepDone, markStepError, markStepRunning, setResult, log])
 
   const handleTransferAuthority = useCallback(async () => {
     if (!walletSigner) return

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -6,6 +6,15 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      '/rpc': {
+        target: 'http://localhost:8899',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/rpc/, ''),
+      },
+    },
+  },
   plugins: [
     nodePolyfills({
       globals: {


### PR DESCRIPTION
  - Align with on-chain audit PRs (`init_id`, `PlanTerms`, `endTs`, `TIME_DRIFT`, zero expiry)
  - Add close MultiDelegate dialog and batch revoke stale delegations
  - Detect ghost plans with immediate cancel+revoke
  - Show delegation ID across dashboard, delegations, and subscriptions