### PR TITLE
docs: fix and update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ apps/web/test-results/
 # TypeScript incremental build cache
 apps/web/tsconfig.tsbuildinfo
 
+# TypeDoc generated API docs
+clients/typescript/docs/
+
 # Vercel project config
 .vercel
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -45,18 +45,23 @@ const client = new MultiDelegatorClient(solanaClient);
 // - delegatee: Address
 
 // 1) Initialize the MultiDelegate account for (owner, tokenMint)
-const initResult = await client.initMultiDelegate(owner, tokenMint, userAta);
+const initResult = await client.initMultiDelegate({
+  owner,
+  tokenMint,
+  userAta,
+  tokenProgram,
+});
 console.log(initResult.signature);
 
 // 2) Create a fixed delegation
-const fixedResult = await client.createFixedDelegation(
-  owner,
+const fixedResult = await client.createFixedDelegation({
+  delegator: owner,
   tokenMint,
   delegatee,
-  0n, // nonce
-  1_000_000n, // amount
-  BigInt(Math.floor(Date.now() / 1000) + 3600), // expiryTs
-);
+  nonce: 0n,
+  amount: 1_000_000n,
+  expiryTs: BigInt(Math.floor(Date.now() / 1000) + 3600),
+});
 console.log(fixedResult.signature);
 
 // 3) Derive delegation PDA (used by transfer/revoke flows)
@@ -80,69 +85,158 @@ Creates a client using an object compatible with Gill's `createSolanaClient(...)
 - `client.rpc`
 - `client.sendAndConfirmTransaction(...)`
 
-#### `initMultiDelegate(owner, tokenMint, userAta, tokenProgram?)`
+#### `initMultiDelegate(params)`
 Initializes the per-`(user, mint)` MultiDelegate PDA and configures token delegation.
 
-- `owner`: `TransactionSigner`
-- `tokenMint`: `Address`
-- `userAta`: `Address`
-- `tokenProgram?`: `Address`
+- `params.owner`: `TransactionSigner`
+- `params.tokenMint`: `Address`
+- `params.userAta`: `Address`
+- `params.tokenProgram`: `Address`
 - Returns: `Promise<{ signature: string }>`
 
-#### `createFixedDelegation(delegator, tokenMint, delegatee, nonce, amount, expiryTs)`
+#### `closeMultiDelegate(params)`
+Closes the MultiDelegate PDA, returning rent to the user. Invalidates all existing delegations on re-initialization (emergency kill switch).
+
+- `params.user`: `TransactionSigner`
+- `params.tokenMint`: `Address`
+- Returns: `Promise<{ signature: string }>`
+
+#### `createFixedDelegation(params)`
 Creates a fixed delegation.
 
-- `delegator`: `TransactionSigner`
-- `tokenMint`: `Address`
-- `delegatee`: `Address`
-- `nonce`: `number | bigint`
-- `amount`: `number | bigint`
-- `expiryTs`: `number | bigint`
+- `params.delegator`: `TransactionSigner`
+- `params.tokenMint`: `Address`
+- `params.delegatee`: `Address`
+- `params.nonce`: `number | bigint`
+- `params.amount`: `number | bigint`
+- `params.expiryTs`: `number | bigint`
 - Returns: `Promise<{ signature: string }>`
 
-#### `createRecurringDelegation(delegator, tokenMint, delegatee, nonce, amountPerPeriod, periodLengthS, startTs, expiryTs)`
+#### `createRecurringDelegation(params)`
 Creates a recurring delegation.
 
-- `delegator`: `TransactionSigner`
-- `tokenMint`: `Address`
-- `delegatee`: `Address`
-- `nonce`: `number | bigint`
-- `amountPerPeriod`: `number | bigint`
-- `periodLengthS`: `number | bigint`
-- `startTs`: `number | bigint`
-- `expiryTs`: `number | bigint`
+- `params.delegator`: `TransactionSigner`
+- `params.tokenMint`: `Address`
+- `params.delegatee`: `Address`
+- `params.nonce`: `number | bigint`
+- `params.amountPerPeriod`: `number | bigint`
+- `params.periodLengthS`: `number | bigint`
+- `params.startTs`: `number | bigint`
+- `params.expiryTs`: `number | bigint`
 - Returns: `Promise<{ signature: string }>`
 
-#### `revokeDelegation(delegator, delegationAccount)`
-Closes an existing delegation account.
+#### `revokeDelegation(params)`
+Closes an existing delegation account, returning rent to the original payer.
 
-- `delegator`: `TransactionSigner`
-- `delegationAccount`: `Address`
+- `params.authority`: `TransactionSigner`
+- `params.delegationAccount`: `Address`
+- `params.receiver?`: `Address`
 - Returns: `Promise<{ signature: string }>`
 
-#### `transferFixed(delegatee, delegator, delegatorAta, tokenMint, delegationPda, amount, receiverAta)`
+#### `transferFixed(params)`
 Transfers tokens through a fixed delegation.
 
-- `delegatee`: `TransactionSigner`
-- `delegator`: `Address`
-- `delegatorAta`: `Address`
-- `tokenMint`: `Address`
-- `delegationPda`: `Address`
-- `amount`: `number | bigint`
-- `receiverAta`: `Address`
+- `params.delegatee`: `TransactionSigner`
+- `params.delegator`: `Address`
+- `params.delegatorAta`: `Address`
+- `params.tokenMint`: `Address`
+- `params.delegationPda`: `Address`
+- `params.amount`: `number | bigint`
+- `params.receiverAta`: `Address`
+- `params.tokenProgram`: `Address`
 - Returns: `Promise<{ signature: string }>`
 
-#### `transferRecurring(delegatee, delegator, delegatorAta, tokenMint, delegationPda, amount, receiverAta)`
+#### `transferRecurring(params)`
 Transfers tokens through a recurring delegation.
 
-- Same parameters as `transferFixed(...)`
+- Same parameters as `transferFixed(params)`
+- Returns: `Promise<{ signature: string }>`
+
+#### `createPlan(params)`
+Creates a subscription plan.
+
+- `params.owner`: `TransactionSigner`
+- `params.planId`: `number | bigint`
+- `params.mint`: `Address`
+- `params.amount`: `number | bigint`
+- `params.periodHours`: `number | bigint`
+- `params.endTs`: `number | bigint`
+- `params.destinations`: `Address[]`
+- `params.pullers`: `Address[]`
+- `params.metadataUri`: `string`
+- Returns: `Promise<{ signature: string; planPda: Address }>`
+
+#### `updatePlan(params)`
+Updates a plan's status, endTs, metadata, or pullers.
+
+- `params.owner`: `TransactionSigner`
+- `params.planPda`: `Address`
+- `params.status`: `PlanStatus`
+- `params.endTs`: `number | bigint`
+- `params.metadataUri`: `string`
+- `params.pullers?`: `Address[]`
+- Returns: `Promise<{ signature: string }>`
+
+#### `subscribe(params)`
+Subscribes to a plan, creating a SubscriptionDelegation PDA.
+
+- `params.subscriber`: `TransactionSigner`
+- `params.merchant`: `Address`
+- `params.planId`: `number | bigint`
+- `params.tokenMint`: `Address`
+- Returns: `Promise<{ signature: string; subscriptionPda: Address }>`
+
+#### `cancelSubscription(params)`
+Cancels a subscription.
+
+- `params.subscriber`: `TransactionSigner`
+- `params.planPda`: `Address`
+- `params.subscriptionPda`: `Address`
+- Returns: `Promise<{ signature: string }>`
+
+#### `transferSubscription(params)`
+Transfers tokens from a subscription delegation.
+
+- `params.caller`: `TransactionSigner`
+- `params.delegator`: `Address`
+- `params.tokenMint`: `Address`
+- `params.subscriptionPda`: `Address`
+- `params.planPda`: `Address`
+- `params.amount`: `number | bigint`
+- `params.receiverAta`: `Address`
+- `params.tokenProgram`: `Address`
+- Returns: `Promise<{ signature: string }>`
+
+#### `deletePlan(params)`
+Deletes an expired plan, recovering rent.
+
+- `params.owner`: `TransactionSigner`
+- `params.planPda`: `Address`
 - Returns: `Promise<{ signature: string }>`
 
 #### `getDelegationsForWallet(wallet)`
-Returns decoded fixed/recurring delegation accounts for a delegator wallet.
+Returns decoded fixed/recurring/subscription delegation accounts for a delegator wallet.
 
 - `wallet`: `Address`
 - Returns: `Promise<Delegation[]>`
+
+#### `getDelegationsAsDelegatee(wallet)`
+Returns decoded delegation accounts where the wallet is the delegatee.
+
+- `wallet`: `Address`
+- Returns: `Promise<Delegation[]>`
+
+#### `getPlansForOwner(owner)`
+Returns all plans owned by the given address.
+
+- `owner`: `Address`
+- Returns: `Promise<PlanWithAddress[]>`
+
+#### `getActiveDelegationSummary(wallet)`
+Returns a summary of active delegations and subscriptions for a wallet. Useful for checking outstanding commitments before closing a MultiDelegate.
+
+- `wallet`: `Address`
+- Returns: `Promise<{ fixed: number; recurring: number; subscriptions: number; total: number }>`
 
 #### `isMultiDelegateInitialized(user, tokenMint)`
 Checks whether the MultiDelegate PDA exists for `(user, tokenMint)`.
@@ -156,6 +250,9 @@ Checks whether the MultiDelegate PDA exists for `(user, tokenMint)`.
 - `Delegation`:
   - `{ kind: "fixed"; address: Address; data: FixedDelegation }`
   - `{ kind: "recurring"; address: Address; data: RecurringDelegation }`
+  - `{ kind: "subscription"; address: Address; data: SubscriptionDelegation }`
+- `PlanWithAddress`: `{ address: Address; data: Plan }`
+- `DelegationKindId`: `"fixed" | "recurring" | "subscription"`
 
 ### PDA Helpers
 
@@ -165,17 +262,37 @@ Derives the MultiDelegate PDA.
 #### `getDelegationPDA(multiDelegate, delegator, delegatee, nonce)`
 Derives the delegation PDA for fixed or recurring delegations.
 
+#### `getPlanPDA(owner, planId)`
+Derives the Plan PDA.
+
+#### `getSubscriptionPDA(planPda, subscriber)`
+Derives the SubscriptionDelegation PDA.
+
+#### `getEventAuthorityPDA(programId?)`
+Derives the event authority PDA used for self-CPI event emission.
+
 ### Constants
 
 From `src/constants.ts`:
 
 - `PROGRAM_ID`
-- `KIND_DISCRIMINATOR_OFFSET`
+- `CURRENT_PROGRAM_VERSION`
+- `ZERO_ADDRESS`
+- `DISCRIMINATOR_OFFSET`
 - `DELEGATOR_OFFSET`
 - `DELEGATEE_OFFSET`
 - `U64_BYTE_SIZE`
 - `MULTI_DELEGATE_SEED`
 - `DELEGATION_SEED`
+- `PLAN_SEED`
+- `SUBSCRIPTION_SEED`
+- `EVENT_AUTHORITY_SEED`
+- `PLAN_SIZE`
+- `SUBSCRIPTION_SIZE`
+- `PLAN_OWNER_OFFSET`
+- `MAX_PLAN_DESTINATIONS`
+- `MAX_PLAN_PULLERS`
+- `METADATA_URI_LEN`
 - `DELEGATION_KINDS`
 - `DelegationKindId`
 
@@ -190,10 +307,18 @@ The package re-exports generated program bindings from `src/generated`, includin
   - `getRevokeDelegationInstruction`
   - `getTransferFixedInstruction`
   - `getTransferRecurringInstruction`
+  - `getCreatePlanInstruction`
+  - `getUpdatePlanInstruction`
+  - `getSubscribeInstruction`
+  - `getCancelSubscriptionInstruction`
+  - `getTransferSubscriptionInstruction`
+  - `getDeletePlanInstruction`
 - Account helpers:
   - `fetchMultiDelegate`
   - `fetchFixedDelegation`
   - `fetchRecurringDelegation`
+  - `fetchSubscriptionDelegation`
+  - `fetchPlan`
 
 ## Contributor Note
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,13 +1,6 @@
-# Multi-Delegator Client
+# @multidelegator/client
 
-TypeScript/JavaScript SDK for interacting with the Multi-Delegator Solana program.
-
-This package exports:
-
-- A high-level `MultiDelegatorClient` class in `src/client.ts`
-- PDA helpers in `src/pdas.ts`
-- Constants in `src/constants.ts`
-- Codama-generated instruction/account bindings re-exported from `src/generated`
+TypeScript SDK for the Multi-Delegator Solana program: token delegation, recurring payments, and subscriptions.
 
 ## Installation
 
@@ -17,323 +10,101 @@ npm install @multidelegator/client
 
 ## Quick Start
 
-```typescript
-import { createSolanaClient } from "gill";
-import { MultiDelegatorClient } from "@multidelegator/client";
-
-const solanaClient = createSolanaClient({ urlOrMoniker: "localnet" });
-const client = new MultiDelegatorClient(solanaClient);
-```
-
-## Usage
+The SDK exports `build*` helpers that return Solana instructions. You sign and send them with your wallet adapter.
 
 ```typescript
+import { address } from "gill";
 import {
-  MultiDelegatorClient,
-  getDelegationPDA,
-  getMultiDelegatePDA,
+  buildInitMultiDelegate,
+  buildCreateFixedDelegation,
 } from "@multidelegator/client";
-import { createSolanaClient } from "gill";
 
-const solanaClient = createSolanaClient({ urlOrMoniker: "localnet" });
-const client = new MultiDelegatorClient(solanaClient);
-
-// Provided by your app/wallet flow:
-// - owner: TransactionSigner
-// - tokenMint: Address
-// - userAta: Address
-// - delegatee: Address
-
-// 1) Initialize the MultiDelegate account for (owner, tokenMint)
-const initResult = await client.initMultiDelegate({
-  owner,
-  tokenMint,
-  userAta,
-  tokenProgram,
+// 1. Initialize the MultiDelegate for a user's token account (once per mint)
+const { instructions: initIxs } = await buildInitMultiDelegate({
+  owner: walletSigner,
+  tokenMint: address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+  userAta: address("..."),
+  tokenProgram: address("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
 });
-console.log(initResult.signature);
+await signAndSendTransaction(initIxs, walletSigner);
 
-// 2) Create a fixed delegation
-const fixedResult = await client.createFixedDelegation({
-  delegator: owner,
-  tokenMint,
-  delegatee,
+// 2. Create a fixed delegation (e.g., allow spending 1,000,000 tokens)
+const { instructions: delegateIxs } = await buildCreateFixedDelegation({
+  delegator: walletSigner,
+  tokenMint: address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+  delegatee: address("DelegateeAddress..."),
   nonce: 0n,
   amount: 1_000_000n,
-  expiryTs: BigInt(Math.floor(Date.now() / 1000) + 3600),
+  expiryTs: BigInt(Math.floor(Date.now() / 1000) + 3600), // 1 hour
 });
-console.log(fixedResult.signature);
-
-// 3) Derive delegation PDA (used by transfer/revoke flows)
-const [multiDelegate] = await getMultiDelegatePDA(owner.address, tokenMint);
-const [delegationPda] = await getDelegationPDA(
-  multiDelegate,
-  owner.address,
-  delegatee,
-  0n,
-);
-console.log(delegationPda);
+await signAndSendTransaction(delegateIxs, walletSigner);
 ```
 
-## API Reference
+Each `build*` helper returns `{ instructions: IInstruction[] }`. You provide signing/sending, so it works with any wallet adapter or backend signer.
 
-### `MultiDelegatorClient`
+> For Node.js/backend usage, `MultiDelegatorClient` wraps all `build*` helpers with automatic transaction signing and sending via a [Gill](https://github.com/solana-foundation/gill)-compatible RPC client. It also provides query methods like `getDelegationsForWallet` and `getActiveDelegationSummary`.
 
-#### `constructor(client)`
-Creates a client using an object compatible with Gill's `createSolanaClient(...)` result:
+## Capabilities
 
-- `client.rpc`
-- `client.sendAndConfirmTransaction(...)`
+### Delegation Management
 
-#### `initMultiDelegate(params)`
-Initializes the per-`(user, mint)` MultiDelegate PDA and configures token delegation.
+| Helper | Description |
+|--------|-------------|
+| `buildInitMultiDelegate` | Set up the per-mint MultiDelegate PDA and token approval |
+| `buildCloseMultiDelegate` | Tear down MultiDelegate, invalidating all delegations (kill switch) |
+| `buildCreateFixedDelegation` | One-time token allowance with optional expiry |
+| `buildCreateRecurringDelegation` | Periodic allowance (amount per time period) |
+| `buildRevokeDelegation` | Permanently close any delegation and reclaim rent |
 
-- `params.owner`: `TransactionSigner`
-- `params.tokenMint`: `Address`
-- `params.userAta`: `Address`
-- `params.tokenProgram`: `Address`
-- Returns: `Promise<{ signature: string }>`
+### Transfers
 
-#### `closeMultiDelegate(params)`
-Closes the MultiDelegate PDA, returning rent to the user. Invalidates all existing delegations on re-initialization (emergency kill switch).
+| Helper | Description |
+|--------|-------------|
+| `buildTransferFixed` | Pull tokens from a fixed delegation |
+| `buildTransferRecurring` | Pull tokens from a recurring delegation |
+| `buildTransferSubscription` | Pull tokens from a subscription delegation |
 
-- `params.user`: `TransactionSigner`
-- `params.tokenMint`: `Address`
-- Returns: `Promise<{ signature: string }>`
+### Subscription Plans
 
-#### `createFixedDelegation(params)`
-Creates a fixed delegation.
+| Helper | Description |
+|--------|-------------|
+| `buildCreatePlan` | Publish a subscription plan with billing terms |
+| `buildUpdatePlan` | Update plan status, end date, pullers, or metadata |
+| `buildDeletePlan` | Delete an expired plan and reclaim rent |
+| `buildSubscribe` | Subscribe to a plan |
+| `buildCancelSubscription` | Cancel a subscription (grace period until end of billing period) |
 
-- `params.delegator`: `TransactionSigner`
-- `params.tokenMint`: `Address`
-- `params.delegatee`: `Address`
-- `params.nonce`: `number | bigint`
-- `params.amount`: `number | bigint`
-- `params.expiryTs`: `number | bigint`
-- Returns: `Promise<{ signature: string }>`
+### Account Queries
 
-#### `createRecurringDelegation(params)`
-Creates a recurring delegation.
-
-- `params.delegator`: `TransactionSigner`
-- `params.tokenMint`: `Address`
-- `params.delegatee`: `Address`
-- `params.nonce`: `number | bigint`
-- `params.amountPerPeriod`: `number | bigint`
-- `params.periodLengthS`: `number | bigint`
-- `params.startTs`: `number | bigint`
-- `params.expiryTs`: `number | bigint`
-- Returns: `Promise<{ signature: string }>`
-
-#### `revokeDelegation(params)`
-Closes an existing delegation account, returning rent to the original payer.
-
-- `params.authority`: `TransactionSigner`
-- `params.delegationAccount`: `Address`
-- `params.receiver?`: `Address`
-- Returns: `Promise<{ signature: string }>`
-
-#### `transferFixed(params)`
-Transfers tokens through a fixed delegation.
-
-- `params.delegatee`: `TransactionSigner`
-- `params.delegator`: `Address`
-- `params.delegatorAta`: `Address`
-- `params.tokenMint`: `Address`
-- `params.delegationPda`: `Address`
-- `params.amount`: `number | bigint`
-- `params.receiverAta`: `Address`
-- `params.tokenProgram`: `Address`
-- Returns: `Promise<{ signature: string }>`
-
-#### `transferRecurring(params)`
-Transfers tokens through a recurring delegation.
-
-- Same parameters as `transferFixed(params)`
-- Returns: `Promise<{ signature: string }>`
-
-#### `createPlan(params)`
-Creates a subscription plan.
-
-- `params.owner`: `TransactionSigner`
-- `params.planId`: `number | bigint`
-- `params.mint`: `Address`
-- `params.amount`: `number | bigint`
-- `params.periodHours`: `number | bigint`
-- `params.endTs`: `number | bigint`
-- `params.destinations`: `Address[]`
-- `params.pullers`: `Address[]`
-- `params.metadataUri`: `string`
-- Returns: `Promise<{ signature: string; planPda: Address }>`
-
-#### `updatePlan(params)`
-Updates a plan's status, endTs, metadata, or pullers.
-
-- `params.owner`: `TransactionSigner`
-- `params.planPda`: `Address`
-- `params.status`: `PlanStatus`
-- `params.endTs`: `number | bigint`
-- `params.metadataUri`: `string`
-- `params.pullers?`: `Address[]`
-- Returns: `Promise<{ signature: string }>`
-
-#### `subscribe(params)`
-Subscribes to a plan, creating a SubscriptionDelegation PDA.
-
-- `params.subscriber`: `TransactionSigner`
-- `params.merchant`: `Address`
-- `params.planId`: `number | bigint`
-- `params.tokenMint`: `Address`
-- Returns: `Promise<{ signature: string; subscriptionPda: Address }>`
-
-#### `cancelSubscription(params)`
-Cancels a subscription.
-
-- `params.subscriber`: `TransactionSigner`
-- `params.planPda`: `Address`
-- `params.subscriptionPda`: `Address`
-- Returns: `Promise<{ signature: string }>`
-
-#### `transferSubscription(params)`
-Transfers tokens from a subscription delegation.
-
-- `params.caller`: `TransactionSigner`
-- `params.delegator`: `Address`
-- `params.tokenMint`: `Address`
-- `params.subscriptionPda`: `Address`
-- `params.planPda`: `Address`
-- `params.amount`: `number | bigint`
-- `params.receiverAta`: `Address`
-- `params.tokenProgram`: `Address`
-- Returns: `Promise<{ signature: string }>`
-
-#### `deletePlan(params)`
-Deletes an expired plan, recovering rent.
-
-- `params.owner`: `TransactionSigner`
-- `params.planPda`: `Address`
-- Returns: `Promise<{ signature: string }>`
-
-#### `getDelegationsForWallet(wallet)`
-Returns decoded fixed/recurring/subscription delegation accounts for a delegator wallet.
-
-- `wallet`: `Address`
-- Returns: `Promise<Delegation[]>`
-
-#### `getDelegationsAsDelegatee(wallet)`
-Returns decoded delegation accounts where the wallet is the delegatee.
-
-- `wallet`: `Address`
-- Returns: `Promise<Delegation[]>`
-
-#### `getPlansForOwner(owner)`
-Returns all plans owned by the given address.
-
-- `owner`: `Address`
-- Returns: `Promise<PlanWithAddress[]>`
-
-#### `getActiveDelegationSummary(wallet)`
-Returns a summary of active delegations and subscriptions for a wallet. Useful for checking outstanding commitments before closing a MultiDelegate.
-
-- `wallet`: `Address`
-- Returns: `Promise<{ fixed: number; recurring: number; subscriptions: number; total: number }>`
-
-#### `isMultiDelegateInitialized(user, tokenMint)`
-Checks whether the MultiDelegate PDA exists for `(user, tokenMint)`.
-
-- `user`: `Address`
-- `tokenMint`: `Address`
-- Returns: `Promise<{ initialized: boolean; pda: Address }>`
-
-### Exported Types
-
-- `Delegation`:
-  - `{ kind: "fixed"; address: Address; data: FixedDelegation }`
-  - `{ kind: "recurring"; address: Address; data: RecurringDelegation }`
-  - `{ kind: "subscription"; address: Address; data: SubscriptionDelegation }`
-- `PlanWithAddress`: `{ address: Address; data: Plan }`
-- `DelegationKindId`: `"fixed" | "recurring" | "subscription"`
+| Function | Description |
+|----------|-------------|
+| `fetchDelegationsByDelegator` | All delegations where wallet is the delegator |
+| `fetchDelegationsByDelegatee` | All delegations where wallet is the delegatee |
+| `fetchPlansForOwner` | All plans owned by an address |
+| `fetchSubscriptionsForUser` | All subscriptions for a user |
+| `decodeDelegationAccount` / `decodePlanAccount` | Decode raw RPC responses |
 
 ### PDA Helpers
 
-#### `getMultiDelegatePDA(user, tokenMint)`
-Derives the MultiDelegate PDA.
+`getMultiDelegatePDA`, `getDelegationPDA`, `getPlanPDA`, `getSubscriptionPDA`, `getEventAuthorityPDA`
 
-#### `getDelegationPDA(multiDelegate, delegator, delegatee, nonce)`
-Derives the delegation PDA for fixed or recurring delegations.
+### Types
 
-#### `getPlanPDA(owner, planId)`
-Derives the Plan PDA.
+- `Delegation` - discriminated union: `{ kind: "fixed" | "recurring" | "subscription"; address; data }`
+- Type guards: `isFixedDelegation`, `isRecurringDelegation`, `isSubscriptionDelegation`
+- `PlanWithAddress`, `DelegationKindId`, `TransferParams`
+- Error handling: `parseProgramError`, `ProgramError`, `ValidationError`
 
-#### `getSubscriptionPDA(planPda, subscriber)`
-Derives the SubscriptionDelegation PDA.
+## API Reference
 
-#### `getEventAuthorityPDA(programId?)`
-Derives the event authority PDA used for self-CPI event emission.
+Full API documentation is generated from source with [TypeDoc](https://typedoc.org/). Run `pnpm docs` to generate locally, or browse `./docs/`.
 
-### Constants
+## Development
 
-From `src/constants.ts`:
-
-- `PROGRAM_ID`
-- `CURRENT_PROGRAM_VERSION`
-- `ZERO_ADDRESS`
-- `DISCRIMINATOR_OFFSET`
-- `DELEGATOR_OFFSET`
-- `DELEGATEE_OFFSET`
-- `U64_BYTE_SIZE`
-- `MULTI_DELEGATE_SEED`
-- `DELEGATION_SEED`
-- `PLAN_SEED`
-- `SUBSCRIPTION_SEED`
-- `EVENT_AUTHORITY_SEED`
-- `PLAN_SIZE`
-- `SUBSCRIPTION_SIZE`
-- `PLAN_OWNER_OFFSET`
-- `MAX_PLAN_DESTINATIONS`
-- `MAX_PLAN_PULLERS`
-- `METADATA_URI_LEN`
-- `DELEGATION_KINDS`
-- `DelegationKindId`
-
-## Generated Bindings (Codama)
-
-The package re-exports generated program bindings from `src/generated`, including instruction builders and account helpers used by the high-level client, such as:
-
-- Instruction builders:
-  - `getInitMultiDelegateInstruction`
-  - `getCreateFixedDelegationInstruction`
-  - `getCreateRecurringDelegationInstruction`
-  - `getRevokeDelegationInstruction`
-  - `getTransferFixedInstruction`
-  - `getTransferRecurringInstruction`
-  - `getCreatePlanInstruction`
-  - `getUpdatePlanInstruction`
-  - `getSubscribeInstruction`
-  - `getCancelSubscriptionInstruction`
-  - `getTransferSubscriptionInstruction`
-  - `getDeletePlanInstruction`
-- Account helpers:
-  - `fetchMultiDelegate`
-  - `fetchFixedDelegation`
-  - `fetchRecurringDelegation`
-  - `fetchSubscriptionDelegation`
-  - `fetchPlan`
-
-## Contributor Note
-
-Generated bindings are produced by Codama and are gitignored in this repository (`clients/typescript/src/generated`).
-
-To regenerate from the repo root:
+Generated bindings in `src/generated/` are produced by [Codama](https://github.com/codama-idl/codama) and gitignored. Regenerate from the repo root:
 
 ```bash
 just generate-client
-```
-
-Or directly:
-
-```bash
-bun run generate
 ```
 
 ## License

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -97,7 +97,7 @@ Each `build*` helper returns `{ instructions: IInstruction[] }`. You provide sig
 
 ## API Reference
 
-Full API documentation is generated from source with [TypeDoc](https://typedoc.org/). Run `pnpm docs` to generate locally, or browse `./docs/`.
+Full API documentation is generated from source with [TypeDoc](https://typedoc.org/). Run `npx typedoc` to generate locally, or browse `./docs/`.
 
 ## Development
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -19,7 +19,8 @@
     "format": "biome check --write",
     "format:check": "biome check",
     "lint": "biome lint --write",
-    "lint:check": "biome lint"
+    "lint:check": "biome lint",
+    "docs": "typedoc"
   },
   "dependencies": {
     "@solana/kit": "latest",
@@ -35,6 +36,7 @@
     "@types/node": "^25.0.10",
     "tsup": "^8.3.0",
     "tweetnacl": "^1.0.3",
+    "typedoc": "^0.28.18",
     "typescript": "^5.7.0",
     "vitest": "^2.1.8"
   }

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -20,7 +20,7 @@
     "format:check": "biome check",
     "lint": "biome lint --write",
     "lint:check": "biome lint",
-    "docs": "typedoc"
+    "docs": "npx typedoc"
   },
   "dependencies": {
     "@solana/kit": "latest",
@@ -36,7 +36,7 @@
     "@types/node": "^25.0.10",
     "tsup": "^8.3.0",
     "tweetnacl": "^1.0.3",
-    "typedoc": "^0.28.18",
+
     "typescript": "^5.7.0",
     "vitest": "^2.1.8"
   }

--- a/clients/typescript/src/accounts/decode.ts
+++ b/clients/typescript/src/accounts/decode.ts
@@ -11,6 +11,7 @@ import {
 import type { Delegation } from '../types/delegation.js';
 import type { PlanWithAddress } from '../types/plan.js';
 
+/** Raw account shape returned by `getProgramAccounts` RPC calls. */
 export type RawProgramAccount = {
   pubkey: Address;
   account: {
@@ -22,6 +23,13 @@ export type RawProgramAccount = {
   };
 };
 
+/**
+ * Converts a {@link RawProgramAccount} into Gill's `EncodedAccount` format for use with Codama decoders.
+ *
+ * @param raw - The raw account as returned by `getProgramAccounts`.
+ * @param programAddress - The program address that owns the account.
+ * @returns An `EncodedAccount` with base64-decoded data.
+ */
 export function toEncodedAccount(
   raw: RawProgramAccount,
   programAddress: Address,

--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -1,51 +1,54 @@
 import { MULTI_DELEGATOR_PROGRAM_ADDRESS } from './generated/index.js';
 
-// Program ID declared via `declare_id!` macro
-// See: programs/multi_delegator/src/lib.rs
+/** Deployed program address, sourced from Codama-generated bindings. */
 export const PROGRAM_ID = MULTI_DELEGATOR_PROGRAM_ADDRESS;
 
-// See: programs/multi_delegator/src/state/header.rs
+/** Current on-chain account schema version. */
 export const CURRENT_PROGRAM_VERSION = 1;
 
-// Default zero address used for padding arrays
+/** Default zero address used for padding arrays (e.g. empty puller/destination slots). */
 export const ZERO_ADDRESS =
   '11111111111111111111111111111111' as import('gill').Address<'11111111111111111111111111111111'>;
 
-// Header struct layout offsets
-// Layout: discriminator (1) + version (1) + bump (1) + delegator (32) + delegatee (32) + payer (32) + init_id (8) = 107 bytes
-// See: programs/multi_delegator/src/state/header.rs
+/** Byte offset of the account discriminator in the Header struct. */
 export const DISCRIMINATOR_OFFSET = 0;
+/** Byte offset of the delegator pubkey in the Header struct. */
 export const DELEGATOR_OFFSET = 3;
+/** Byte offset of the delegatee pubkey in the Header struct. */
 export const DELEGATEE_OFFSET = 35;
 
-// Byte size for u64 values (used in nonce encoding)
+/** Byte size of a u64 value (used in nonce encoding). */
 export const U64_BYTE_SIZE = 8;
 
-// PDA seed for MultiDelegate account
-// See: programs/multi_delegator/src/state/multi_delegate.rs (MultiDelegate::SEED)
+/** PDA seed for MultiDelegate accounts. */
 export const MULTI_DELEGATE_SEED = 'MultiDelegate';
 
-// PDA seed for delegation accounts (FixedDelegation, RecurringDelegation)
-// See: programs/multi_delegator/src/state/common.rs (DELEGATE_BASE_SEED)
+/** PDA seed for delegation accounts (FixedDelegation, RecurringDelegation). */
 export const DELEGATION_SEED = 'delegation';
 
+/** PDA seed for Plan accounts. */
 export const PLAN_SEED = 'plan';
+/** PDA seed for SubscriptionDelegation accounts. */
 export const SUBSCRIPTION_SEED = 'subscription';
+/** PDA seed for the event authority (self-CPI). */
 export const EVENT_AUTHORITY_SEED = 'event_authority';
 
-// Plan: discriminator(1) + owner(32) + bump(1) + status(1) + planData(456)
+/** On-chain Plan account size in bytes: discriminator(1) + owner(32) + bump(1) + status(1) + planData(456). */
 export const PLAN_SIZE = 491;
-// Subscription: header(107) + terms(24) + amountPulledInPeriod(8) + currentPeriodStartTs(8) + expiresAtTs(8)
+/** On-chain SubscriptionDelegation account size in bytes: header(107) + terms(24) + pulled(8) + periodStart(8) + expiresAt(8). */
 export const SUBSCRIPTION_SIZE = 155;
 
+/** Byte offset of the owner pubkey in a Plan account. */
 export const PLAN_OWNER_OFFSET = 1;
 
+/** Maximum number of destination addresses in a Plan. */
 export const MAX_PLAN_DESTINATIONS = 4;
+/** Maximum number of puller addresses in a Plan. */
 export const MAX_PLAN_PULLERS = 4;
+/** Maximum byte length of a Plan's metadata URI. */
 export const METADATA_URI_LEN = 128;
 
-// Delegation kinds with metadata for UI display
-// Maps to AccountDiscriminator enum in programs/multi_delegator/src/state/common.rs
+/** Delegation kind metadata for UI display. Maps to the on-chain AccountDiscriminator enum. */
 export const DELEGATION_KINDS = {
   fixed: {
     id: 'fixed',

--- a/clients/typescript/src/pdas.ts
+++ b/clients/typescript/src/pdas.ts
@@ -22,6 +22,14 @@ function encodeU64Le(value: number | bigint): Uint8Array {
   return bytes;
 }
 
+/**
+ * Derives the MultiDelegate PDA for a user and token mint.
+ *
+ * @param user - Wallet address of the delegate owner.
+ * @param tokenMint - SPL token mint address.
+ * @param programId - Program address override (defaults to {@link PROGRAM_ID}).
+ * @returns A tuple of `[pda, bump]`.
+ */
 export async function getMultiDelegatePDA(
   user: Address,
   tokenMint: Address,
@@ -40,6 +48,16 @@ export async function getMultiDelegatePDA(
   return [pda, bump];
 }
 
+/**
+ * Derives the delegation PDA for fixed or recurring delegations.
+ *
+ * @param multiDelegate - The MultiDelegate PDA address.
+ * @param delegator - Wallet address of the delegator.
+ * @param delegatee - Wallet address of the delegatee.
+ * @param nonce - Unique nonce allowing multiple delegations between the same pair.
+ * @param programId - Program address override (defaults to {@link PROGRAM_ID}).
+ * @returns A tuple of `[pda, bump]`.
+ */
 export async function getDelegationPDA(
   multiDelegate: Address,
   delegator: Address,
@@ -62,6 +80,14 @@ export async function getDelegationPDA(
   return [pda, bump];
 }
 
+/**
+ * Derives the Plan PDA for a merchant and plan identifier.
+ *
+ * @param owner - Wallet address of the plan owner (merchant).
+ * @param planId - Unique plan identifier.
+ * @param programId - Program address override (defaults to {@link PROGRAM_ID}).
+ * @returns A tuple of `[pda, bump]`.
+ */
 export async function getPlanPDA(
   owner: Address,
   planId: number | bigint,
@@ -80,6 +106,12 @@ export async function getPlanPDA(
   return [pda, bump];
 }
 
+/**
+ * Derives the event authority PDA used for self-CPI event emission.
+ *
+ * @param programId - Program address override (defaults to {@link PROGRAM_ID}).
+ * @returns A tuple of `[pda, bump]`.
+ */
 export async function getEventAuthorityPDA(
   programId?: Address,
 ): Promise<[Address, number]> {
@@ -92,6 +124,14 @@ export async function getEventAuthorityPDA(
   return [pda, bump];
 }
 
+/**
+ * Derives the SubscriptionDelegation PDA for a plan and subscriber.
+ *
+ * @param planPda - The Plan PDA address.
+ * @param subscriber - Wallet address of the subscriber.
+ * @param programId - Program address override (defaults to {@link PROGRAM_ID}).
+ * @returns A tuple of `[pda, bump]`.
+ */
 export async function getSubscriptionPDA(
   planPda: Address,
   subscriber: Address,

--- a/clients/typescript/typedoc.json
+++ b/clients/typescript/typedoc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"],
+  "out": "./docs",
+  "tsconfig": "./tsconfig.json",
+  "exclude": ["**/generated/**"],
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "readme": "none",
+  "name": "@multidelegator/client"
+}

--- a/docs/001-multi-delegator-architecture.md
+++ b/docs/001-multi-delegator-architecture.md
@@ -277,13 +277,13 @@ One-time delegation with explicit amount and expiry:
 ```rust
 #[repr(C, packed)]
 pub struct FixedDelegation {
-    pub header: Header,     // 99 bytes
+    pub header: Header,     // 107 bytes
     pub amount: u64,        // 8 bytes - remaining pullable amount
     pub expiry_ts: i64,     // 8 bytes - Unix timestamp (0 = no expiry)
 }
 
 impl FixedDelegation {
-    pub const LEN: usize = 115;
+    pub const LEN: usize = 123;
 }
 ```
 
@@ -298,7 +298,7 @@ Recurring delegation with period tracking:
 ```rust
 #[repr(C, packed)]
 pub struct RecurringDelegation {
-    pub header: Header,              // 99 bytes
+    pub header: Header,              // 107 bytes
     pub current_period_start_ts: i64, // 8 bytes - start of current period
     pub period_length_s: u64,         // 8 bytes - seconds per period
     pub expiry_ts: i64,               // 8 bytes - delegation expiry (0 = no expiry)
@@ -307,7 +307,7 @@ pub struct RecurringDelegation {
 }
 
 impl RecurringDelegation {
-    pub const LEN: usize = 139;
+    pub const LEN: usize = 147;
 }
 ```
 

--- a/docs/002-subscriptions-architecture.md
+++ b/docs/002-subscriptions-architecture.md
@@ -256,13 +256,13 @@ The `destinations` array controls where pulled funds can be sent. If the array i
 
 Per-subscriber billing state linked to a Plan:
 
-- `header`: 99 bytes - shared `Header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber)
+- `header`: 107 bytes - shared `Header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber)
 - `terms`: 24 bytes (`PlanTerms`) - snapshot of the plan's billing terms at subscribe time
 - `amount_pulled_in_period`: 8 bytes (`u64`) - tokens transferred in the current billing period
 - `current_period_start_ts`: 8 bytes (`i64`) - start of the current billing period
 - `expires_at_ts`: 8 bytes (`i64`) - cancellation timestamp (0 = active, non-zero = cancelled)
 
-**Total size**: 147 bytes
+**Total size**: 155 bytes
 
 **PDA seeds**: `["subscription", plan_pda, subscriber]`
 
@@ -327,8 +327,9 @@ Plan owner updates mutable admin fields (status, end_ts, pullers, metadata_uri).
 3. Reject if plan is already in Sunset status (else `PlanImmutableAfterSunset`) - Sunset is a terminal state
 4. Reject if status=Sunset and end_ts=0 (else `SunsetRequiresEndTs`) - sunsetting requires a finite expiration
 5. Validate input data: `PlanStatus::try_from(status)` must succeed (else `InvalidPlanStatus`), `end_ts == 0` or `end_ts > current_time` (else `InvalidEndTs`)
-6. Reject if plan has expired: `plan.end_ts != 0 && current_ts > plan.end_ts` (else `PlanExpired`)
-7. Write status, end_ts, pullers, and metadata_uri from input data
+6. Validate end_ts is at least one billing period in the future: `end_ts == 0` or `end_ts >= current_time + (terms.period_hours * 3600)` (else `InvalidEndTs`)
+7. Reject if plan has expired: `plan.end_ts != 0 && current_ts > plan.end_ts` (else `PlanExpired`)
+8. Write status, end_ts, pullers, and metadata_uri from input data
 
 **Immutable fields (never modified by update_plan):**
 `plan_id`, `owner`, `bump`, `mint`, `terms` (amount, period_hours, created_at), `destinations`
@@ -454,7 +455,7 @@ After `expires_at_ts` passes, pulls are blocked. The subscriber can then call `r
 3. Verify subscription's delegatee matches the plan PDA (else `SubscriptionPlanMismatch`)
 
 **Process:**
-1. If plan is valid (program-owned) and `check_plan_terms()` passes: compute `expires_at_ts = current_period_start + (periods_elapsed + 1) * period_length` using subscription's snapshotted `terms.period_hours`
+1. If plan is valid (program-owned) and `check_plan_terms()` passes: compute `expires_at_ts = current_period_start + (periods_elapsed + 1) * period_length` using subscription's snapshotted `terms.period_hours`, then cap at `plan.end_ts` if `end_ts != 0` (so a cancelled subscription cannot outlive the plan itself)
 2. If plan is valid but `check_plan_terms()` fails (ghost plan): set `expires_at_ts = current_ts` (immediate, no grace period)
 3. If plan is closed (not program-owned): set `expires_at_ts = current_ts`
 4. Emit `SubscriptionCancelled` event via self-CPI

--- a/docs/003-versioning-migration-architecture.md
+++ b/docs/003-versioning-migration-architecture.md
@@ -91,6 +91,7 @@ common `Header` where:
 - Bytes 3--34: `delegator`
 - Bytes 35--66: `delegatee`
 - Bytes 67--98: `payer`
+- Bytes 99--106: `init_id`
 
 The version check reads `data[VERSION_OFFSET]` (byte 1), not byte 0.
 `MultiDelegate` and `Plan` accounts have their own layouts but also store a discriminator at

--- a/docs/004-program-upgrade-mechanism.md
+++ b/docs/004-program-upgrade-mechanism.md
@@ -66,8 +66,8 @@ After an upgrade, anyone can verify the on-chain program matches the public sour
 
 ```bash
 solana-verify verify-from-repo \
-    --program-id 3PuMsYqaLY4Sy1DR8np3aAiHravZXCeyMYDUECLqfswY \
-    --url https://github.com/Moonsong-Labs/multi-delegator
+    --program-id <PROGRAM_ID> \
+    --url https://github.com/solana-program/multi-delegator
 ```
 
 ## References

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -5,9 +5,10 @@ Web interface for managing Solana token delegations (USDC). Connects to the Mult
 ## Features
 
 - **Wallet Connection** - Solana wallet integration (tested with Phantom) with real-time SOL and USDC balance display
-- **Create Delegations** - Two delegation types:
+- **Create Delegations** - Three delegation types:
   - **Fixed**: one-time total amount with an expiry date
   - **Recurring**: per-period amount with configurable period length
+  - **Subscription**: plan-based recurring billing with merchant-defined terms
 - **View Delegations** - Separate tabs for outgoing (delegator) and incoming (delegatee) delegations, with active/expired filtering
 - **Revoke Delegations** - Cancel active outgoing delegations on-chain
 - **Transfer Under Delegation** - Delegatees can withdraw amounts within the delegation rules
@@ -24,7 +25,7 @@ Web interface for managing Solana token delegations (USDC). Connects to the Mult
 | `npm run lint` | Run ESLint across the project |
 | `npm run preview` | Preview the production build locally |
 
-From the project root, `just webapp` builds the program and clients, starts a local validator + API, and launches the webapp.
+From the project root, `just webapp-run` builds the program and clients, starts a local validator + API, and launches the webapp.
 
 ## Tech Stack
 


### PR DESCRIPTION
  - Fix incorrect byte sizes, missing fields and outdated method signatures across all docs
  - Rewrite TS client README around `build*` helpers with TypeDoc setup for full API reference
