### PR TITLE
[audit] feat: Allow sponsor to revoke expired delegation accounts

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -145,10 +145,11 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Revoke (close) a delegation account, returning rent to the delegator. */
+  /** Revoke (close) a delegation account, returning rent to the original payer. */
   async revokeDelegation(params: {
     authority: TransactionSigner;
     delegationAccount: Address;
+    receiver?: Address;
   }): Promise<TransactionResult> {
     const { instructions } = buildRevokeDelegation(params);
     const signature = await this.buildAndSendTransaction(

--- a/clients/typescript/src/instructions/delegation.ts
+++ b/clients/typescript/src/instructions/delegation.ts
@@ -1,4 +1,9 @@
-import type { Address, Instruction, TransactionSigner } from 'gill';
+import {
+  AccountRole,
+  type Address,
+  type Instruction,
+  type TransactionSigner,
+} from 'gill';
 import { ValidationError } from '../errors/types.js';
 import {
   getCloseMultiDelegateInstruction,
@@ -66,6 +71,7 @@ export async function buildCreateFixedDelegation(params: {
   nonce: number | bigint;
   amount: number | bigint;
   expiryTs: number | bigint;
+  payer?: TransactionSigner;
   programAddress?: Address;
 }): Promise<{ instructions: Instruction[]; delegationPda: Address }> {
   const {
@@ -75,6 +81,7 @@ export async function buildCreateFixedDelegation(params: {
     nonce,
     amount,
     expiryTs,
+    payer,
     programAddress,
   } = params;
   const config = programAddress ? { programAddress } : undefined;
@@ -106,6 +113,21 @@ export async function buildCreateFixedDelegation(params: {
     config,
   );
 
+  if (payer) {
+    const accounts = [
+      ...instruction.accounts,
+      {
+        address: payer.address,
+        role: AccountRole.WRITABLE_SIGNER,
+        signer: payer,
+      },
+    ];
+    return {
+      instructions: [{ ...instruction, accounts }],
+      delegationPda,
+    };
+  }
+
   return { instructions: [instruction], delegationPda };
 }
 
@@ -132,6 +154,7 @@ export async function buildCreateRecurringDelegation(params: {
   periodLengthS: number | bigint;
   startTs: number | bigint;
   expiryTs: number | bigint;
+  payer?: TransactionSigner;
   programAddress?: Address;
 }): Promise<{ instructions: Instruction[]; delegationPda: Address }> {
   const {
@@ -143,6 +166,7 @@ export async function buildCreateRecurringDelegation(params: {
     periodLengthS,
     startTs,
     expiryTs,
+    payer,
     programAddress,
   } = params;
   const config = programAddress ? { programAddress } : undefined;
@@ -182,19 +206,36 @@ export async function buildCreateRecurringDelegation(params: {
     config,
   );
 
+  if (payer) {
+    const accounts = [
+      ...instruction.accounts,
+      {
+        address: payer.address,
+        role: AccountRole.WRITABLE_SIGNER,
+        signer: payer,
+      },
+    ];
+    return {
+      instructions: [{ ...instruction, accounts }],
+      delegationPda,
+    };
+  }
+
   return { instructions: [instruction], delegationPda };
 }
 
 /**
  * Builds a `revokeDelegation` instruction that permanently closes a delegation account.
  *
- * @param params.authority - The delegator or delegatee authorized to revoke.
+ * @param params.authority - The delegator or sponsor authorized to revoke.
  * @param params.delegationAccount - Address of the delegation PDA to revoke.
+ * @param params.receiver - Rent destination when payer differs from authority (e.g., delegator revoking a sponsor-funded delegation).
  * @returns The instruction array.
  */
 export function buildRevokeDelegation(params: {
   authority: TransactionSigner;
   delegationAccount: Address;
+  receiver?: Address;
   programAddress?: Address;
 }): { instructions: Instruction[] } {
   const config = params.programAddress
@@ -207,6 +248,15 @@ export function buildRevokeDelegation(params: {
     },
     config,
   );
+
+  if (params.receiver) {
+    const accounts = [
+      ...instruction.accounts,
+      { address: params.receiver, role: AccountRole.WRITABLE },
+    ];
+    return { instructions: [{ ...instruction, accounts }] };
+  }
+
   return { instructions: [instruction] };
 }
 

--- a/clients/typescript/test/delegation-security.test.ts
+++ b/clients/typescript/test/delegation-security.test.ts
@@ -8,7 +8,12 @@ import {
   MULTI_DELEGATOR_ERROR__STALE_MULTI_DELEGATE,
   MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
 } from '../src/generated/errors/multiDelegator.ts';
-import { buildCloseMultiDelegate } from '../src/instructions/delegation.ts';
+import {
+  buildCloseMultiDelegate,
+  buildCreateFixedDelegation,
+  buildCreateRecurringDelegation,
+  buildRevokeDelegation,
+} from '../src/instructions/delegation.ts';
 import { getDelegationPDA, getMultiDelegatePDA } from '../src/pdas.ts';
 import { addressAsSigner } from '../src/wallet.ts';
 import {
@@ -992,5 +997,281 @@ describe('Delegation Security', () => {
       expiryTs: currentTs + BigInt(ONE_HOUR_IN_SECONDS),
     });
     expect(signature).toBeDefined();
+  });
+});
+
+describe('Sponsor Revoke', () => {
+  test('sponsor can revoke expired fixed delegation', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+    const sponsorWallet = await t.createFundedWallet(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(ONE_HOUR_IN_SECONDS);
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    await t.timeTravel(Number(expiryTs) + 200);
+
+    const { instructions: revokeIxs } = buildRevokeDelegation({
+      authority: sponsor,
+      delegationAccount: delegationPda,
+    });
+    await sponsorWallet.sendInstructions(revokeIxs);
+
+    const { fetchMaybeFixedDelegation } = await import(
+      '../src/generated/index.ts'
+    );
+    const account = await fetchMaybeFixedDelegation(t.rpc, delegationPda);
+    expect(account.exists).toBe(false);
+  });
+
+  test('sponsor can revoke expired recurring delegation', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+    const sponsorWallet = await t.createFundedWallet(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(2 * ONE_DAY_IN_SECONDS);
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateRecurringDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amountPerPeriod: 100_000n,
+        periodLengthS: BigInt(ONE_DAY_IN_SECONDS),
+        startTs: currentTs,
+        expiryTs,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    await t.timeTravel(Number(expiryTs) + 200);
+
+    const { instructions: revokeIxs } = buildRevokeDelegation({
+      authority: sponsor,
+      delegationAccount: delegationPda,
+    });
+    await sponsorWallet.sendInstructions(revokeIxs);
+
+    const { fetchMaybeRecurringDelegation } = await import(
+      '../src/generated/index.ts'
+    );
+    const account = await fetchMaybeRecurringDelegation(t.rpc, delegationPda);
+    expect(account.exists).toBe(false);
+  });
+
+  test('sponsor cannot revoke non-expired delegation', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(2 * ONE_HOUR_IN_SECONDS);
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    await expectProgramError(
+      t.client.revokeDelegation({
+        authority: sponsor,
+        delegationAccount: delegationPda,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+  });
+
+  test('sponsor cannot revoke delegation with no expiry', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs: 0n,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    await expectProgramError(
+      t.client.revokeDelegation({
+        authority: sponsor,
+        delegationAccount: delegationPda,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
+  });
+
+  test('delegator can revoke sponsor-funded delegation before expiry', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(2 * ONE_HOUR_IN_SECONDS);
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    const { instructions: revokeIxs } = buildRevokeDelegation({
+      authority: t.payerKeypair,
+      delegationAccount: delegationPda,
+      receiver: sponsor.address,
+    });
+    await t.payer.sendInstructions(revokeIxs);
+
+    const { fetchMaybeFixedDelegation } = await import(
+      '../src/generated/index.ts'
+    );
+    const account = await fetchMaybeFixedDelegation(t.rpc, delegationPda);
+    expect(account.exists).toBe(false);
+  });
+
+  test('random account cannot revoke delegation', async () => {
+    const t = await initTestSuite();
+    const sponsor = await t.createFundedKeypair(5_000_000_000n);
+    const attacker = await t.createFundedKeypair(5_000_000_000n);
+
+    const userAta = await t.createAtaWithBalance(
+      t.tokenMint,
+      t.payerKeypair.address,
+      DEFAULT_TEST_BALANCE,
+    );
+
+    await t.client.initMultiDelegate({
+      owner: t.payerKeypair,
+      tokenMint: t.tokenMint,
+      userAta,
+      tokenProgram: t.tokenProgram,
+    });
+
+    const delegatee = await t.createFundedKeypair();
+    const currentTs = await t.getValidatorTime();
+    const expiryTs = currentTs + BigInt(ONE_HOUR_IN_SECONDS);
+
+    const { instructions: createIxs, delegationPda } =
+      await buildCreateFixedDelegation({
+        delegator: t.payerKeypair,
+        tokenMint: t.tokenMint,
+        delegatee: delegatee.address,
+        nonce: 0n,
+        amount: 500_000n,
+        expiryTs,
+        payer: sponsor,
+      });
+    await t.payer.sendInstructions(createIxs);
+
+    await t.timeTravel(Number(expiryTs) + 200);
+
+    await expectProgramError(
+      t.client.revokeDelegation({
+        authority: attacker,
+        delegationAccount: delegationPda,
+      }),
+      MULTI_DELEGATOR_ERROR__UNAUTHORIZED,
+    );
   });
 });

--- a/docs/001-multi-delegator-architecture.md
+++ b/docs/001-multi-delegator-architecture.md
@@ -125,7 +125,7 @@ sequenceDiagram
     end
 ```
 
-### Revocation: Alice Closes Delegation
+### Revocation: Closing a Delegation
 
 ```mermaid
 sequenceDiagram
@@ -133,19 +133,16 @@ sequenceDiagram
     participant P as Program
     participant S as Sponsor (if payer != delegator)
 
-    Note over A,S: Only delegator can revoke,<br/>rent returns to original payer
-
-    A->>P: revoke_delegation(delegation_pda[, sponsor])
-    Note over P: Validate Alice is delegator
-
-    alt Alice is the payer
-        P->>P: Close delegation PDA
-        P->>A: Rent returned to Alice
-    else Sponsor paid for delegation
-        P->>P: Close delegation PDA
-        P->>S: Rent returned to sponsor
+    alt Delegator revokes (any time)
+        A->>P: revoke_delegation(delegation_pda[, sponsor_receiver])
+        P->>P: Close PDA, rent to original payer
+    else Sponsor revokes (only after expiry)
+        S->>P: revoke_delegation(delegation_pda)
+        P->>P: Close PDA, rent to sponsor
     end
 ```
+
+> **Note:** Sponsors of delegations with `expiry_ts == 0` (no expiry) cannot independently reclaim rent.
 
 ---
 
@@ -183,7 +180,7 @@ getProgramAccounts(PROGRAM_ID, {
 | ----------------------------- | --------- | ----------------------------------------------------------------------------------- |
 | `create_fixed_delegation`     | Delegator | Create one-time delegation with nonce, amount, and expiry (payer can be sponsor)     |
 | `create_recurring_delegation` | Delegator | Create recurring delegation with period limits (payer can be sponsor)              |
-| `revoke_delegation`           | Delegator | Close a delegation account and return rent to the original payer (delegator/sponsor) |
+| `revoke_delegation`           | Delegator / Sponsor | Close a delegation account and return rent to the original payer. Sponsor can only revoke after expiry. |
 
 ### Transfer
 
@@ -401,16 +398,14 @@ Revokes a delegation by closing the delegation PDA and returning rent to the ori
 
 | Account | Type     | Description                                                                 |
 | ------- | -------- | --------------------------------------------------------------------------- |
-| 0       | signer, writable | The delegator (authority)                                        |
+| 0       | signer, writable | The delegator or sponsor (authority)                             |
 | 1       | writable | Delegation PDA to close                                                    |
-| 2       | writable | Receiver account (required only if payer != delegator)                     |
+| 2       | writable | Receiver account (required only when delegator revokes a sponsor-funded delegation) |
 
 **Process:**
 
-1. Validate that the signer matches the `delegator` field in the delegation header
-2. Determine rent destination: if payer == delegator, use delegator account; otherwise, use provided receiver account
-3. Close the delegation account
-4. Transfer rent lamports back to the original payer (delegator or sponsor)
+1. Authorize caller: must be the `delegator` or the `payer` (sponsor). Sponsor requires `expiry_ts != 0 && expiry_ts < current_ts`.
+2. Close the delegation account and return rent to the original payer.
 
 ### `close_multidelegate` (Discriminator: 6)
 

--- a/programs/multi_delegator/src/instructions/revoke_delegation.rs
+++ b/programs/multi_delegator/src/instructions/revoke_delegation.rs
@@ -6,7 +6,10 @@ use pinocchio::{
 
 use crate::{
     check_and_update_version,
-    state::{common::AccountDiscriminator, subscription_delegation::SubscriptionDelegation},
+    state::{
+        common::AccountDiscriminator, fixed_delegation::FixedDelegation,
+        recurring_delegation::RecurringDelegation, subscription_delegation::SubscriptionDelegation,
+    },
     AccountCheck, AccountClose, Header, MultiDelegatorError, ProgramAccount, SignerAccount,
     WritableAccount, DELEGATEE_OFFSET, DELEGATOR_OFFSET, DISCRIMINATOR_OFFSET, PAYER_OFFSET,
 };
@@ -49,57 +52,94 @@ pub const DISCRIMINATOR: &u8 = &3;
 /// Revokes a delegation by closing the delegation PDA.
 /// The rent lamports are returned to the original payer.
 ///
-/// For Fixed/Recurring delegations: closes immediately.
+/// For Fixed/Recurring delegations: the delegator can close at any time;
+/// a third-party sponsor (original payer) can close only after expiry.
 /// For Subscriptions: requires cancellation first (expires_at_ts != 0) and expiration in the past.
 pub fn process(accounts: &[AccountView]) -> ProgramResult {
     let accounts = RevokeDelegationAccounts::try_from(accounts)?;
 
-    let mut data = accounts.delegation_account.try_borrow_mut()?;
+    let destination = {
+        let mut data = accounts.delegation_account.try_borrow_mut()?;
 
-    if data.len() < Header::LEN {
-        return Err(MultiDelegatorError::InvalidHeaderData.into());
-    }
-
-    let kind = data[DISCRIMINATOR_OFFSET];
-
-    // For subscriptions, validate cancellation before closing
-    if kind == AccountDiscriminator::SubscriptionDelegation as u8 {
-        check_and_update_version(&mut data)?;
-        let subscription = SubscriptionDelegation::load_with_min_size(&data)?;
-
-        if subscription.header.delegator != *accounts.authority.address() {
-            return Err(MultiDelegatorError::Unauthorized.into());
+        if data.len() < Header::LEN {
+            return Err(MultiDelegatorError::InvalidHeaderData.into());
         }
 
-        // Subscription must be cancelled (expires_at_ts != 0) and expired
-        let current_ts = Clock::get()?.unix_timestamp;
-        if subscription.expires_at_ts == 0 || subscription.expires_at_ts > current_ts {
-            return Err(MultiDelegatorError::SubscriptionNotCancelled.into());
-        }
-    } else if kind != AccountDiscriminator::FixedDelegation as u8
-        && kind != AccountDiscriminator::RecurringDelegation as u8
-    {
-        return Err(MultiDelegatorError::InvalidAccountDiscriminator.into());
-    }
+        let kind = AccountDiscriminator::try_from(data[DISCRIMINATOR_OFFSET])?;
 
-    let destination = resolve_destination(&data, &accounts)?;
-    drop(data);
+        match kind {
+            AccountDiscriminator::SubscriptionDelegation => {
+                check_and_update_version(&mut data)?;
+                let subscription = SubscriptionDelegation::load_with_min_size(&data)?;
+
+                if subscription.header.delegator != *accounts.authority.address() {
+                    return Err(MultiDelegatorError::Unauthorized.into());
+                }
+
+                // Subscription must be cancelled (expires_at_ts != 0) and expired
+                let current_ts = Clock::get()?.unix_timestamp;
+                if subscription.expires_at_ts == 0 || subscription.expires_at_ts > current_ts {
+                    return Err(MultiDelegatorError::SubscriptionNotCancelled.into());
+                }
+            }
+            AccountDiscriminator::FixedDelegation | AccountDiscriminator::RecurringDelegation => {
+                let is_sponsor = check_is_sponsor(&data, accounts.authority)?;
+
+                // Sponsor can only revoke expired delegations
+                if is_sponsor {
+                    let expiry_ts = match kind {
+                        AccountDiscriminator::FixedDelegation => {
+                            FixedDelegation::load_with_min_size(&data)?.expiry_ts
+                        }
+                        _ => RecurringDelegation::load_with_min_size(&data)?.expiry_ts,
+                    };
+                    if expiry_ts == 0 {
+                        return Err(MultiDelegatorError::Unauthorized.into());
+                    }
+                    let current_ts = Clock::get()?.unix_timestamp;
+                    if expiry_ts > current_ts {
+                        return Err(MultiDelegatorError::Unauthorized.into());
+                    }
+                }
+            }
+            _ => return Err(MultiDelegatorError::InvalidAccountDiscriminator.into()),
+        }
+
+        resolve_destination(&data, &accounts)?
+    };
 
     ProgramAccount::close(accounts.delegation_account, destination)
 }
 
+/// Checks whether the caller is the sponsor (payer) rather than the delegator.
+/// Returns `Unauthorized` if the caller is neither.
+fn check_is_sponsor(data: &[u8], authority: &AccountView) -> Result<bool, ProgramError> {
+    let delegator_bytes: &[u8; 32] = data[DELEGATOR_OFFSET..DELEGATEE_OFFSET]
+        .try_into()
+        .map_err(|_| MultiDelegatorError::InvalidHeaderData)?;
+
+    if delegator_bytes == authority.address().as_ref() {
+        return Ok(false);
+    }
+
+    let payer_bytes: &[u8; 32] = data[PAYER_OFFSET..PAYER_OFFSET + 32]
+        .try_into()
+        .map_err(|_| MultiDelegatorError::InvalidPayerData)?;
+
+    if payer_bytes == authority.address().as_ref() {
+        return Ok(true);
+    }
+
+    Err(MultiDelegatorError::Unauthorized.into())
+}
+
 /// Resolves the rent destination from the payer field in the header.
+/// Rent always goes back to the original payer: if payer == authority, return
+/// authority directly; otherwise require a receiver account matching payer.
 fn resolve_destination<'a>(
     data: &[u8],
     accounts: &RevokeDelegationAccounts<'a>,
 ) -> Result<&'a AccountView, ProgramError> {
-    let delegator_bytes: &[u8; 32] = data[DELEGATOR_OFFSET..DELEGATEE_OFFSET]
-        .try_into()
-        .map_err(|_| MultiDelegatorError::InvalidHeaderData)?;
-    if delegator_bytes != accounts.authority.address().as_ref() {
-        return Err(MultiDelegatorError::Unauthorized.into());
-    }
-
     let payer_bytes: &[u8; 32] = data[PAYER_OFFSET..PAYER_OFFSET + 32]
         .try_into()
         .map_err(|_| MultiDelegatorError::InvalidPayerData)?;
@@ -666,6 +706,303 @@ mod tests {
         RevokeSubscription::new(&mut litesvm, &alice, subscription_pda)
             .execute()
             .assert_err(MultiDelegatorError::MigrationRequired);
+    }
+
+    #[test]
+    fn sponsor_can_revoke_expired_fixed_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + hours(1) as i64;
+
+        let (res, delegation_pda) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .fixed(100, expiry_ts);
+        res.assert_ok();
+
+        let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
+
+        move_clock_forward(litesvm, hours(2));
+
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&sponsor)
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&delegation_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + delegation_rent - 10000);
+    }
+
+    #[test]
+    fn sponsor_can_revoke_expired_recurring_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + days(2) as i64;
+
+        let (res, delegation_pda) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .recurring(100, days(1), current_ts(), expiry_ts);
+        res.assert_ok();
+
+        let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
+
+        move_clock_forward(litesvm, days(3));
+
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&sponsor)
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&delegation_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + delegation_rent - 10000);
+    }
+
+    #[test]
+    fn sponsor_cannot_revoke_non_expired_fixed_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + hours(2) as i64;
+
+        let (res, _) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .fixed(100, expiry_ts);
+        res.assert_ok();
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&sponsor)
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn sponsor_cannot_revoke_non_expired_recurring_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + days(2) as i64;
+
+        let (res, _) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .recurring(100, days(1), current_ts(), expiry_ts);
+        res.assert_ok();
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&sponsor)
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn sponsor_cannot_revoke_no_expiry_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+
+        let (res, _) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .fixed(100, 0);
+        res.assert_ok();
+
+        move_clock_forward(litesvm, days(365));
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&sponsor)
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn delegator_can_revoke_sponsor_funded_before_expiry() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + hours(2) as i64;
+
+        let (res, delegation_pda) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .fixed(100, expiry_ts);
+        res.assert_ok();
+
+        let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .receiver(sponsor.pubkey())
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&delegation_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + delegation_rent - 10000);
+    }
+
+    #[test]
+    fn attacker_cannot_revoke_sponsor_funded_delegation() {
+        let (litesvm, user) = &mut setup();
+        let delegator = user;
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+        let attacker = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(delegator.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, delegator.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action(litesvm, delegator, mint)
+            .0
+            .assert_ok();
+
+        let delegatee = Pubkey::new_unique();
+        let nonce: u64 = 0;
+        let expiry_ts = current_ts() + hours(1) as i64;
+
+        let (res, _) = CreateDelegation::new(litesvm, delegator, mint, delegatee)
+            .payer(&sponsor)
+            .nonce(nonce)
+            .fixed(100, expiry_ts);
+        res.assert_ok();
+
+        move_clock_forward(litesvm, hours(2));
+
+        // Attacker passes sponsor as receiver to try to close the account
+        RevokeDelegation::new(litesvm, delegator, mint, delegatee, nonce)
+            .signer(&attacker)
+            .receiver(sponsor.pubkey())
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
     }
 
     #[allow(clippy::result_large_err)]

--- a/programs/multi_delegator/src/tests/utils.rs
+++ b/programs/multi_delegator/src/tests/utils.rs
@@ -507,6 +507,7 @@ impl<'a> TransferDelegation<'a> {
 pub struct RevokeDelegation<'a> {
     litesvm: &'a mut LiteSVM,
     delegator: &'a Keypair,
+    signer: Option<&'a Keypair>,
     mint: Pubkey,
     delegatee: Pubkey,
     nonce: u64,
@@ -525,12 +526,18 @@ impl<'a> RevokeDelegation<'a> {
         Self {
             litesvm,
             delegator,
+            signer: None,
             mint,
             delegatee,
             nonce,
             receiver: None,
             custom_pda: None,
         }
+    }
+
+    pub fn signer(mut self, signer: &'a Keypair) -> Self {
+        self.signer = Some(signer);
+        self
     }
 
     pub fn receiver(mut self, receiver: Pubkey) -> Self {
@@ -554,8 +561,10 @@ impl<'a> RevokeDelegation<'a> {
         );
         let delegation_pda = self.custom_pda.unwrap_or(derived_pda);
 
+        let authority = self.signer.unwrap_or(self.delegator);
+
         let mut accounts = vec![
-            AccountMeta::new(self.delegator.pubkey(), true),
+            AccountMeta::new(authority.pubkey(), true),
             AccountMeta::new(delegation_pda, false),
         ];
 
@@ -569,12 +578,7 @@ impl<'a> RevokeDelegation<'a> {
             data: vec![*revoke_delegation::DISCRIMINATOR],
         };
 
-        build_and_send_transaction(
-            self.litesvm,
-            &[self.delegator],
-            &self.delegator.pubkey(),
-            &ix,
-        )
+        build_and_send_transaction(self.litesvm, &[authority], &authority.pubkey(), &ix)
     }
 }
 


### PR DESCRIPTION
Closes audit issue 4

- Sponsor can call `revoke_delegation` when `expiry_ts != 0 && expiry_ts < current_ts`
- Applies to `Fixed` and `Recurring` delegations only
- Update docs
- Add integration tests