### PR TITLE
feat!: optional sponsor payer for subscribe and init multi delegate

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -13,6 +13,7 @@ import {
   buildCreateRecurringDelegation,
   buildInitMultiDelegate,
   buildRevokeDelegation,
+  buildRevokeSubscription,
 } from './instructions/delegation.js';
 import {
   buildCreatePlan,
@@ -166,18 +167,35 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Revoke (close) a delegation account, returning rent to the original payer.
-   *
-   * For subscription PDAs, `planPda` must be supplied (see
-   * `buildRevokeDelegation`). It is ignored for fixed/recurring delegations.
+  /** Revoke (close) a fixed or recurring delegation account, returning rent
+   * to the original payer. For subscription PDAs, use {@link revokeSubscription}.
    */
   async revokeDelegation(params: {
     authority: TransactionSigner;
     delegationAccount: Address;
-    planPda?: Address;
     receiver?: Address;
   }): Promise<TransactionResult> {
     const { instructions } = buildRevokeDelegation(params);
+    const signature = await this.buildAndSendTransaction(
+      instructions,
+      params.authority,
+    );
+    return { signature };
+  }
+
+  /** Revoke (close) a subscription PDA, returning rent to the original payer.
+   *
+   * `planPda` is required so the program can bind the subscription and detect
+   * plan-ended / plan-closed conditions for the sponsor path. Pass `receiver`
+   * when the recorded payer differs from the authority.
+   */
+  async revokeSubscription(params: {
+    authority: TransactionSigner;
+    subscriptionPda: Address;
+    planPda: Address;
+    receiver?: Address;
+  }): Promise<TransactionResult> {
+    const { instructions } = buildRevokeSubscription(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
       params.authority,

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -145,10 +145,15 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Revoke (close) a delegation account, returning rent to the original payer. */
+  /** Revoke (close) a delegation account, returning rent to the original payer.
+   *
+   * For subscription PDAs, `planPda` must be supplied (see
+   * `buildRevokeDelegation`). It is ignored for fixed/recurring delegations.
+   */
   async revokeDelegation(params: {
     authority: TransactionSigner;
     delegationAccount: Address;
+    planPda?: Address;
     receiver?: Address;
   }): Promise<TransactionResult> {
     const { instructions } = buildRevokeDelegation(params);

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -61,23 +61,33 @@ export class MultiDelegatorClient {
     return this.client.sendAndConfirmTransaction(signedTransaction);
   }
 
-  /** Initialize a MultiDelegate PDA for the owner's token account. */
+  /** Initialize a MultiDelegate PDA for the owner's token account.
+   *
+   * When `payer` is supplied, the sponsor funds rent and is also used as the
+   * transaction fee payer so the owner spends zero SOL.
+   */
   async initMultiDelegate(params: {
     owner: TransactionSigner;
     tokenMint: Address;
     userAta: Address;
     tokenProgram: Address;
+    payer?: TransactionSigner;
   }): Promise<TransactionResult> {
     const { instructions } = await buildInitMultiDelegate(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
-      params.owner,
+      params.payer ?? params.owner,
     );
     return { signature };
   }
 
   /**
-   * Close a MultiDelegate PDA, returning rent to the user.
+   * Close a MultiDelegate PDA, returning rent to the recorded payer.
+   *
+   * When the MultiDelegate was sponsor-funded (stored `payer` differs from
+   * `user`), pass `receiver` set to the sponsor's address so the program can
+   * route rent back to them. Caller is responsible for fetching the on-chain
+   * MultiDelegate to determine whether `receiver` is required.
    *
    * Closing invalidates all existing delegations on re-initialization
    * (init_id mismatch). This can serve as an emergency kill switch to
@@ -86,6 +96,7 @@ export class MultiDelegatorClient {
   async closeMultiDelegate(params: {
     user: TransactionSigner;
     tokenMint: Address;
+    receiver?: Address;
   }): Promise<TransactionResult> {
     try {
       const delegations = await this.getDelegationsForWallet(
@@ -109,7 +120,11 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Create a fixed (one-time) delegation. */
+  /** Create a fixed (one-time) delegation.
+   *
+   * When `payer` is supplied, the sponsor funds the delegation PDA rent and
+   * the transaction fee.
+   */
   async createFixedDelegation(params: {
     delegator: TransactionSigner;
     tokenMint: Address;
@@ -117,16 +132,21 @@ export class MultiDelegatorClient {
     nonce: number | bigint;
     amount: number | bigint;
     expiryTs: number | bigint;
+    payer?: TransactionSigner;
   }): Promise<TransactionResult> {
     const { instructions } = await buildCreateFixedDelegation(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
-      params.delegator,
+      params.payer ?? params.delegator,
     );
     return { signature };
   }
 
-  /** Create a recurring delegation with periodic allowance. */
+  /** Create a recurring delegation with periodic allowance.
+   *
+   * When `payer` is supplied, the sponsor funds the delegation PDA rent and
+   * the transaction fee.
+   */
   async createRecurringDelegation(params: {
     delegator: TransactionSigner;
     tokenMint: Address;
@@ -136,11 +156,12 @@ export class MultiDelegatorClient {
     periodLengthS: number | bigint;
     startTs: number | bigint;
     expiryTs: number | bigint;
+    payer?: TransactionSigner;
   }): Promise<TransactionResult> {
     const { instructions } = await buildCreateRecurringDelegation(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
-      params.delegator,
+      params.payer ?? params.delegator,
     );
     return { signature };
   }
@@ -268,17 +289,24 @@ export class MultiDelegatorClient {
     return { signature };
   }
 
-  /** Subscribe to a plan. */
+  /** Subscribe to a plan.
+   *
+   * When `payer` is supplied, the sponsor funds the subscription PDA rent and
+   * the transaction fee, so the subscriber spends zero SOL. The sponsor is
+   * also recorded as the subscription's `header.payer` and receives rent on
+   * close.
+   */
   async subscribe(params: {
     subscriber: TransactionSigner;
     merchant: Address;
     planId: number | bigint;
     tokenMint: Address;
+    payer?: TransactionSigner;
   }): Promise<TransactionResult & { subscriptionPda: Address }> {
     const { instructions, subscriptionPda } = await buildSubscribe(params);
     const signature = await this.buildAndSendTransaction(
       instructions,
-      params.subscriber,
+      params.payer ?? params.subscriber,
     );
     return { signature, subscriptionPda };
   }

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -32,6 +32,7 @@ export {
   buildCreateRecurringDelegation,
   buildInitMultiDelegate,
   buildRevokeDelegation,
+  buildRevokeSubscription,
 } from './instructions/delegation.js';
 export {
   buildCreatePlan,

--- a/clients/typescript/src/instructions/delegation.ts
+++ b/clients/typescript/src/instructions/delegation.ts
@@ -243,28 +243,23 @@ export async function buildCreateRecurringDelegation(params: {
 }
 
 /**
- * Builds a `revokeDelegation` instruction that permanently closes a delegation
- * (or subscription) account.
+ * Builds a `revokeDelegation` instruction for **fixed or recurring**
+ * delegations. For subscription PDAs use {@link buildRevokeSubscription}.
  *
- * Trailing-account layout depends on the delegation kind read on-chain:
- *
- * * Fixed / Recurring: `[receiver?]` — only required if `payer` differs from `authority`.
- * * Subscription: `[planPda, receiver?]` — `planPda` is required for subscription
- *   PDAs so the program can prove plan-ended / plan-closed conditions and bind
- *   the subscription to the passed plan.
+ * Trailing-account layout for fixed/recurring: `[receiver?]`. `receiver` is
+ * only required when the recorded payer differs from `authority` (e.g., the
+ * delegator is revoking a sponsor-funded delegation, or the sponsor is
+ * revoking an expired delegation).
  *
  * @param params.authority - The delegator or sponsor authorized to revoke.
- * @param params.delegationAccount - Address of the delegation PDA to revoke.
- * @param params.planPda - Required when revoking a subscription PDA. Pass the
- *   plan PDA the subscription was created against. Ignored for fixed/recurring.
+ * @param params.delegationAccount - Address of the fixed/recurring delegation PDA.
  * @param params.receiver - Rent destination when the recorded payer differs
- *   from the authority (e.g., subscriber revoking a sponsor-funded subscription).
+ *   from the authority. Must equal the stored `header.payer`.
  * @returns The instruction array.
  */
 export function buildRevokeDelegation(params: {
   authority: TransactionSigner;
   delegationAccount: Address;
-  planPda?: Address;
   receiver?: Address;
   programAddress?: Address;
 }): { instructions: Instruction[] } {
@@ -279,20 +274,63 @@ export function buildRevokeDelegation(params: {
     config,
   );
 
-  const trailing: Array<{ address: Address; role: number }> = [];
-  if (params.planPda) {
-    trailing.push({ address: params.planPda, role: AccountRole.READONLY });
-  }
   if (params.receiver) {
-    trailing.push({ address: params.receiver, role: AccountRole.WRITABLE });
-  }
-
-  if (trailing.length > 0) {
-    const accounts = [...instruction.accounts, ...trailing];
+    const accounts = [
+      ...instruction.accounts,
+      { address: params.receiver, role: AccountRole.WRITABLE },
+    ];
     return { instructions: [{ ...instruction, accounts }] };
   }
 
   return { instructions: [instruction] };
+}
+
+/**
+ * Builds a `revokeDelegation` instruction for **subscription** PDAs. Wraps
+ * the same on-chain instruction as {@link buildRevokeDelegation} but appends
+ * the subscription-specific trailing accounts (`[planPda, receiver?]`).
+ *
+ * For fixed/recurring delegations, use {@link buildRevokeDelegation} — passing
+ * `planPda` to the program for a fixed/recurring revoke would be misread as a
+ * `receiver` and fail with `Unauthorized`.
+ *
+ * @param params.authority - Subscriber (delegator) or sponsor (recorded `header.payer`).
+ * @param params.subscriptionPda - Address of the subscription PDA to revoke.
+ * @param params.planPda - Required. The plan PDA the subscription is bound to.
+ *   Used by the program for the binding check and plan-ended / plan-closed
+ *   detection on the sponsor path. Pass the plan PDA address even if the plan
+ *   has been closed by the merchant — the program inspects ownership directly.
+ * @param params.receiver - Rent destination when the recorded payer differs
+ *   from the authority. Must equal the stored `header.payer`.
+ * @returns The instruction array.
+ */
+export function buildRevokeSubscription(params: {
+  authority: TransactionSigner;
+  subscriptionPda: Address;
+  planPda: Address;
+  receiver?: Address;
+  programAddress?: Address;
+}): { instructions: Instruction[] } {
+  const config = params.programAddress
+    ? { programAddress: params.programAddress }
+    : undefined;
+  const instruction = getRevokeDelegationInstruction(
+    {
+      authority: params.authority,
+      delegationAccount: params.subscriptionPda,
+    },
+    config,
+  );
+
+  const trailing: Array<{ address: Address; role: number }> = [
+    { address: params.planPda, role: AccountRole.READONLY },
+  ];
+  if (params.receiver) {
+    trailing.push({ address: params.receiver, role: AccountRole.WRITABLE });
+  }
+
+  const accounts = [...instruction.accounts, ...trailing];
+  return { instructions: [{ ...instruction, accounts }] };
 }
 
 /**

--- a/clients/typescript/src/instructions/delegation.ts
+++ b/clients/typescript/src/instructions/delegation.ts
@@ -21,6 +21,7 @@ import { getDelegationPDA, getMultiDelegatePDA } from '../pdas.js';
  * @param params.tokenMint - SPL token mint address.
  * @param params.userAta - Owner's associated token account for the mint.
  * @param params.tokenProgram - Token program (typically Token-2022).
+ * @param params.payer - Optional sponsor that funds the rent. Defaults to `owner` when omitted.
  * @returns The instruction array and the derived `multiDelegatePda`.
  */
 export async function buildInitMultiDelegate(params: {
@@ -28,9 +29,11 @@ export async function buildInitMultiDelegate(params: {
   tokenMint: Address;
   userAta: Address;
   tokenProgram: Address;
+  payer?: TransactionSigner;
   programAddress?: Address;
 }): Promise<{ instructions: Instruction[]; multiDelegatePda: Address }> {
-  const { owner, tokenMint, userAta, tokenProgram, programAddress } = params;
+  const { owner, tokenMint, userAta, tokenProgram, payer, programAddress } =
+    params;
   const config = programAddress ? { programAddress } : undefined;
   const [multiDelegatePda] = await getMultiDelegatePDA(
     owner.address,
@@ -48,6 +51,21 @@ export async function buildInitMultiDelegate(params: {
     },
     config,
   );
+
+  if (payer) {
+    const accounts = [
+      ...instruction.accounts,
+      {
+        address: payer.address,
+        role: AccountRole.WRITABLE_SIGNER,
+        signer: payer,
+      },
+    ];
+    return {
+      instructions: [{ ...instruction, accounts }],
+      multiDelegatePda,
+    };
+  }
 
   return { instructions: [instruction], multiDelegatePda };
 }
@@ -225,16 +243,28 @@ export async function buildCreateRecurringDelegation(params: {
 }
 
 /**
- * Builds a `revokeDelegation` instruction that permanently closes a delegation account.
+ * Builds a `revokeDelegation` instruction that permanently closes a delegation
+ * (or subscription) account.
+ *
+ * Trailing-account layout depends on the delegation kind read on-chain:
+ *
+ * * Fixed / Recurring: `[receiver?]` — only required if `payer` differs from `authority`.
+ * * Subscription: `[planPda, receiver?]` — `planPda` is required for subscription
+ *   PDAs so the program can prove plan-ended / plan-closed conditions and bind
+ *   the subscription to the passed plan.
  *
  * @param params.authority - The delegator or sponsor authorized to revoke.
  * @param params.delegationAccount - Address of the delegation PDA to revoke.
- * @param params.receiver - Rent destination when payer differs from authority (e.g., delegator revoking a sponsor-funded delegation).
+ * @param params.planPda - Required when revoking a subscription PDA. Pass the
+ *   plan PDA the subscription was created against. Ignored for fixed/recurring.
+ * @param params.receiver - Rent destination when the recorded payer differs
+ *   from the authority (e.g., subscriber revoking a sponsor-funded subscription).
  * @returns The instruction array.
  */
 export function buildRevokeDelegation(params: {
   authority: TransactionSigner;
   delegationAccount: Address;
+  planPda?: Address;
   receiver?: Address;
   programAddress?: Address;
 }): { instructions: Instruction[] } {
@@ -249,11 +279,16 @@ export function buildRevokeDelegation(params: {
     config,
   );
 
+  const trailing: Array<{ address: Address; role: number }> = [];
+  if (params.planPda) {
+    trailing.push({ address: params.planPda, role: AccountRole.READONLY });
+  }
   if (params.receiver) {
-    const accounts = [
-      ...instruction.accounts,
-      { address: params.receiver, role: AccountRole.WRITABLE },
-    ];
+    trailing.push({ address: params.receiver, role: AccountRole.WRITABLE });
+  }
+
+  if (trailing.length > 0) {
+    const accounts = [...instruction.accounts, ...trailing];
     return { instructions: [{ ...instruction, accounts }] };
   }
 
@@ -266,11 +301,16 @@ export function buildRevokeDelegation(params: {
  *
  * @param params.user - The wallet that owns the multi-delegate account.
  * @param params.tokenMint - SPL token mint associated with the account.
+ * @param params.receiver - Required when the MultiDelegate was sponsor-funded
+ *   (i.e., the stored `payer` differs from `user`). Must equal the stored payer
+ *   address. The caller is responsible for fetching the on-chain MultiDelegate
+ *   account to determine whether a receiver is needed.
  * @returns The instruction array.
  */
 export async function buildCloseMultiDelegate(params: {
   user: TransactionSigner;
   tokenMint: Address;
+  receiver?: Address;
   programAddress?: Address;
 }): Promise<{ instructions: Instruction[] }> {
   const config = params.programAddress
@@ -289,6 +329,14 @@ export async function buildCloseMultiDelegate(params: {
     },
     config,
   );
+
+  if (params.receiver) {
+    const accounts = [
+      ...instruction.accounts,
+      { address: params.receiver, role: AccountRole.WRITABLE },
+    ];
+    return { instructions: [{ ...instruction, accounts }] };
+  }
 
   return { instructions: [instruction] };
 }

--- a/clients/typescript/src/instructions/subscription.ts
+++ b/clients/typescript/src/instructions/subscription.ts
@@ -1,4 +1,9 @@
-import type { Address, Instruction, TransactionSigner } from 'gill';
+import {
+  AccountRole,
+  type Address,
+  type Instruction,
+  type TransactionSigner,
+} from 'gill';
 import {
   getCancelSubscriptionInstructionAsync,
   getSubscribeInstructionAsync,
@@ -16,6 +21,9 @@ import {
  * @param params.merchant - The plan owner's address.
  * @param params.planId - Numeric identifier of the plan to subscribe to.
  * @param params.tokenMint - SPL token mint the plan uses.
+ * @param params.payer - Optional sponsor that funds the subscription PDA rent.
+ *   When provided, the sponsor is recorded as the subscription's `header.payer`
+ *   and receives rent on close. Defaults to `subscriber` when omitted.
  * @returns The instruction array and the derived `subscriptionPda`.
  */
 export async function buildSubscribe(params: {
@@ -23,9 +31,11 @@ export async function buildSubscribe(params: {
   merchant: Address;
   planId: number | bigint;
   tokenMint: Address;
+  payer?: TransactionSigner;
   programAddress?: Address;
 }): Promise<{ instructions: Instruction[]; subscriptionPda: Address }> {
-  const { subscriber, merchant, planId, tokenMint, programAddress } = params;
+  const { subscriber, merchant, planId, tokenMint, payer, programAddress } =
+    params;
   const config = programAddress ? { programAddress } : undefined;
 
   const [planPda, planBump] = await getPlanPDA(
@@ -55,6 +65,21 @@ export async function buildSubscribe(params: {
     },
     config,
   );
+
+  if (payer) {
+    const accounts = [
+      ...instruction.accounts,
+      {
+        address: payer.address,
+        role: AccountRole.WRITABLE_SIGNER,
+        signer: payer,
+      },
+    ];
+    return {
+      instructions: [{ ...instruction, accounts }],
+      subscriptionPda,
+    };
+  }
 
   return { instructions: [instruction], subscriptionPda };
 }

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -295,6 +295,7 @@ describe('Subscription Lifecycle', () => {
     const { signature: revokeSig } = await t.client.revokeDelegation({
       authority: subscriber,
       delegationAccount: subscriptionPda,
+      planPda,
     });
     expect(revokeSig).toBeDefined();
 

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -292,9 +292,9 @@ describe('Subscription Lifecycle', () => {
     expect(subAfterCancel.expiresAtTs).not.toBe(0n);
 
     // 7. Subscriber revokes delegation, getting rent back
-    const { signature: revokeSig } = await t.client.revokeDelegation({
+    const { signature: revokeSig } = await t.client.revokeSubscription({
       authority: subscriber,
-      delegationAccount: subscriptionPda,
+      subscriptionPda,
       planPda,
     });
     expect(revokeSig).toBeDefined();

--- a/clients/typescript/test/subscription-security.test.ts
+++ b/clients/typescript/test/subscription-security.test.ts
@@ -81,6 +81,7 @@ describe('Subscription Security', () => {
       t.client.revokeDelegation({
         authority: subscriber,
         delegationAccount: subscriptionPda,
+        planPda,
       }),
       MULTI_DELEGATOR_ERROR__SUBSCRIPTION_NOT_CANCELLED,
     );
@@ -90,6 +91,7 @@ describe('Subscription Security', () => {
     const { signature } = await t.client.revokeDelegation({
       authority: subscriber,
       delegationAccount: subscriptionPda,
+      planPda,
     });
     expect(signature).toBeDefined();
   });
@@ -619,6 +621,7 @@ describe('Subscription Security', () => {
     await t.client.revokeDelegation({
       authority: subscriber,
       delegationAccount: subscriptionPda,
+      planPda,
     });
 
     const subAfterRevoke = await fetchMaybeSubscriptionDelegation(
@@ -774,6 +777,7 @@ describe('Subscription Security', () => {
     const { signature } = await t.client.revokeDelegation({
       authority: subscriber,
       delegationAccount: subscriptionPda,
+      planPda,
     });
     expect(signature).toBeDefined();
 
@@ -1201,6 +1205,7 @@ describe('Subscription Security', () => {
     const { signature } = await t.client.revokeDelegation({
       authority: subscriber,
       delegationAccount: subscriptionPda,
+      planPda,
     });
     expect(signature).toBeDefined();
 

--- a/clients/typescript/test/subscription-security.test.ts
+++ b/clients/typescript/test/subscription-security.test.ts
@@ -78,9 +78,9 @@ describe('Subscription Security', () => {
     expect(subAfterCancel.expiresAtTs).not.toBe(0n);
 
     await expectProgramError(
-      t.client.revokeDelegation({
+      t.client.revokeSubscription({
         authority: subscriber,
-        delegationAccount: subscriptionPda,
+        subscriptionPda,
         planPda,
       }),
       MULTI_DELEGATOR_ERROR__SUBSCRIPTION_NOT_CANCELLED,
@@ -88,9 +88,9 @@ describe('Subscription Security', () => {
 
     await t.timeTravel(Number(subAfterCancel.expiresAtTs) + 60);
 
-    const { signature } = await t.client.revokeDelegation({
+    const { signature } = await t.client.revokeSubscription({
       authority: subscriber,
-      delegationAccount: subscriptionPda,
+      subscriptionPda,
       planPda,
     });
     expect(signature).toBeDefined();
@@ -618,9 +618,9 @@ describe('Subscription Security', () => {
       .data;
     await t.timeTravel(Number(subData.expiresAtTs) + 60);
 
-    await t.client.revokeDelegation({
+    await t.client.revokeSubscription({
       authority: subscriber,
-      delegationAccount: subscriptionPda,
+      subscriptionPda,
       planPda,
     });
 
@@ -774,9 +774,9 @@ describe('Subscription Security', () => {
     ).data;
     expect(subAfterCancel.expiresAtTs).not.toBe(0n);
 
-    const { signature } = await t.client.revokeDelegation({
+    const { signature } = await t.client.revokeSubscription({
       authority: subscriber,
-      delegationAccount: subscriptionPda,
+      subscriptionPda,
       planPda,
     });
     expect(signature).toBeDefined();
@@ -1202,9 +1202,9 @@ describe('Subscription Security', () => {
       .data;
     expect(subData.expiresAtTs).toBeLessThanOrEqual(endTs);
 
-    const { signature } = await t.client.revokeDelegation({
+    const { signature } = await t.client.revokeSubscription({
       authority: subscriber,
-      delegationAccount: subscriptionPda,
+      subscriptionPda,
       planPda,
     });
     expect(signature).toBeDefined();

--- a/programs/multi_delegator/src/instructions/close_multidelegate.rs
+++ b/programs/multi_delegator/src/instructions/close_multidelegate.rs
@@ -9,13 +9,16 @@ use crate::{
 pub struct CloseMultiDelegateAccounts<'a> {
     pub user: &'a AccountView,
     pub multi_delegate: &'a AccountView,
+    /// Optional rent destination required when the recorded payer differs from
+    /// the user. Must match the stored `MultiDelegate.payer`.
+    pub receiver: Option<&'a AccountView>,
 }
 
 impl<'a> TryFrom<&'a [AccountView]> for CloseMultiDelegateAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a [AccountView]) -> Result<Self, Self::Error> {
-        let [user, multi_delegate] = accounts else {
+        let [user, multi_delegate, rem @ ..] = accounts else {
             return Err(MultiDelegatorError::NotEnoughAccountKeys.into());
         };
 
@@ -27,6 +30,7 @@ impl<'a> TryFrom<&'a [AccountView]> for CloseMultiDelegateAccounts<'a> {
         Ok(Self {
             user,
             multi_delegate,
+            receiver: rem.first(),
         })
     }
 }
@@ -34,29 +38,51 @@ impl<'a> TryFrom<&'a [AccountView]> for CloseMultiDelegateAccounts<'a> {
 /// Instruction discriminator byte for `CloseMultiDelegate`.
 pub const DISCRIMINATOR: &u8 = &6;
 
-/// Closes a MultiDelegate PDA account, returning the lamports to the user.
-/// Only the user who owns the MultiDelegate can close it.
+/// Closes a MultiDelegate PDA account, returning the lamports to the recorded
+/// payer (which is the user when no sponsor funded creation, or the sponsor
+/// otherwise).
+///
+/// Only the user who owns the MultiDelegate can close it. When the recorded
+/// payer differs from the user, an optional `receiver` account must be
+/// provided that matches the stored payer.
 pub fn process(accounts: &[AccountView]) -> ProgramResult {
     let accounts = CloseMultiDelegateAccounts::try_from(accounts)?;
 
-    let data = accounts.multi_delegate.try_borrow()?;
-    let multi_delegate = MultiDelegate::load(&data)?;
+    let (stored_payer, payer_is_user) = {
+        let data = accounts.multi_delegate.try_borrow()?;
+        let multi_delegate = MultiDelegate::load(&data)?;
 
-    multi_delegate.check_owner(accounts.user.address())?;
+        multi_delegate.check_owner(accounts.user.address())?;
 
-    // Verify the PDA derivation matches
-    let expected_pda = MultiDelegate::verify_pda(
-        &multi_delegate.user,
-        &multi_delegate.token_mint,
-        multi_delegate.bump,
-    )?;
-    if expected_pda.as_ref() != accounts.multi_delegate.address().as_ref() {
-        return Err(MultiDelegatorError::InvalidMultiDelegatePda.into());
+        // Verify the PDA derivation matches
+        let expected_pda = MultiDelegate::verify_pda(
+            &multi_delegate.user,
+            &multi_delegate.token_mint,
+            multi_delegate.bump,
+        )?;
+        if expected_pda.as_ref() != accounts.multi_delegate.address().as_ref() {
+            return Err(MultiDelegatorError::InvalidMultiDelegatePda.into());
+        }
+
+        let stored_payer = multi_delegate.payer;
+        let payer_is_user = stored_payer == *accounts.user.address();
+        (stored_payer, payer_is_user)
+    };
+
+    if payer_is_user {
+        // Self-funded — close to user (existing behavior).
+        ProgramAccount::close(accounts.multi_delegate, accounts.user)
+    } else {
+        // Sponsor-funded — require a receiver matching the stored payer.
+        let receiver = accounts
+            .receiver
+            .ok_or(MultiDelegatorError::NotEnoughAccountKeys)?;
+        WritableAccount::check(receiver)?;
+        if *receiver.address() != stored_payer {
+            return Err(MultiDelegatorError::Unauthorized.into());
+        }
+        ProgramAccount::close(accounts.multi_delegate, receiver)
     }
-
-    drop(data);
-
-    ProgramAccount::close(accounts.multi_delegate, accounts.user)
 }
 
 #[cfg(test)]
@@ -68,11 +94,11 @@ mod tests {
             asserts::TransactionResultExt,
             constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
             utils::{
-                init_ata, init_mint, init_wallet, initialize_multidelegate_action, setup,
-                CloseMultiDelegate,
+                init_ata, init_mint, init_wallet, initialize_multidelegate_action,
+                initialize_multidelegate_action_with_sponsor, setup, CloseMultiDelegate,
             },
         },
-        MultiDelegatorError,
+        MultiDelegate, MultiDelegatorError,
     };
 
     #[test]
@@ -247,6 +273,124 @@ mod tests {
             let res = build_and_send_transaction(litesvm, &[&fee_payer], &fee_payer.pubkey(), &ix);
             res.assert_err(MultiDelegatorError::NotSigner);
         }
+    }
+
+    #[test]
+    fn close_returns_rent_to_sponsor() {
+        let (litesvm, user) = &mut setup();
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+
+        let (res, multi_delegate_pda, _bump) =
+            initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor));
+        res.assert_ok();
+
+        // Stored payer should be the sponsor.
+        let account = litesvm.get_account(&multi_delegate_pda).unwrap();
+        let md = MultiDelegate::load(&account.data).unwrap();
+        assert_eq!(md.payer.to_bytes(), sponsor.pubkey().to_bytes());
+
+        let rent = account.lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        let res = CloseMultiDelegate::new(litesvm, user, mint)
+            .receiver(sponsor.pubkey())
+            .execute();
+        res.assert_ok();
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + rent - 10_000);
+    }
+
+    #[test]
+    fn close_without_receiver_when_sponsor_funded_fails() {
+        let (litesvm, user) = &mut setup();
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor))
+            .0
+            .assert_ok();
+
+        // No receiver passed → must fail because stored payer differs from user.
+        let res = CloseMultiDelegate::new(litesvm, user, mint).execute();
+        res.assert_err(MultiDelegatorError::NotEnoughAccountKeys);
+    }
+
+    #[test]
+    fn close_with_wrong_receiver_unauthorized() {
+        let (litesvm, user) = &mut setup();
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+        let attacker = init_wallet(litesvm, 1_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+
+        initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor))
+            .0
+            .assert_ok();
+
+        let res = CloseMultiDelegate::new(litesvm, user, mint)
+            .receiver(attacker.pubkey())
+            .execute();
+        res.assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn idempotent_init_preserves_original_payer() {
+        let (litesvm, user) = &mut setup();
+        let sponsor_a = init_wallet(litesvm, 10_000_000_000);
+        let sponsor_b = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+
+        // Sponsor A inits.
+        let (res, multi_delegate_pda, _) =
+            initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor_a));
+        res.assert_ok();
+
+        // Sponsor B re-runs init.
+        initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor_b))
+            .0
+            .assert_ok();
+
+        // Stored payer must remain sponsor A.
+        let account = litesvm.get_account(&multi_delegate_pda).unwrap();
+        let md = MultiDelegate::load(&account.data).unwrap();
+        assert_eq!(md.payer.to_bytes(), sponsor_a.pubkey().to_bytes());
     }
 
     #[test]

--- a/programs/multi_delegator/src/instructions/initialize_multidelegate.rs
+++ b/programs/multi_delegator/src/instructions/initialize_multidelegate.rs
@@ -23,13 +23,16 @@ pub struct InitializeMultiDelegateAccounts<'a> {
     pub user_ata: &'a AccountView,
     pub system_program: &'a AccountView,
     pub token_program: &'a AccountView,
+    /// The account funding rent. Defaults to `user` if no extra account is provided.
+    pub payer: &'a AccountView,
 }
 
 impl<'a> TryFrom<&'a [AccountView]> for InitializeMultiDelegateAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a [AccountView]) -> Result<Self, Self::Error> {
-        let [user, multi_delegate, token_mint, user_ata, system_program, token_program] = accounts
+        let [user, multi_delegate, token_mint, user_ata, system_program, token_program, rem @ ..] =
+            accounts
         else {
             return Err(MultiDelegatorError::NotEnoughAccountKeys.into());
         };
@@ -43,6 +46,14 @@ impl<'a> TryFrom<&'a [AccountView]> for InitializeMultiDelegateAccounts<'a> {
         TokenProgramInterface::check(token_program)?;
         SystemAccount::check(system_program)?;
 
+        let payer = if let Some(payer) = rem.first() {
+            SignerAccount::check(payer)?;
+            WritableAccount::check(payer)?;
+            payer
+        } else {
+            user
+        };
+
         Ok(Self {
             multi_delegate,
             user,
@@ -50,6 +61,7 @@ impl<'a> TryFrom<&'a [AccountView]> for InitializeMultiDelegateAccounts<'a> {
             user_ata,
             system_program,
             token_program,
+            payer,
         })
     }
 }
@@ -81,10 +93,16 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
         Seed::from(&bump_binding),
     ];
 
-    // Initialize the account if it doesn't exist
+    // Initialize the account if it doesn't exist.
+    //
+    // Idempotency note: when the PDA already exists (e.g., re-running init
+    // to refresh the SPL `Approve` after the user revoked it), the trailing
+    // optional `payer` account is intentionally NOT used to overwrite the
+    // stored payer. The original sponsor recorded at first creation remains
+    // the rent recipient on close.
     if accounts.multi_delegate.data_len() == 0 {
         ProgramAccount::init::<MultiDelegate>(
-            accounts.user,
+            accounts.payer,
             accounts.multi_delegate,
             &seeds,
             MultiDelegate::LEN,
@@ -96,6 +114,7 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
             &mut data,
             accounts.user.address(),
             accounts.token_mint.address(),
+            accounts.payer.address(),
             bump,
             init_id,
         )?;
@@ -109,6 +128,10 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
 
     // Approve delegation on the correct token program (SPL Token vs Token-2022).
     // The instruction data is the same, but the program id differs.
+    //
+    // Authority must be `accounts.user` (the ATA owner). A sponsor cannot
+    // approve on the user's ATA — sponsor only funds rent. The user must
+    // still sign this instruction so the Approve CPI succeeds.
     if accounts.token_program.address().eq(&TOKEN_2022_PROGRAM_ID) {
         Approve2022 {
             token_program: accounts.token_program.address(),
@@ -143,7 +166,10 @@ mod tests {
             constants::{
                 MINT_DECIMALS, SYSTEM_PROGRAM_ID, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID,
             },
-            utils::{fetch_account, init_ata, init_mint, initialize_multidelegate_action, setup},
+            utils::{
+                fetch_account, init_ata, init_mint, init_wallet, initialize_multidelegate_action,
+                initialize_multidelegate_action_with_sponsor, setup,
+            },
         },
         AccountDiscriminator, MultiDelegate, MultiDelegatorError,
     };
@@ -174,12 +200,53 @@ mod tests {
         );
         assert_eq!(multi_delegate.user.to_bytes(), user.pubkey().to_bytes());
         assert_eq!(multi_delegate.token_mint.to_bytes(), mint.to_bytes());
+        // Default payer is the user when no sponsor is supplied.
+        assert_eq!(multi_delegate.payer.to_bytes(), user.pubkey().to_bytes());
         assert_eq!(multi_delegate.bump, bump);
         assert!(multi_delegate.init_id >= 0);
 
         // Verify delegation
         let ata_account = fetch_account::<spl_token_2022::state::Account>(litesvm, &user_ata);
         assert!(ata_account.delegate.is_some());
+        assert_eq!(ata_account.delegate.unwrap(), multi_delegate_pda);
+        assert_eq!(ata_account.delegated_amount, u64::MAX);
+    }
+
+    #[test]
+    fn initialize_multidelegate_with_sponsor() {
+        let (litesvm, user) = &mut setup();
+        let sponsor = init_wallet(litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+
+        let user_balance_before = litesvm.get_account(&user.pubkey()).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        let (res, multi_delegate_pda, _bump) =
+            initialize_multidelegate_action_with_sponsor(litesvm, user, mint, Some(&sponsor));
+        res.assert_ok();
+
+        let account = litesvm.get_account(&multi_delegate_pda).unwrap();
+        let md = MultiDelegate::load(&account.data).unwrap();
+        assert_eq!(md.user.to_bytes(), user.pubkey().to_bytes());
+        assert_eq!(md.payer.to_bytes(), sponsor.pubkey().to_bytes());
+
+        // Sponsor pays both rent and the transaction fee. User must not be charged.
+        let user_balance_after = litesvm.get_account(&user.pubkey()).unwrap().lamports;
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert_eq!(user_balance_after, user_balance_before);
+        assert!(sponsor_balance_after < sponsor_balance_before);
+
+        // Verify Approve still went through with user as the ATA authority.
+        let ata_account = fetch_account::<spl_token_2022::state::Account>(litesvm, &user_ata);
         assert_eq!(ata_account.delegate.unwrap(), multi_delegate_pda);
         assert_eq!(ata_account.delegated_amount, u64::MAX);
     }
@@ -537,9 +604,13 @@ mod tests {
         }
     }
 
+    /// A trailing account is interpreted as the optional sponsor payer.
+    /// A non-signer extra must be rejected because the payer slot requires a
+    /// signer.
     #[test]
-    fn extra_accounts_rejected() {
+    fn non_signer_payer_rejected() {
         use solana_instruction::{AccountMeta, Instruction};
+        use solana_pubkey::Pubkey;
         use solana_signer::Signer;
 
         use crate::{
@@ -564,7 +635,8 @@ mod tests {
 
         let (multi_delegate_pda, _bump) = get_multidelegate_pda(&user.pubkey(), &mint);
 
-        let extra_account = user.pubkey();
+        // Random pubkey that is NOT a signer in this transaction.
+        let extra_account = Pubkey::new_unique();
 
         let ix = Instruction {
             program_id: PROGRAM_ID,
@@ -581,6 +653,6 @@ mod tests {
         };
 
         let res = build_and_send_transaction(litesvm, &[user], &user.pubkey(), &ix);
-        assert!(res.is_err());
+        res.assert_err(MultiDelegatorError::NotSigner);
     }
 }

--- a/programs/multi_delegator/src/instructions/revoke_delegation.rs
+++ b/programs/multi_delegator/src/instructions/revoke_delegation.rs
@@ -7,7 +7,7 @@ use pinocchio::{
 use crate::{
     check_and_update_version,
     state::{
-        common::AccountDiscriminator, fixed_delegation::FixedDelegation,
+        common::AccountDiscriminator, fixed_delegation::FixedDelegation, plan::Plan,
         recurring_delegation::RecurringDelegation, subscription_delegation::SubscriptionDelegation,
     },
     AccountCheck, AccountClose, Header, MultiDelegatorError, ProgramAccount, SignerAccount,
@@ -15,14 +15,18 @@ use crate::{
 };
 
 /// Validated accounts for the [`RevokeDelegation`](crate::MultiDelegatorInstruction::RevokeDelegation) instruction.
+///
+/// Trailing accounts (`rem`) are parsed inside `process` based on the
+/// delegation kind read from the account data, since the layout differs
+/// between fixed/recurring (just an optional `receiver`) and subscription
+/// (a required `plan_pda` followed by an optional `receiver`).
 pub struct RevokeDelegationAccounts<'a> {
-    /// The delegator revoking the delegation (must be signer + writable; receives rent if self-funded).
+    /// The delegator or sponsor revoking the delegation (must be signer + writable).
     pub authority: &'a AccountView,
     /// The delegation PDA to close.
     pub delegation_account: &'a AccountView,
-    /// Optional third-party account to receive rent (required when the original
-    /// payer differs from the delegator).
-    pub receiver: Option<&'a AccountView>,
+    /// Trailing accounts whose interpretation depends on delegation kind.
+    pub rem: &'a [AccountView],
 }
 
 impl<'a> TryFrom<&'a [AccountView]> for RevokeDelegationAccounts<'a> {
@@ -41,7 +45,7 @@ impl<'a> TryFrom<&'a [AccountView]> for RevokeDelegationAccounts<'a> {
         Ok(Self {
             authority,
             delegation_account,
-            receiver: rem.first(),
+            rem,
         })
     }
 }
@@ -52,9 +56,23 @@ pub const DISCRIMINATOR: &u8 = &3;
 /// Revokes a delegation by closing the delegation PDA.
 /// The rent lamports are returned to the original payer.
 ///
-/// For Fixed/Recurring delegations: the delegator can close at any time;
-/// a third-party sponsor (original payer) can close only after expiry.
-/// For Subscriptions: requires cancellation first (expires_at_ts != 0) and expiration in the past.
+/// Trailing-account layout depends on the delegation kind read from the
+/// account data:
+///
+/// * Fixed / Recurring: `[receiver?]` — `receiver` required when the original
+///   payer differs from the authority.
+/// * Subscription: `[plan_pda, receiver?]` — `plan_pda` always required;
+///   `receiver` required when the original payer differs from the authority.
+///
+/// Authorization rules:
+///
+/// * Fixed / Recurring: the delegator can close at any time. The sponsor
+///   (original payer) can close only after the delegation's `expiry_ts` is in
+///   the past (and non-zero).
+/// * Subscription: the subscriber (delegator) can close once `expires_at_ts`
+///   has elapsed (set by `cancel_subscription`). The sponsor can close when
+///   the plan ended naturally, the plan account was deleted, or the
+///   subscriber cancelled and the subscription expired.
 pub fn process(accounts: &[AccountView]) -> ProgramResult {
     let accounts = RevokeDelegationAccounts::try_from(accounts)?;
 
@@ -67,20 +85,52 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
 
         let kind = AccountDiscriminator::try_from(data[DISCRIMINATOR_OFFSET])?;
 
-        match kind {
+        let receiver = match kind {
             AccountDiscriminator::SubscriptionDelegation => {
                 check_and_update_version(&mut data)?;
                 let subscription = SubscriptionDelegation::load_with_min_size(&data)?;
-
-                if subscription.header.delegator != *accounts.authority.address() {
-                    return Err(MultiDelegatorError::Unauthorized.into());
-                }
-
-                // Subscription must be cancelled (expires_at_ts != 0) and expired
                 let current_ts = Clock::get()?.unix_timestamp;
-                if subscription.expires_at_ts == 0 || subscription.expires_at_ts > current_ts {
-                    return Err(MultiDelegatorError::SubscriptionNotCancelled.into());
+
+                // Subscription branch consumes `[plan_pda, receiver?]`.
+                let plan_pda = accounts
+                    .rem
+                    .first()
+                    .ok_or(MultiDelegatorError::NotEnoughAccountKeys)?;
+                let receiver = accounts.rem.get(1);
+
+                // Bind the passed plan_pda to the subscription via header.delegatee.
+                if subscription.header.delegatee != *plan_pda.address() {
+                    return Err(MultiDelegatorError::SubscriptionPlanMismatch.into());
                 }
+
+                let is_sponsor = check_is_sponsor(&data, accounts.authority)?;
+
+                if is_sponsor {
+                    // Sponsor can revoke when subscription is cancelled+expired,
+                    // when the plan account has been closed, or when the plan
+                    // ended naturally.
+                    let sub_expired =
+                        subscription.expires_at_ts != 0 && subscription.expires_at_ts <= current_ts;
+                    let plan_closed = !plan_pda.owned_by(&crate::ID);
+                    let plan_ended = if plan_closed {
+                        false
+                    } else {
+                        let plan_data = plan_pda.try_borrow()?;
+                        let plan = Plan::load(&plan_data)?;
+                        plan.data.end_ts != 0 && current_ts > plan.data.end_ts
+                    };
+
+                    if !(sub_expired || plan_closed || plan_ended) {
+                        return Err(MultiDelegatorError::Unauthorized.into());
+                    }
+                } else {
+                    // Subscriber: must have cancelled and waited out the period.
+                    if subscription.expires_at_ts == 0 || subscription.expires_at_ts > current_ts {
+                        return Err(MultiDelegatorError::SubscriptionNotCancelled.into());
+                    }
+                }
+
+                receiver
             }
             AccountDiscriminator::FixedDelegation | AccountDiscriminator::RecurringDelegation => {
                 let is_sponsor = check_is_sponsor(&data, accounts.authority)?;
@@ -101,11 +151,13 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
                         return Err(MultiDelegatorError::Unauthorized.into());
                     }
                 }
+
+                accounts.rem.first()
             }
             _ => return Err(MultiDelegatorError::InvalidAccountDiscriminator.into()),
-        }
+        };
 
-        resolve_destination(&data, &accounts)?
+        resolve_destination(&data, accounts.authority, receiver)?
     };
 
     ProgramAccount::close(accounts.delegation_account, destination)
@@ -138,18 +190,17 @@ fn check_is_sponsor(data: &[u8], authority: &AccountView) -> Result<bool, Progra
 /// authority directly; otherwise require a receiver account matching payer.
 fn resolve_destination<'a>(
     data: &[u8],
-    accounts: &RevokeDelegationAccounts<'a>,
+    authority: &'a AccountView,
+    receiver: Option<&'a AccountView>,
 ) -> Result<&'a AccountView, ProgramError> {
     let payer_bytes: &[u8; 32] = data[PAYER_OFFSET..PAYER_OFFSET + 32]
         .try_into()
         .map_err(|_| MultiDelegatorError::InvalidPayerData)?;
 
-    if payer_bytes == accounts.authority.address().as_ref() {
-        Ok(accounts.authority)
+    if payer_bytes == authority.address().as_ref() {
+        Ok(authority)
     } else {
-        let receiver = accounts
-            .receiver
-            .ok_or(MultiDelegatorError::NotEnoughAccountKeys)?;
+        let receiver = receiver.ok_or(MultiDelegatorError::NotEnoughAccountKeys)?;
         WritableAccount::check(receiver)?;
         if receiver.address().as_ref() != payer_bytes {
             return Err(MultiDelegatorError::Unauthorized.into());
@@ -539,11 +590,12 @@ mod tests {
 
     #[test]
     fn revoke_subscription_without_cancel_rejected() {
-        let (mut litesvm, alice, _merchant, _mint, _plan_pda, _, subscription_pda) =
+        let (mut litesvm, alice, _merchant, _mint, plan_pda, _, subscription_pda) =
             setup_with_subscription();
 
         // Try to revoke without cancelling first
-        let result = RevokeSubscription::new(&mut litesvm, &alice, subscription_pda).execute();
+        let result =
+            RevokeSubscription::new(&mut litesvm, &alice, subscription_pda, plan_pda).execute();
         result.assert_err(MultiDelegatorError::SubscriptionNotCancelled);
 
         // Account should still exist
@@ -567,7 +619,7 @@ mod tests {
         move_clock_forward(&mut litesvm, hours(1));
 
         // Then revoke
-        RevokeSubscription::new(&mut litesvm, &alice, subscription_pda)
+        RevokeSubscription::new(&mut litesvm, &alice, subscription_pda, plan_pda)
             .execute()
             .assert_ok();
 
@@ -594,7 +646,8 @@ mod tests {
                 .expires_at_ts(current_ts() + days(1) as i64)
                 .execute();
 
-        let result = RevokeSubscription::new(&mut litesvm, &alice, subscription_pda).execute();
+        let result =
+            RevokeSubscription::new(&mut litesvm, &alice, subscription_pda, plan_pda).execute();
         result.assert_err(MultiDelegatorError::SubscriptionNotCancelled);
 
         // Account should still exist
@@ -703,7 +756,7 @@ mod tests {
         account.data[VERSION_OFFSET] = 0;
         litesvm.set_account(subscription_pda, account).unwrap();
 
-        RevokeSubscription::new(&mut litesvm, &alice, subscription_pda)
+        RevokeSubscription::new(&mut litesvm, &alice, subscription_pda, plan_pda)
             .execute()
             .assert_err(MultiDelegatorError::MigrationRequired);
     }
@@ -1030,5 +1083,247 @@ mod tests {
         };
 
         build_and_send_transaction(litesvm, &[signer], &signer.pubkey(), &ix)
+    }
+
+    /// Helper: spin up a sponsor-funded subscription, returning everything callers
+    /// need to drive subsequent revoke-subscription tests.
+    fn setup_sponsored_subscription(
+        plan_end_ts: i64,
+    ) -> (
+        litesvm::LiteSVM,
+        solana_keypair::Keypair, // alice (subscriber)
+        solana_keypair::Keypair, // merchant
+        solana_keypair::Keypair, // sponsor
+        Pubkey,                  // plan_pda
+        Pubkey,                  // subscription_pda
+    ) {
+        use crate::tests::{
+            constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
+            pda::get_subscription_pda,
+            utils::{
+                init_ata, init_mint, init_wallet, initialize_multidelegate_action, setup,
+                CreatePlan, Subscribe,
+            },
+        };
+
+        let (mut litesvm, alice) = setup();
+        let merchant = solana_keypair::Keypair::new();
+        litesvm.airdrop(&merchant.pubkey(), 10_000_000_000).unwrap();
+        let sponsor = init_wallet(&mut litesvm, 10_000_000_000);
+
+        let mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+        let _alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+
+        initialize_multidelegate_action(&mut litesvm, &alice, mint)
+            .0
+            .assert_ok();
+
+        let (res, plan_pda) = CreatePlan::new(&mut litesvm, &merchant, mint)
+            .plan_id(1)
+            .amount(50_000_000)
+            .period_hours(1)
+            .end_ts(plan_end_ts)
+            .execute();
+        res.assert_ok();
+
+        let (_, plan_bump) = crate::tests::pda::get_plan_pda(&merchant.pubkey(), 1);
+
+        Subscribe::new(
+            &mut litesvm,
+            &alice,
+            merchant.pubkey(),
+            plan_pda,
+            1,
+            plan_bump,
+            mint,
+        )
+        .payer(&sponsor)
+        .execute()
+        .assert_ok();
+
+        let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+        (
+            litesvm,
+            alice,
+            merchant,
+            sponsor,
+            plan_pda,
+            subscription_pda,
+        )
+    }
+
+    #[test]
+    fn sponsor_revoke_subscription_when_plan_ended() {
+        let plan_end_ts = current_ts() + hours(2) as i64;
+        let (mut litesvm, _alice, _merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        let sub_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        // Move past plan end.
+        move_clock_forward(&mut litesvm, hours(3));
+
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, plan_pda)
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&subscription_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + sub_rent - 10_000);
+    }
+
+    #[test]
+    fn sponsor_revoke_subscription_when_plan_closed() {
+        use crate::{state::common::PlanStatus, tests::utils::DeletePlan};
+
+        let plan_end_ts = current_ts() + hours(2) as i64;
+        let (mut litesvm, _alice, merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Sunset, expire, and delete the plan.
+        crate::tests::utils::UpdatePlan::new(&mut litesvm, &merchant, plan_pda)
+            .status(PlanStatus::Sunset)
+            .end_ts(plan_end_ts)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, hours(3));
+
+        DeletePlan::new(&mut litesvm, &merchant, plan_pda)
+            .execute()
+            .assert_ok();
+
+        // Plan account is now system-owned (closed). Sponsor can revoke.
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, plan_pda)
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&subscription_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+    }
+
+    #[test]
+    fn sponsor_revoke_subscription_when_cancelled_and_expired() {
+        let plan_end_ts = current_ts() + days(30) as i64;
+        let (mut litesvm, alice, _merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Subscriber cancels.
+        CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda)
+            .execute()
+            .assert_ok();
+
+        // Wait for the cancellation period to end.
+        move_clock_forward(&mut litesvm, hours(2));
+
+        let sub_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, plan_pda)
+            .execute()
+            .assert_ok();
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + sub_rent - 10_000);
+    }
+
+    #[test]
+    fn sponsor_revoke_active_subscription_rejected() {
+        let plan_end_ts = current_ts() + days(30) as i64;
+        let (mut litesvm, _alice, _merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Plan still active, subscription not cancelled. Sponsor cannot revoke.
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, plan_pda)
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn sponsor_revoke_subscription_with_wrong_plan_pda_rejected() {
+        let plan_end_ts = current_ts() + hours(2) as i64;
+        let (mut litesvm, _alice, merchant, sponsor, _plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Create a second, unrelated plan.
+        let mint = init_mint(
+            &mut litesvm,
+            crate::tests::constants::TOKEN_PROGRAM_ID,
+            crate::tests::constants::MINT_DECIMALS,
+            1_000_000_000,
+            None,
+            &[],
+        );
+        let other_plan_end = current_ts() + days(60) as i64;
+        let (res, other_plan_pda) =
+            crate::tests::utils::CreatePlan::new(&mut litesvm, &merchant, mint)
+                .plan_id(99)
+                .amount(1_000)
+                .period_hours(24)
+                .end_ts(other_plan_end)
+                .execute();
+        res.assert_ok();
+
+        move_clock_forward(&mut litesvm, hours(3));
+
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, other_plan_pda)
+            .execute()
+            .assert_err(MultiDelegatorError::SubscriptionPlanMismatch);
+    }
+
+    #[test]
+    fn attacker_cannot_revoke_sponsor_funded_subscription() {
+        let plan_end_ts = current_ts() + hours(2) as i64;
+        let (mut litesvm, _alice, _merchant, _sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        let attacker = init_wallet(&mut litesvm, 10_000_000_000);
+
+        // Even after the plan expires, an attacker (not delegator and not payer)
+        // must not be able to revoke.
+        move_clock_forward(&mut litesvm, hours(3));
+
+        RevokeSubscription::new(&mut litesvm, &attacker, subscription_pda, plan_pda)
+            .execute()
+            .assert_err(MultiDelegatorError::Unauthorized);
+    }
+
+    #[test]
+    fn subscriber_revoke_routes_rent_to_sponsor() {
+        let plan_end_ts = current_ts() + days(30) as i64;
+        let (mut litesvm, alice, _merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Subscriber cancels and waits.
+        CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda)
+            .execute()
+            .assert_ok();
+        move_clock_forward(&mut litesvm, hours(2));
+
+        let sub_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        // Subscriber revokes but receiver = sponsor (because header.payer = sponsor).
+        RevokeSubscription::new(&mut litesvm, &alice, subscription_pda, plan_pda)
+            .receiver(sponsor.pubkey())
+            .execute()
+            .assert_ok();
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + sub_rent - 10_000);
     }
 }

--- a/programs/multi_delegator/src/instructions/revoke_delegation.rs
+++ b/programs/multi_delegator/src/instructions/revoke_delegation.rs
@@ -107,20 +107,25 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
 
                 if is_sponsor {
                     // Sponsor can revoke when subscription is cancelled+expired,
-                    // when the plan account has been closed, or when the plan
-                    // ended naturally.
+                    // when the plan account has been closed, when the plan
+                    // ended naturally, or when the same plan_id was deleted and
+                    // recreated with different terms — a "ghost" the
+                    // subscription can no longer pull from.
                     let sub_expired =
                         subscription.expires_at_ts != 0 && subscription.expires_at_ts <= current_ts;
                     let plan_closed = !plan_pda.owned_by(&crate::ID);
-                    let plan_ended = if plan_closed {
+                    let plan_ended_or_recreated = if plan_closed {
                         false
                     } else {
                         let plan_data = plan_pda.try_borrow()?;
                         let plan = Plan::load(&plan_data)?;
-                        plan.data.end_ts != 0 && current_ts > plan.data.end_ts
+                        let terms_mismatch =
+                            subscription.check_plan_terms(&plan.data.terms).is_err();
+                        let plan_ended = plan.data.end_ts != 0 && current_ts > plan.data.end_ts;
+                        terms_mismatch || plan_ended
                     };
 
-                    if !(sub_expired || plan_closed || plan_ended) {
+                    if !(sub_expired || plan_closed || plan_ended_or_recreated) {
                         return Err(MultiDelegatorError::Unauthorized.into());
                     }
                 } else {
@@ -1214,6 +1219,69 @@ mod tests {
         assert!(
             account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
         );
+    }
+
+    #[test]
+    fn sponsor_revoke_subscription_when_plan_recreated_with_different_terms() {
+        // Same-address ghost plan: merchant deletes the expired plan and
+        // recreates it under the same `plan_id` with different terms. The
+        // subscription is no longer pull-eligible (transfers fail via
+        // `check_plan_terms`), and the sponsor should be able to recover rent
+        // unilaterally even though `plan_closed` is false on the recreated PDA.
+        use crate::{state::common::PlanStatus, tests::utils::DeletePlan};
+
+        let plan_end_ts = current_ts() + hours(2) as i64;
+        let (mut litesvm, _alice, merchant, sponsor, plan_pda, subscription_pda) =
+            setup_sponsored_subscription(plan_end_ts);
+
+        // Sunset, expire, delete.
+        crate::tests::utils::UpdatePlan::new(&mut litesvm, &merchant, plan_pda)
+            .status(PlanStatus::Sunset)
+            .end_ts(plan_end_ts)
+            .execute()
+            .assert_ok();
+
+        move_clock_forward(&mut litesvm, hours(3));
+
+        DeletePlan::new(&mut litesvm, &merchant, plan_pda)
+            .execute()
+            .assert_ok();
+
+        // Recreate the same plan_id with different terms (ghost plan). End_ts
+        // is in the future so neither plan_ended nor plan_closed would fire.
+        let new_end_ts = current_ts() + days(60) as i64;
+        let mint = init_mint(
+            &mut litesvm,
+            crate::tests::constants::TOKEN_PROGRAM_ID,
+            crate::tests::constants::MINT_DECIMALS,
+            1_000_000_000,
+            None,
+            &[],
+        );
+        let (res, recreated_plan_pda) =
+            crate::tests::utils::CreatePlan::new(&mut litesvm, &merchant, mint)
+                .plan_id(1)
+                .amount(999_000_000)
+                .period_hours(720)
+                .end_ts(new_end_ts)
+                .execute();
+        res.assert_ok();
+        assert_eq!(recreated_plan_pda, plan_pda);
+
+        let sub_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        RevokeSubscription::new(&mut litesvm, &sponsor, subscription_pda, plan_pda)
+            .execute()
+            .assert_ok();
+
+        let account_after = litesvm.get_account(&subscription_pda);
+        assert!(
+            account_after.is_none() || account_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0
+        );
+
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after >= sponsor_balance_before + sub_rent - 10_000);
     }
 
     #[test]

--- a/programs/multi_delegator/src/instructions/subscribe.rs
+++ b/programs/multi_delegator/src/instructions/subscribe.rs
@@ -129,7 +129,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
     ];
 
     ProgramAccount::init::<()>(
-        accounts_struct.subscriber,
+        accounts_struct.payer,
         accounts_struct.subscription_pda,
         &seeds,
         SubscriptionDelegation::LEN,
@@ -148,7 +148,7 @@ pub fn process(accounts: &[AccountView], data: &SubscribeData) -> ProgramResult 
             bump,
             accounts_struct.subscriber.address(),
             accounts_struct.plan_pda.address(),
-            accounts_struct.subscriber.address(),
+            accounts_struct.payer.address(),
             init_id,
         );
 
@@ -186,13 +186,15 @@ pub struct SubscribeAccounts<'a> {
     pub system_program: &'a AccountView,
     pub event_authority: &'a AccountView,
     pub self_program: &'a AccountView,
+    /// The account funding rent. Defaults to `subscriber` if no extra account is provided.
+    pub payer: &'a AccountView,
 }
 
 impl<'a> TryFrom<&'a [AccountView]> for SubscribeAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a [AccountView]) -> Result<Self, Self::Error> {
-        let [subscriber, merchant, plan_pda, subscription_pda, multi_delegate_pda, system_program, event_authority, self_program] =
+        let [subscriber, merchant, plan_pda, subscription_pda, multi_delegate_pda, system_program, event_authority, self_program, rem @ ..] =
             accounts
         else {
             return Err(MultiDelegatorError::NotEnoughAccountKeys.into());
@@ -205,6 +207,14 @@ impl<'a> TryFrom<&'a [AccountView]> for SubscribeAccounts<'a> {
         MultiDelegateAccount::check(multi_delegate_pda)?;
         SystemAccount::check(system_program)?;
 
+        let payer = if let Some(payer) = rem.first() {
+            SignerAccount::check(payer)?;
+            WritableAccount::check(payer)?;
+            payer
+        } else {
+            subscriber
+        };
+
         Ok(Self {
             subscriber,
             merchant,
@@ -214,6 +224,7 @@ impl<'a> TryFrom<&'a [AccountView]> for SubscribeAccounts<'a> {
             system_program,
             event_authority,
             self_program,
+            payer,
         })
     }
 }
@@ -443,6 +454,44 @@ mod tests {
         .execute();
         // Should fail because multidelegate PDA doesn't exist (not owned by program)
         res.assert_err(MultiDelegatorError::InvalidMultiDelegatePda);
+    }
+
+    #[test]
+    fn subscribe_with_sponsor() {
+        use crate::tests::utils::init_wallet;
+
+        let end_ts = current_ts() + days(30) as i64;
+        let (mut litesvm, alice, merchant, mint, plan_pda, plan_bump) = setup_plan(1, end_ts);
+        let sponsor = init_wallet(&mut litesvm, 10_000_000_000);
+
+        let alice_balance_before = litesvm.get_account(&alice.pubkey()).unwrap().lamports;
+        let sponsor_balance_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+        let res = Subscribe::new(
+            &mut litesvm,
+            &alice,
+            merchant.pubkey(),
+            plan_pda,
+            1,
+            plan_bump,
+            mint,
+        )
+        .payer(&sponsor)
+        .execute();
+        res.assert_ok();
+
+        // Subscriber must not be charged.
+        let alice_balance_after = litesvm.get_account(&alice.pubkey()).unwrap().lamports;
+        assert_eq!(alice_balance_after, alice_balance_before);
+        let sponsor_balance_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+        assert!(sponsor_balance_after < sponsor_balance_before);
+
+        // header.payer should be sponsor.
+        let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+        let sub_account = litesvm.get_account(&subscription_pda).unwrap();
+        let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
+        assert_eq!(sub.header.payer.to_bytes(), sponsor.pubkey().to_bytes());
+        assert_eq!(sub.header.delegator.to_bytes(), alice.pubkey().to_bytes());
     }
 
     #[test]

--- a/programs/multi_delegator/src/state/multi_delegate.rs
+++ b/programs/multi_delegator/src/state/multi_delegate.rs
@@ -23,6 +23,9 @@ pub struct MultiDelegate {
     pub user: Address,
     /// The SPL token mint this delegation covers.
     pub token_mint: Address,
+    /// The account that funded the PDA creation. Receives rent on close.
+    /// Defaults to `user` when no separate sponsor was provided at init time.
+    pub payer: Address,
     /// PDA bump seed.
     pub bump: u8,
     /// Initialization identifier set from `Clock::slot` when the account is created.
@@ -44,6 +47,7 @@ impl MultiDelegate {
         bytes: &'a mut [u8],
         user: &Address,
         token_mint: &Address,
+        payer: &Address,
         bump: u8,
         init_id: i64,
     ) -> Result<&'a Self, ProgramError> {
@@ -54,6 +58,7 @@ impl MultiDelegate {
         account.discriminator = AccountDiscriminator::MultiDelegate as u8;
         account.user = *user;
         account.token_mint = *token_mint;
+        account.payer = *payer;
         account.bump = bump;
         account.init_id = init_id;
         Ok(account)

--- a/programs/multi_delegator/src/tests/utils.rs
+++ b/programs/multi_delegator/src/tests/utils.rs
@@ -266,26 +266,46 @@ pub fn initialize_multidelegate_action(
     payer: &Keypair,
     mint: Pubkey,
 ) -> (TransactionResult, Pubkey, u8) {
+    initialize_multidelegate_action_with_sponsor(litesvm, payer, mint, None)
+}
+
+pub fn initialize_multidelegate_action_with_sponsor(
+    litesvm: &mut LiteSVM,
+    user: &Keypair,
+    mint: Pubkey,
+    sponsor: Option<&Keypair>,
+) -> (TransactionResult, Pubkey, u8) {
     let token_program = litesvm.get_account(&mint).unwrap().owner;
     let user_ata =
-        get_associated_token_address_with_program_id(&payer.pubkey(), &mint, &token_program);
-    let (multi_delegate_pda, bump) = get_multidelegate_pda(&payer.pubkey(), &mint);
+        get_associated_token_address_with_program_id(&user.pubkey(), &mint, &token_program);
+    let (multi_delegate_pda, bump) = get_multidelegate_pda(&user.pubkey(), &mint);
+
+    let mut accounts = vec![
+        AccountMeta::new(user.pubkey(), true),
+        AccountMeta::new(multi_delegate_pda, false),
+        AccountMeta::new_readonly(mint, false),
+        AccountMeta::new(user_ata, false),
+        AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        AccountMeta::new_readonly(token_program, false),
+    ];
+
+    let mut signers: Vec<&Keypair> = vec![user];
+    let mut fee_payer = user.pubkey();
+
+    if let Some(sponsor) = sponsor {
+        accounts.push(AccountMeta::new(sponsor.pubkey(), true));
+        signers.push(sponsor);
+        fee_payer = sponsor.pubkey();
+    }
 
     let ix = Instruction {
         program_id: PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new(payer.pubkey(), true),
-            AccountMeta::new(multi_delegate_pda, false),
-            AccountMeta::new_readonly(mint, false),
-            AccountMeta::new(user_ata, false),
-            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
-            AccountMeta::new_readonly(token_program, false),
-        ],
+        accounts,
         data: vec![*initialize_multidelegate::DISCRIMINATOR],
     };
 
     (
-        build_and_send_transaction(litesvm, &[payer], &payer.pubkey(), &ix),
+        build_and_send_transaction(litesvm, &signers, &fee_payer, &ix),
         multi_delegate_pda,
         bump,
     )
@@ -587,6 +607,7 @@ pub struct CloseMultiDelegate<'a> {
     user: &'a Keypair,
     mint: Pubkey,
     custom_pda: Option<Pubkey>,
+    receiver: Option<Pubkey>,
 }
 
 impl<'a> CloseMultiDelegate<'a> {
@@ -596,6 +617,7 @@ impl<'a> CloseMultiDelegate<'a> {
             user,
             mint,
             custom_pda: None,
+            receiver: None,
         }
     }
 
@@ -604,15 +626,24 @@ impl<'a> CloseMultiDelegate<'a> {
         self
     }
 
+    pub fn receiver(mut self, receiver: Pubkey) -> Self {
+        self.receiver = Some(receiver);
+        self
+    }
+
     #[allow(clippy::result_large_err)]
     pub fn execute(self) -> TransactionResult {
         let (derived_pda, _) = get_multidelegate_pda(&self.user.pubkey(), &self.mint);
         let multi_delegate_pda = self.custom_pda.unwrap_or(derived_pda);
 
-        let accounts = vec![
+        let mut accounts = vec![
             AccountMeta::new(self.user.pubkey(), true),
             AccountMeta::new(multi_delegate_pda, false),
         ];
+
+        if let Some(receiver) = self.receiver {
+            accounts.push(AccountMeta::new(receiver, false));
+        }
 
         let ix = Instruction {
             program_id: PROGRAM_ID,
@@ -1083,6 +1114,7 @@ pub struct Subscribe<'a> {
     plan_id: u64,
     plan_bump: u8,
     mint: Pubkey,
+    payer: Option<&'a Keypair>,
 }
 
 impl<'a> Subscribe<'a> {
@@ -1103,7 +1135,13 @@ impl<'a> Subscribe<'a> {
             plan_id,
             plan_bump,
             mint,
+            payer: None,
         }
+    }
+
+    pub fn payer(mut self, payer: &'a Keypair) -> Self {
+        self.payer = Some(payer);
+        self
     }
 
     #[allow(clippy::result_large_err)]
@@ -1113,7 +1151,7 @@ impl<'a> Subscribe<'a> {
 
         let event_authority = Pubkey::new_from_array(event_authority_pda::ID.to_bytes());
 
-        let accounts = vec![
+        let mut accounts = vec![
             AccountMeta::new(self.subscriber.pubkey(), true),
             AccountMeta::new_readonly(self.merchant, false),
             AccountMeta::new_readonly(self.plan_pda, false),
@@ -1123,6 +1161,15 @@ impl<'a> Subscribe<'a> {
             AccountMeta::new_readonly(event_authority, false),
             AccountMeta::new_readonly(PROGRAM_ID, false),
         ];
+
+        let mut signers: Vec<&Keypair> = vec![self.subscriber];
+        let mut fee_payer = self.subscriber.pubkey();
+
+        if let Some(p) = self.payer {
+            accounts.push(AccountMeta::new(p.pubkey(), true));
+            signers.push(p);
+            fee_payer = p.pubkey();
+        }
 
         let data = [
             vec![*subscribe::DISCRIMINATOR],
@@ -1137,12 +1184,7 @@ impl<'a> Subscribe<'a> {
             data,
         };
 
-        build_and_send_transaction(
-            self.litesvm,
-            &[self.subscriber],
-            &self.subscriber.pubkey(),
-            &ix,
-        )
+        build_and_send_transaction(self.litesvm, &signers, &fee_payer, &ix)
     }
 }
 
@@ -1265,29 +1307,44 @@ pub fn setup_with_subscription() -> (
 
 pub struct RevokeSubscription<'a> {
     litesvm: &'a mut LiteSVM,
-    subscriber: &'a Keypair,
+    authority: &'a Keypair,
     subscription_pda: Pubkey,
+    plan_pda: Pubkey,
+    receiver: Option<Pubkey>,
 }
 
 impl<'a> RevokeSubscription<'a> {
     pub fn new(
         litesvm: &'a mut LiteSVM,
-        subscriber: &'a Keypair,
+        authority: &'a Keypair,
         subscription_pda: Pubkey,
+        plan_pda: Pubkey,
     ) -> Self {
         Self {
             litesvm,
-            subscriber,
+            authority,
             subscription_pda,
+            plan_pda,
+            receiver: None,
         }
+    }
+
+    pub fn receiver(mut self, receiver: Pubkey) -> Self {
+        self.receiver = Some(receiver);
+        self
     }
 
     #[allow(clippy::result_large_err)]
     pub fn execute(self) -> TransactionResult {
-        let accounts = vec![
-            AccountMeta::new(self.subscriber.pubkey(), true),
+        let mut accounts = vec![
+            AccountMeta::new(self.authority.pubkey(), true),
             AccountMeta::new(self.subscription_pda, false),
+            AccountMeta::new_readonly(self.plan_pda, false),
         ];
+
+        if let Some(receiver) = self.receiver {
+            accounts.push(AccountMeta::new(receiver, false));
+        }
 
         let ix = Instruction {
             program_id: PROGRAM_ID,
@@ -1297,8 +1354,8 @@ impl<'a> RevokeSubscription<'a> {
 
         build_and_send_transaction(
             self.litesvm,
-            &[self.subscriber],
-            &self.subscriber.pubkey(),
+            &[self.authority],
+            &self.authority.pubkey(),
             &ix,
         )
     }


### PR DESCRIPTION
## Summary
- Adds an optional trailing `payer` account to `subscribe` and `init_multi_delegate`, mirroring the pattern already used by `create_fixed_delegation` / `create_recurring_delegation` (`helpers/delegation.rs::CreateDelegationAccounts`). When supplied, the sponsor funds the PDA rent and is recorded in `header.payer` (subscription) or `MultiDelegate.payer` (root).
- Extends `revoke_delegation`'s subscription branch with a sponsor revoke path. The sponsor can revoke unilaterally when the plan ended naturally, the plan account was deleted, or the subscriber cancelled and the period elapsed. `plan_pda` is now a required trailing account for the subscription branch, used both for binding (`header.delegatee == plan_pda`) and for the plan-ended / plan-closed checks.
- `close_multi_delegate` now reads the stored `payer` and routes rent to a trailing optional `receiver` when payer ≠ user. Authority remains user-only — sponsor cannot force-close to avoid stranding active subscriptions.
- TypeScript builders updated: `buildSubscribe` and `buildInitMultiDelegate` accept `payer?`, `buildCloseMultiDelegate` accepts `receiver?`, `buildRevokeDelegation` accepts `planPda?` and `receiver?`. Existing call sites are unchanged.

## Breaking Changes
Pre-deploy program; no on-chain migration is required.
- `MultiDelegate` struct gains `payer: Address` between `token_mint` and `bump`. `MultiDelegate::LEN` grows by 32 bytes; `MultiDelegate::init` now takes a `payer` argument.
- `revoke_delegation` for subscription PDAs now requires a trailing `plan_pda` account (subscriber and sponsor paths both pass it).
- `close_multi_delegate` requires a trailing `receiver` account whenever the stored payer differs from the user.

## Test Plan
- [x] `just build-program` clean
- [x] `cargo test-sbf` — 209 / 209 pass (existing + new sponsor coverage)
- [x] `pnpm run generate` regenerates IDL + TS client without diff vs intended schema
- [x] `pnpm run build` (TS client) — ESM + CJS + DTS all green
- [x] `cargo clippy --workspace --exclude multidelegator-client --all-targets --no-deps -- -D warnings` — clean
- [x] Format check (Rust + biome) — clean (4 pre-existing warnings in `test/subscription-security.test.ts` unrelated to this PR)

New tests added:
- `initialize_multidelegate_with_sponsor`, `idempotent_init_preserves_original_payer`, `non_signer_payer_rejected`
- `close_returns_rent_to_sponsor`, `close_without_receiver_when_sponsor_funded_fails`, `close_with_wrong_receiver_unauthorized`
- `subscribe_with_sponsor` (asserts `header.payer == sponsor`)
- `sponsor_revoke_subscription_when_plan_ended` / `_when_plan_closed` / `_when_cancelled_and_expired`
- `sponsor_revoke_active_subscription_rejected`, `sponsor_revoke_subscription_with_wrong_plan_pda_rejected`
- `attacker_cannot_revoke_sponsor_funded_subscription`, `subscriber_revoke_routes_rent_to_sponsor`

## Notes
- Out of audit scope (Cantina baseline `b4b0345`). Recommend re-audit before mainnet.
- `MultiDelegate` rent recovery is voluntary — the user must initiate `close_multi_delegate`. No stale-timeout mechanism is added in this PR (treated as one-shot CAC, ~0.0014 SOL).