### PR TITLE
feat: expand integration tests

### DIFF
--- a/clients/typescript/test/delegation-security.test.ts
+++ b/clients/typescript/test/delegation-security.test.ts
@@ -1,0 +1,996 @@
+import { describe, expect, test } from 'vitest';
+import {
+  MULTI_DELEGATOR_ERROR__AMOUNT_EXCEEDS_PERIOD_LIMIT,
+  MULTI_DELEGATOR_ERROR__DELEGATION_ALREADY_EXISTS,
+  MULTI_DELEGATOR_ERROR__DELEGATION_EXPIRED,
+  MULTI_DELEGATOR_ERROR__DELEGATION_NOT_STARTED,
+  MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+  MULTI_DELEGATOR_ERROR__STALE_MULTI_DELEGATE,
+  MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+} from '../src/generated/errors/multiDelegator.ts';
+import { buildCloseMultiDelegate } from '../src/instructions/delegation.ts';
+import { getDelegationPDA, getMultiDelegatePDA } from '../src/pdas.ts';
+import { addressAsSigner } from '../src/wallet.ts';
+import {
+  DEFAULT_TEST_BALANCE,
+  expectProgramError,
+  initTestSuite,
+  ONE_DAY_IN_SECONDS,
+  ONE_HOUR_IN_SECONDS,
+} from './setup.ts';
+
+describe('Delegation Security', () => {
+  test('stale delegation after re-init is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    const [oldDelegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    await t.client.transferFixed({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda: oldDelegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { instructions: closeIxs } = await buildCloseMultiDelegate({
+      user: addressAsSigner(t.payerKeypair.address),
+      tokenMint: t.tokenMint,
+    });
+    await t.payer.sendInstructions(closeIxs);
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await expectProgramError(
+      t.client.transferFixed({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda: oldDelegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__STALE_MULTI_DELEGATE,
+    );
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 1n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    const [newDelegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      1n,
+    );
+
+    const { signature } = await t.client.transferFixed({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda: newDelegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('close MultiDelegate kills all transfers', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE * 2n,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+
+    const delegatee1 = await t.createFundedKeypair();
+    const delegatee1Ata = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee1.address,
+      0n,
+    );
+    const delegatee2 = await t.createFundedKeypair();
+    const delegatee2Ata = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee2.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee1.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee2.address,
+      nonce: 0n,
+      amountPerPeriod: 100_000n,
+      periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+      startTs: currentTs,
+      expiryTs: currentTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+    });
+
+    const [fixedPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee1.address,
+      0n,
+    );
+    const [recurringPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee2.address,
+      0n,
+    );
+
+    await t.client.transferFixed({
+      delegatee: delegatee1,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda: fixedPda,
+      amount: 50_000n,
+      receiverAta: delegatee1Ata,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await t.client.transferRecurring({
+      delegatee: delegatee2,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda: recurringPda,
+      amount: 50_000n,
+      receiverAta: delegatee2Ata,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { instructions: closeIxs } = await buildCloseMultiDelegate({
+      user: addressAsSigner(t.payerKeypair.address),
+      tokenMint: t.tokenMint,
+    });
+    await t.payer.sendInstructions(closeIxs);
+
+    await expectProgramError(
+      t.client.transferFixed({
+        delegatee: delegatee1,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda: fixedPda,
+        amount: 50_000n,
+        receiverAta: delegatee1Ata,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+    );
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee: delegatee2,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda: recurringPda,
+        amount: 50_000n,
+        receiverAta: delegatee2Ata,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+    );
+  });
+
+  test('expired fixed delegation transfer is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(ONE_HOUR_IN_SECONDS);
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs,
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    const { signature } = await t.client.transferFixed({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+
+    await t.timeTravel(Number(expiryTs) + 200);
+
+    await expectProgramError(
+      t.client.transferFixed({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__DELEGATION_EXPIRED,
+    );
+  });
+
+  test('expired recurring delegation transfer is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(ONE_HOUR_IN_SECONDS);
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amountPerPeriod: 100_000n,
+      periodLengthS: BigInt(ONE_HOUR_IN_SECONDS),
+      startTs: currentTs,
+      expiryTs,
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    const { signature } = await t.client.transferRecurring({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+
+    await t.timeTravel(Number(expiryTs) + 200);
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__DELEGATION_EXPIRED,
+    );
+  });
+
+  test('wrong signer rejected on fixed delegation', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const legitimateDelegatee = await t.createFundedKeypair();
+    const attacker = await t.createFundedKeypair();
+    const attackerAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      attacker.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: legitimateDelegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      legitimateDelegatee.address,
+      0n,
+    );
+
+    await expectProgramError(
+      t.client.transferFixed({
+        delegatee: attacker,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: attackerAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+
+    const legitimateAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      legitimateDelegatee.address,
+      0n,
+    );
+    const { signature } = await t.client.transferFixed({
+      delegatee: legitimateDelegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: legitimateAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('wrong signer rejected on recurring delegation', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const legitimateDelegatee = await t.createFundedKeypair();
+    const attacker = await t.createFundedKeypair();
+    const attackerAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      attacker.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: legitimateDelegatee.address,
+      nonce: 0n,
+      amountPerPeriod: 100_000n,
+      periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+      startTs: currentTs,
+      expiryTs: currentTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      legitimateDelegatee.address,
+      0n,
+    );
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee: attacker,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: attackerAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+
+    const legitimateAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      legitimateDelegatee.address,
+      0n,
+    );
+    const { signature } = await t.client.transferRecurring({
+      delegatee: legitimateDelegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: legitimateAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('skipped periods do not accumulate allowance', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    const periodS = BigInt(ONE_DAY_IN_SECONDS);
+    const amountPerPeriod = 100_000n;
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amountPerPeriod,
+      periodLengthS: periodS,
+      startTs: currentTs,
+      expiryTs: currentTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    await t.timeTravel(Number(currentTs) + ONE_DAY_IN_SECONDS * 3 + 60);
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: amountPerPeriod * 3n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__AMOUNT_EXCEEDS_PERIOD_LIMIT,
+    );
+
+    const { signature } = await t.client.transferRecurring({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: amountPerPeriod,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('exceed per-period limit is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    const amountPerPeriod = 100_000n;
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amountPerPeriod,
+      periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+      startTs: currentTs,
+      expiryTs: currentTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    await t.client.transferRecurring({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 60_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__AMOUNT_EXCEEDS_PERIOD_LIMIT,
+    );
+
+    const { signature } = await t.client.transferRecurring({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 40_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('transfer before recurring start time is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    const startTs = currentTs + BigInt(ONE_HOUR_IN_SECONDS);
+
+    await t.client.createRecurringDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amountPerPeriod: 100_000n,
+      periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+      startTs,
+      expiryTs: startTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    await expectProgramError(
+      t.client.transferRecurring({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__DELEGATION_NOT_STARTED,
+    );
+
+    await t.timeTravel(Number(startTs) + 60);
+
+    const { signature } = await t.client.transferRecurring({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('cross-type nonce collision: fixed then recurring same nonce', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    await expectProgramError(
+      t.client.createRecurringDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amountPerPeriod: 100_000n,
+        periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+        startTs: currentTs,
+        expiryTs: currentTs + BigInt(ONE_DAY_IN_SECONDS * 30),
+      }),
+      MULTI_DELEGATOR_ERROR__DELEGATION_ALREADY_EXISTS,
+    );
+  });
+
+  test('SPL token delegate revocation and recovery', async () => {
+    const t = await initTestSuite();
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const [multiDelegatePda] = await getMultiDelegatePDA(
+      subscriber.address,
+      t.tokenMint,
+    );
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: subscriber,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    const [delegationPda] = await getDelegationPDA(
+      multiDelegatePda,
+      subscriber.address,
+      delegatee.address,
+      0n,
+    );
+
+    const { getRevokeInstruction } = await import('@solana-program/token');
+    const revokeIx = getRevokeInstruction({
+      source: subscriberAta,
+      owner: subscriber,
+    });
+    await t.payer.sendInstructions([revokeIx]);
+
+    // Fails at SPL Token program level (not a multi-delegator error),
+    // so we assert the generic rejection rather than a specific program error code
+    await expect(
+      t.client.transferFixed({
+        delegatee,
+        delegator: subscriber.address,
+        delegatorAta: subscriberAta,
+        tokenMint: t.tokenMint,
+        delegationPda,
+        amount: 50_000n,
+        receiverAta: delegateeAta,
+        tokenProgram: t.tokenProgram,
+      }),
+    ).rejects.toThrow(/simulation failed/i);
+
+    const { getApproveInstruction } = await import('@solana-program/token');
+    const approveIx = getApproveInstruction({
+      source: subscriberAta,
+      delegate: multiDelegatePda,
+      owner: subscriber,
+      amount: BigInt('18446744073709551615'),
+    });
+    await t.payer.sendInstructions([approveIx]);
+
+    const { signature } = await t.client.transferFixed({
+      delegatee,
+      delegator: subscriber.address,
+      delegatorAta: subscriberAta,
+      tokenMint: t.tokenMint,
+      delegationPda,
+      amount: 50_000n,
+      receiverAta: delegateeAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('nonce collision is blocked', async () => {
+    const t = await initTestSuite();
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+
+    await expectProgramError(
+      t.client.createFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+      }),
+      MULTI_DELEGATOR_ERROR__DELEGATION_ALREADY_EXISTS,
+    );
+
+    const { signature } = await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 1n,
+      amount: 500_000n,
+      expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
+    });
+    expect(signature).toBeDefined();
+  });
+});

--- a/clients/typescript/test/multi-wallet-scenarios.test.ts
+++ b/clients/typescript/test/multi-wallet-scenarios.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, test } from 'vitest';
+import {
+  MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+  MULTI_DELEGATOR_ERROR__SUBSCRIPTION_CANCELLED,
+} from '../src/generated/errors/multiDelegator.ts';
+import { fetchSubscriptionDelegation } from '../src/generated/index.ts';
+import { getDelegationPDA, getMultiDelegatePDA } from '../src/pdas.ts';
+import {
+  DEFAULT_TEST_BALANCE,
+  expectProgramError,
+  initTestSuite,
+} from './setup.ts';
+
+describe('Multi-Wallet Scenarios', () => {
+  test('multi-subscriber isolation: cancel one does not affect others', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscribers = await Promise.all(
+      Array.from({ length: 3 }, () => t.createFundedKeypair()),
+    );
+    const subscriberAtas = await Promise.all(
+      subscribers.map((s) =>
+        t.createAtaWithBalance(t.tokenMint, s.address, DEFAULT_TEST_BALANCE),
+      ),
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await t.client.initMultiDelegate({
+        owner: subscribers[i],
+        tokenMint: t.tokenMint,
+        userAta: subscriberAtas[i],
+        tokenProgram: t.tokenProgram,
+      });
+    }
+
+    const subPdas: `${string}`[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { subscriptionPda } = await t.client.subscribe({
+        subscriber: subscribers[i],
+        merchant: t.payerKeypair.address,
+        planId: 1n,
+        tokenMint: t.tokenMint,
+      });
+      subPdas.push(subscriptionPda);
+    }
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscribers[0].address,
+      tokenMint: t.tokenMint,
+      subscriptionPda: subPdas[0],
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscribers[1].address,
+      tokenMint: t.tokenMint,
+      subscriptionPda: subPdas[1],
+      planPda,
+      amount: 150_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber: subscribers[2],
+      planPda,
+      subscriptionPda: subPdas[2],
+    });
+
+    const subC = (await fetchSubscriptionDelegation(t.rpc, subPdas[2])).data;
+    await t.timeTravel(Number(subC.expiresAtTs) + 60);
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscribers[2].address,
+        tokenMint: t.tokenMint,
+        subscriptionPda: subPdas[2],
+        planPda,
+        amount: 50_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__SUBSCRIPTION_CANCELLED,
+    );
+
+    const { signature: sigA } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscribers[0].address,
+      tokenMint: t.tokenMint,
+      subscriptionPda: subPdas[0],
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(sigA).toBeDefined();
+
+    const { signature: sigB } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscribers[1].address,
+      tokenMint: t.tokenMint,
+      subscriptionPda: subPdas[1],
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(sigB).toBeDefined();
+
+    // Time travel moved past C's grace period (~2 hours), advancing A and B
+    // into a new billing period. amountPulledInPeriod resets, so only the
+    // second charge (100k each) is reflected.
+    const subAData = (await fetchSubscriptionDelegation(t.rpc, subPdas[0]))
+      .data;
+    const subBData = (await fetchSubscriptionDelegation(t.rpc, subPdas[1]))
+      .data;
+    expect(subAData.amountPulledInPeriod).toBe(100_000n);
+    expect(subBData.amountPulledInPeriod).toBe(100_000n);
+    expect(subC.expiresAtTs).not.toBe(0n);
+  });
+
+  test('re-init defense: user kill-switch blocks merchant, then recovers', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    const { signature: chargeSig } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(chargeSig).toBeDefined();
+
+    await t.client.closeMultiDelegate({
+      user: subscriber,
+      tokenMint: t.tokenMint,
+    });
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 100_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const trustedDelegatee = await t.createFundedKeypair();
+    const trustedAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      trustedDelegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+    await t.client.createFixedDelegation({
+      delegator: subscriber,
+      tokenMint: t.tokenMint,
+      delegatee: trustedDelegatee.address,
+      nonce: 0n,
+      amount: 200_000n,
+      expiryTs: currentTs + 3600n,
+    });
+
+    const [mdPda] = await getMultiDelegatePDA(subscriber.address, t.tokenMint);
+    const [delegPda] = await getDelegationPDA(
+      mdPda,
+      subscriber.address,
+      trustedDelegatee.address,
+      0n,
+    );
+
+    const { signature: newTransferSig } = await t.client.transferFixed({
+      delegatee: trustedDelegatee,
+      delegator: subscriber.address,
+      delegatorAta: subscriberAta,
+      tokenMint: t.tokenMint,
+      delegationPda: delegPda,
+      amount: 50_000n,
+      receiverAta: trustedAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(newTransferSig).toBeDefined();
+  });
+
+  test('multi-mint kill-switch isolation', async () => {
+    const t = await initTestSuite();
+
+    const mintB = await t.createTokenMint(6);
+
+    const userAtaA = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    const userAtaB = await t.createAtaWithBalance(
+      mintB,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta: userAtaA,
+      tokenProgram: t.tokenProgram,
+    });
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: mintB,
+      userAta: userAtaB,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const delegateeAtaA = await t.createAtaWithBalance(
+      t.tokenMint,
+      delegatee.address,
+      0n,
+    );
+    const delegateeAtaB = await t.createAtaWithBalance(
+      mintB,
+      delegatee.address,
+      0n,
+    );
+
+    const currentTs = await t.getValidatorTime();
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + 3600n,
+    });
+
+    await t.client.createFixedDelegation({
+      delegator: t.payerKeypair,
+      tokenMint: mintB,
+      delegatee: delegatee.address,
+      nonce: 0n,
+      amount: 500_000n,
+      expiryTs: currentTs + 3600n,
+    });
+
+    const [mdPdaA] = await getMultiDelegatePDA(
+      t.payerKeypair.address,
+      t.tokenMint,
+    );
+    const [mdPdaB] = await getMultiDelegatePDA(t.payerKeypair.address, mintB);
+    const [delegPdaA] = await getDelegationPDA(
+      mdPdaA,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+    const [delegPdaB] = await getDelegationPDA(
+      mdPdaB,
+      t.payerKeypair.address,
+      delegatee.address,
+      0n,
+    );
+
+    await t.client.closeMultiDelegate({
+      user: t.payerKeypair,
+      tokenMint: t.tokenMint,
+    });
+
+    await expectProgramError(
+      t.client.transferFixed({
+        delegatee,
+        delegator: t.payerKeypair.address,
+        delegatorAta: userAtaA,
+        tokenMint: t.tokenMint,
+        delegationPda: delegPdaA,
+        amount: 50_000n,
+        receiverAta: delegateeAtaA,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__INVALID_MULTI_DELEGATE_PDA,
+    );
+
+    const { signature } = await t.client.transferFixed({
+      delegatee,
+      delegator: t.payerKeypair.address,
+      delegatorAta: userAtaB,
+      tokenMint: mintB,
+      delegationPda: delegPdaB,
+      amount: 50_000n,
+      receiverAta: delegateeAtaB,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+});

--- a/clients/typescript/test/setup.ts
+++ b/clients/typescript/test/setup.ts
@@ -20,7 +20,9 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
 } from 'gill';
+import { expect } from 'vitest';
 import { MultiDelegatorClient } from '../src/client.js';
+import { parseProgramError } from '../src/errors/map.js';
 import { KeyPairWallet, type Wallet } from '../src/wallet.js';
 import {
   createSmartWallets as createAdapterSmartWallets,
@@ -513,6 +515,47 @@ async function createAtaWithTokens(
   await client.sendAndConfirmTransaction(signedTransaction);
 
   return ata;
+}
+
+function extractErrorCode(error: unknown): number | null {
+  if (error == null) return null;
+  const pe = parseProgramError(error);
+  if (pe) return pe.errorCode;
+  // biome-ignore lint/suspicious/noExplicitAny: error introspection
+  const ctx = (error as any)?.context;
+  if (ctx?.code != null) return Number(ctx.code);
+  const msg = error instanceof Error ? error.message : String(error);
+  const m = /custom program error: #(\d+)/.exec(msg);
+  if (m?.[1]) return Number(m[1]);
+  if (error instanceof Error && error.cause) {
+    return extractErrorCode(error.cause);
+  }
+  return null;
+}
+
+export async function expectProgramError(
+  promise: Promise<unknown>,
+  expectedCode: number,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error(
+      `Expected program error 0x${expectedCode.toString(16)} but tx succeeded`,
+    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith('Expected program error')
+    ) {
+      throw error;
+    }
+    const code = extractErrorCode(error);
+    if (code != null) {
+      expect(code).toBe(expectedCode);
+      return;
+    }
+    throw error;
+  }
 }
 
 // ============================================================================

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from 'vitest';
+import { MULTI_DELEGATOR_ERROR__PLAN_TERMS_MISMATCH } from '../src/generated/errors/multiDelegator.ts';
 import {
   fetchMaybePlan,
   fetchMaybeSubscriptionDelegation,
   fetchSubscriptionDelegation,
   PlanStatus,
 } from '../src/generated/index.ts';
-import { DEFAULT_TEST_BALANCE, initTestSuite } from './setup.ts';
+import {
+  DEFAULT_TEST_BALANCE,
+  expectProgramError,
+  initTestSuite,
+} from './setup.ts';
 
 describe('Subscription Lifecycle', () => {
   test('full lifecycle: create, subscribe, pull, cancel, sunset, delete', async () => {
@@ -260,7 +265,7 @@ describe('Subscription Lifecycle', () => {
       0n,
     );
 
-    await expect(
+    await expectProgramError(
       t.client.transferSubscription({
         caller: t.payerKeypair,
         delegator: subscriber.address,
@@ -271,7 +276,8 @@ describe('Subscription Lifecycle', () => {
         receiverAta: merchantAta,
         tokenProgram: t.tokenProgram,
       }),
-    ).rejects.toThrow();
+      MULTI_DELEGATOR_ERROR__PLAN_TERMS_MISMATCH,
+    );
 
     // 6. Subscriber cancels (immediate expiry, no grace period)
     await t.client.cancelSubscription({

--- a/clients/typescript/test/subscription-security.test.ts
+++ b/clients/typescript/test/subscription-security.test.ts
@@ -1,0 +1,1213 @@
+import { describe, expect, test } from 'vitest';
+import {
+  MULTI_DELEGATOR_ERROR__ALREADY_SUBSCRIBED,
+  MULTI_DELEGATOR_ERROR__PLAN_CLOSED,
+  MULTI_DELEGATOR_ERROR__PLAN_EXPIRED,
+  MULTI_DELEGATOR_ERROR__PLAN_IMMUTABLE_AFTER_SUNSET,
+  MULTI_DELEGATOR_ERROR__PLAN_NOT_EXPIRED,
+  MULTI_DELEGATOR_ERROR__PLAN_SUNSET,
+  MULTI_DELEGATOR_ERROR__STALE_MULTI_DELEGATE,
+  MULTI_DELEGATOR_ERROR__SUBSCRIPTION_ALREADY_CANCELLED,
+  MULTI_DELEGATOR_ERROR__SUBSCRIPTION_CANCELLED,
+  MULTI_DELEGATOR_ERROR__SUBSCRIPTION_NOT_CANCELLED,
+  MULTI_DELEGATOR_ERROR__SUBSCRIPTION_PLAN_MISMATCH,
+  MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+  MULTI_DELEGATOR_ERROR__UNAUTHORIZED_DESTINATION,
+} from '../src/generated/errors/multiDelegator.ts';
+import {
+  fetchMaybePlan,
+  fetchMaybeSubscriptionDelegation,
+  fetchSubscriptionDelegation,
+  PlanStatus,
+} from '../src/generated/index.ts';
+import { buildCloseMultiDelegate } from '../src/instructions/delegation.ts';
+import { getMultiDelegatePDA, getPlanPDA } from '../src/pdas.ts';
+import { addressAsSigner } from '../src/wallet.ts';
+import {
+  DEFAULT_TEST_BALANCE,
+  expectProgramError,
+  initTestSuite,
+  ONE_HOUR_IN_SECONDS,
+} from './setup.ts';
+
+describe('Subscription Security', () => {
+  test('revoke blocked during grace period, allowed after expiry', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const subAfterCancel = (
+      await fetchSubscriptionDelegation(t.rpc, subscriptionPda)
+    ).data;
+    expect(subAfterCancel.expiresAtTs).not.toBe(0n);
+
+    await expectProgramError(
+      t.client.revokeDelegation({
+        authority: subscriber,
+        delegationAccount: subscriptionPda,
+      }),
+      MULTI_DELEGATOR_ERROR__SUBSCRIPTION_NOT_CANCELLED,
+    );
+
+    await t.timeTravel(Number(subAfterCancel.expiresAtTs) + 60);
+
+    const { signature } = await t.client.revokeDelegation({
+      authority: subscriber,
+      delegationAccount: subscriptionPda,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('unauthorized puller is rejected', async () => {
+    const t = await initTestSuite();
+    const authorizedPuller = await t.createFundedKeypair();
+    const attacker = await t.createFundedKeypair();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [authorizedPuller.address],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const attackerAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      attacker.address,
+      0n,
+    );
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: attacker,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 100_000n,
+        receiverAta: attackerAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+
+    const pullerAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      authorizedPuller.address,
+      0n,
+    );
+    const { signature: pullerSig } = await t.client.transferSubscription({
+      caller: authorizedPuller,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: pullerAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(pullerSig).toBeDefined();
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+    const { signature: merchantSig } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(merchantSig).toBeDefined();
+  });
+
+  test('destination whitelist is enforced', async () => {
+    const t = await initTestSuite();
+
+    const allowedReceiver = await t.createFundedKeypair();
+    const allowedAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      allowedReceiver.address,
+      0n,
+    );
+
+    const unauthorizedReceiver = await t.createFundedKeypair();
+    const unauthorizedAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      unauthorizedReceiver.address,
+      0n,
+    );
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [allowedReceiver.address],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 100_000n,
+        receiverAta: unauthorizedAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED_DESTINATION,
+    );
+
+    const { signature } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: allowedAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('double subscription is blocked', async () => {
+    const t = await initTestSuite();
+
+    await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await expectProgramError(
+      t.client.subscribe({
+        subscriber,
+        merchant: t.payerKeypair.address,
+        planId: 1n,
+        tokenMint: t.tokenMint,
+      }),
+      MULTI_DELEGATOR_ERROR__ALREADY_SUBSCRIBED,
+    );
+  });
+
+  test('sunset plan blocks new subscriptions', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Sunset,
+      endTs,
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await expectProgramError(
+      t.client.subscribe({
+        subscriber,
+        merchant: t.payerKeypair.address,
+        planId: 1n,
+        tokenMint: t.tokenMint,
+      }),
+      MULTI_DELEGATOR_ERROR__PLAN_SUNSET,
+    );
+  });
+
+  test('grace period honored then blocked after expiry', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 200_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const { signature: graceSig } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(graceSig).toBeDefined();
+
+    const subData = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda))
+      .data;
+    await t.timeTravel(Number(subData.expiresAtTs) + 60);
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 50_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__SUBSCRIPTION_CANCELLED,
+    );
+  });
+
+  test('double cancel is blocked', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    await expectProgramError(
+      t.client.cancelSubscription({
+        subscriber,
+        planPda,
+        subscriptionPda,
+      }),
+      MULTI_DELEGATOR_ERROR__SUBSCRIPTION_ALREADY_CANCELLED,
+    );
+  });
+
+  test('plan delete before expiry is blocked', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await expectProgramError(
+      t.client.deletePlan({
+        owner: t.payerKeypair,
+        planPda,
+      }),
+      MULTI_DELEGATOR_ERROR__PLAN_NOT_EXPIRED,
+    );
+
+    await t.timeTravel(Number(endTs) + 60);
+
+    const { signature } = await t.client.deletePlan({
+      owner: t.payerKeypair,
+      planPda,
+    });
+    expect(signature).toBeDefined();
+
+    const planAfter = await fetchMaybePlan(t.rpc, planPda);
+    expect(planAfter.exists).toBe(false);
+  });
+
+  test('plan update after sunset is blocked', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Sunset,
+      endTs,
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await expectProgramError(
+      t.client.updatePlan({
+        owner: t.payerKeypair,
+        planPda,
+        status: PlanStatus.Active,
+        endTs: 0n,
+        metadataUri: 'https://example.com/updated.json',
+      }),
+      MULTI_DELEGATOR_ERROR__PLAN_IMMUTABLE_AFTER_SUNSET,
+    );
+  });
+
+  test('subscribe, cancel, revoke, then re-subscribe', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const subData = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda))
+      .data;
+    await t.timeTravel(Number(subData.expiresAtTs) + 60);
+
+    await t.client.revokeDelegation({
+      authority: subscriber,
+      delegationAccount: subscriptionPda,
+    });
+
+    const subAfterRevoke = await fetchMaybeSubscriptionDelegation(
+      t.rpc,
+      subscriptionPda,
+    );
+    expect(subAfterRevoke.exists).toBe(false);
+
+    const { subscriptionPda: newSubPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const newSub = (await fetchSubscriptionDelegation(t.rpc, newSubPda)).data;
+    expect(newSub.amountPulledInPeriod).toBe(0n);
+    expect(newSub.expiresAtTs).toBe(0n);
+    expect(newSub.header.delegator).toBe(subscriber.address);
+  });
+
+  test('re-init + stale subscription transfer is blocked', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    await t.client.closeMultiDelegate({
+      user: subscriber,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 100_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__STALE_MULTI_DELEGATE,
+    );
+  });
+
+  test('cancel and revoke when plan is already deleted', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Sunset,
+      endTs,
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await t.timeTravel(Number(endTs) + 60);
+
+    await t.client.deletePlan({
+      owner: t.payerKeypair,
+      planPda,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const subAfterCancel = (
+      await fetchSubscriptionDelegation(t.rpc, subscriptionPda)
+    ).data;
+    expect(subAfterCancel.expiresAtTs).not.toBe(0n);
+
+    const { signature } = await t.client.revokeDelegation({
+      authority: subscriber,
+      delegationAccount: subscriptionPda,
+    });
+    expect(signature).toBeDefined();
+
+    const subAfterRevoke = await fetchMaybeSubscriptionDelegation(
+      t.rpc,
+      subscriptionPda,
+    );
+    expect(subAfterRevoke.exists).toBe(false);
+  });
+
+  test('re-subscribe before revoke is blocked', async () => {
+    const t = await initTestSuite();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    await expectProgramError(
+      t.client.subscribe({
+        subscriber,
+        merchant: t.payerKeypair.address,
+        planId: 1n,
+        tokenMint: t.tokenMint,
+      }),
+      MULTI_DELEGATOR_ERROR__ALREADY_SUBSCRIBED,
+    );
+  });
+
+  test('error precedence: PLAN_CLOSED when plan deleted and subscription cancelled', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Sunset,
+      endTs,
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    await t.timeTravel(Number(endTs) + 60);
+
+    await t.client.deletePlan({
+      owner: t.payerKeypair,
+      planPda,
+    });
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 50_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__PLAN_CLOSED,
+    );
+  });
+
+  test('dynamic puller removal blocks old puller', async () => {
+    const t = await initTestSuite();
+    const pullerA = await t.createFundedKeypair();
+    const pullerB = await t.createFundedKeypair();
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [pullerA.address],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const pullerAAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      pullerA.address,
+      0n,
+    );
+
+    const { signature: firstPull } = await t.client.transferSubscription({
+      caller: pullerA,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 50_000n,
+      receiverAta: pullerAAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(firstPull).toBeDefined();
+
+    await t.client.updatePlan({
+      owner: t.payerKeypair,
+      planPda,
+      status: PlanStatus.Active,
+      endTs: 0n,
+      metadataUri: 'https://example.com/plan.json',
+      pullers: [pullerB.address],
+    });
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: pullerA,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 50_000n,
+        receiverAta: pullerAAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+
+    const pullerBAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      pullerB.address,
+      0n,
+    );
+    const { signature: newPull } = await t.client.transferSubscription({
+      caller: pullerB,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 50_000n,
+      receiverAta: pullerBAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(newPull).toBeDefined();
+  });
+
+  test('cancel with wrong plan account fails', async () => {
+    const t = await initTestSuite();
+
+    const { planPda: planA } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours: 1n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/planA.json',
+    });
+
+    await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 2n,
+      mint: t.tokenMint,
+      amount: 100_000n,
+      periodHours: 24n,
+      endTs: 0n,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/planB.json',
+    });
+
+    const [planBPda] = await getPlanPDA(t.payerKeypair.address, 2n);
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await expectProgramError(
+      t.client.cancelSubscription({
+        subscriber,
+        planPda: planBPda,
+        subscriptionPda,
+      }),
+      MULTI_DELEGATOR_ERROR__SUBSCRIPTION_PLAN_MISMATCH,
+    );
+
+    const { signature } = await t.client.cancelSubscription({
+      subscriber,
+      planPda: planA,
+      subscriptionPda,
+    });
+    expect(signature).toBeDefined();
+  });
+
+  test('plan end_ts expiry blocks subscription transfer', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    const merchantAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      0n,
+    );
+
+    const { signature } = await t.client.transferSubscription({
+      caller: t.payerKeypair,
+      delegator: subscriber.address,
+      tokenMint: t.tokenMint,
+      subscriptionPda,
+      planPda,
+      amount: 100_000n,
+      receiverAta: merchantAta,
+      tokenProgram: t.tokenProgram,
+    });
+    expect(signature).toBeDefined();
+
+    await t.timeTravel(Number(endTs) + 60);
+
+    await expectProgramError(
+      t.client.transferSubscription({
+        caller: t.payerKeypair,
+        delegator: subscriber.address,
+        tokenMint: t.tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 50_000n,
+        receiverAta: merchantAta,
+        tokenProgram: t.tokenProgram,
+      }),
+      MULTI_DELEGATOR_ERROR__PLAN_EXPIRED,
+    );
+  });
+
+  test('cancel on expired plan caps expires_at_ts, enabling immediate revoke', async () => {
+    const t = await initTestSuite();
+    const periodHours = 1n;
+    const endTs = await t.minPlanEndTs(periodHours);
+
+    const { planPda } = await t.client.createPlan({
+      owner: t.payerKeypair,
+      planId: 1n,
+      mint: t.tokenMint,
+      amount: 500_000n,
+      periodHours,
+      endTs,
+      destinations: [],
+      pullers: [],
+      metadataUri: 'https://example.com/plan.json',
+    });
+
+    const subscriber = await t.createFundedKeypair();
+    const subscriberAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      subscriber.address,
+      DEFAULT_TEST_BALANCE,
+    );
+    await t.client.initMultiDelegate({
+      owner: subscriber,
+      tokenMint: t.tokenMint,
+      userAta: subscriberAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const { subscriptionPda } = await t.client.subscribe({
+      subscriber,
+      merchant: t.payerKeypair.address,
+      planId: 1n,
+      tokenMint: t.tokenMint,
+    });
+
+    await t.timeTravel(Number(endTs) + 120);
+
+    await t.client.cancelSubscription({
+      subscriber,
+      planPda,
+      subscriptionPda,
+    });
+
+    const subData = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda))
+      .data;
+    expect(subData.expiresAtTs).toBeLessThanOrEqual(endTs);
+
+    const { signature } = await t.client.revokeDelegation({
+      authority: subscriber,
+      delegationAccount: subscriptionPda,
+    });
+    expect(signature).toBeDefined();
+
+    const subAfterRevoke = await fetchMaybeSubscriptionDelegation(
+      t.rpc,
+      subscriptionPda,
+    );
+    expect(subAfterRevoke.exists).toBe(false);
+  });
+});


### PR DESCRIPTION
 ## New tests

  ### delegation-security.test.ts (12 tests)
  - Stale delegation after MultiDelegate re-init (`STALE_MULTI_DELEGATE`)
  - Close MultiDelegate kills all fixed + recurring transfers (`INVALID_MULTI_DELEGATE_PDA`)
  - Expired fixed/recurring delegation transfer blocked (`DELEGATION_EXPIRED`)
  - Wrong signer rejected on fixed/recurring (`UNAUTHORIZED`)
  - Skipped periods don't accumulate recurring allowance (`AMOUNT_EXCEEDS_PERIOD_LIMIT`)
  - Exceed per-period limit within single period
  - Transfer before recurring start time (`DELEGATION_NOT_STARTED`)
  - Cross-type nonce collision: fixed then recurring same nonce (`DELEGATION_ALREADY_EXISTS`)
  - SPL token delegate external revocation and recovery
  - Same-type nonce collision

  ### subscription-security.test.ts (18 tests)
  - Revoke blocked during grace period, allowed after expiry (`SUBSCRIPTION_NOT_CANCELLED`)
  - Unauthorized puller rejected, authorized puller + merchant succeed (`UNAUTHORIZED`)
  - Destination whitelist enforcement (`UNAUTHORIZED_DESTINATION`)
  - Double subscription blocked (`ALREADY_SUBSCRIBED`)
  - Sunset blocks new subscriptions (`PLAN_SUNSET`)
  - Grace period honored then blocked after expiry (`SUBSCRIPTION_CANCELLED`)
  - Double cancel blocked (`SUBSCRIPTION_ALREADY_CANCELLED`)
  - Plan delete before expiry blocked (`PLAN_NOT_EXPIRED`)
  - Plan update after sunset blocked (`PLAN_IMMUTABLE_AFTER_SUNSET`)
  - Subscribe, cancel, revoke, re-subscribe full cycle
  - Re-init + stale subscription transfer (`STALE_MULTI_DELEGATE`)
  - Cancel/revoke when plan already deleted (immediate expiry path)
  - Re-subscribe before revoke blocked (`ALREADY_SUBSCRIBED`)
  - Error precedence: `PLAN_CLOSED` wins over `SUBSCRIPTION_CANCELLED`
  - Dynamic puller removal blocks old puller
  - Cancel with wrong plan account (`SUBSCRIPTION_PLAN_MISMATCH`)
  - Plan end_ts expiry blocks subscription transfer (`PLAN_EXPIRED`)
  - Cancel on expired plan caps expires_at_ts for immediate revoke

  ### multi-wallet-scenarios.test.ts (3 tests)
  - Multi-subscriber isolation: cancel one doesn't affect others
  - Re-init defense: user kill-switch blocks merchant, user recovers
  - Multi-mint kill-switch isolation: closing mint A doesn't affect mint B