### PR TITLE
fix(webapp): filter stale subscription terms

### DIFF
--- a/clients/typescript/test/collect-utils.test.ts
+++ b/clients/typescript/test/collect-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import {
+  computeEligibleSubscribers,
+  getStalePlanSubscribers,
+  hasMatchingPlanTerms,
+  type PlanSubscriberForCollection,
+  type PlanTermsFingerprint,
+} from '../../../webapp/src/lib/collect-utils.ts';
+
+function createSubscriber(
+  subscriptionAddress: string,
+  terms: PlanTermsFingerprint,
+): PlanSubscriberForCollection {
+  return {
+    subscriptionAddress,
+    delegator: `${subscriptionAddress}-delegator`,
+    terms,
+    amountPulledInPeriod: 0n,
+    currentPeriodStartTs: 0n,
+    expiresAtTs: 0n,
+  };
+}
+
+describe('computeEligibleSubscribers', () => {
+  test('excludes same-amount same-period subscriptions from previous plan lifecycles', () => {
+    const planTerms = {
+      amount: 500_000n,
+      periodHours: 1n,
+      createdAt: 2_000n,
+    };
+    const staleSubscriber = createSubscriber('stale-subscription', {
+      ...planTerms,
+      createdAt: 1_000n,
+    });
+    const currentSubscriber = createSubscriber(
+      'current-subscription',
+      planTerms,
+    );
+
+    expect(hasMatchingPlanTerms(staleSubscriber, planTerms)).toBe(false);
+    expect(hasMatchingPlanTerms(currentSubscriber, planTerms)).toBe(true);
+    expect(
+      getStalePlanSubscribers(
+        [staleSubscriber, currentSubscriber],
+        planTerms,
+      ).map((subscriber) => subscriber.subscriptionAddress),
+    ).toEqual(['stale-subscription']);
+
+    expect(
+      computeEligibleSubscribers(
+        [staleSubscriber, currentSubscriber],
+        planTerms,
+        1_800,
+      ),
+    ).toEqual([
+      {
+        subscriptionAddress: 'current-subscription',
+        delegator: 'current-subscription-delegator',
+        collectAmount: 500_000n,
+      },
+    ]);
+  });
+});

--- a/webapp/src/components/plan/collect-payments-panel.tsx
+++ b/webapp/src/components/plan/collect-payments-panel.tsx
@@ -12,7 +12,7 @@ import { useSubscriptionsMutations } from '@/hooks/use-subscriptions-mutations'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
-import { computeEligibleSubscribers } from '@/lib/collect-utils'
+import { computeEligibleSubscribers, hasMatchingPlanTerms } from '@/lib/collect-utils'
 import { getCollectionHistory, addCollectionRecord, createSuccessRecord, createFailureRecord, type CollectionRecord } from '@/lib/collection-history'
 import { parsePlanMeta, ICON_MAP } from '@/lib/plan-constants'
 import { Star } from 'lucide-react'
@@ -64,19 +64,24 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
 
   const handleCollect = useCallback(async () => {
     setIsCollecting(true)
-    const totalSubs = subscriberCount
     try {
       const subscribers = await fetchPlanSubscriptions(rpcUrl, plan.address, progAddr)
       const ts = await getBlockTimestamp(rpcUrl)
       const eligible = computeEligibleSubscribers(
         subscribers,
-        plan.data.terms.amount,
-        plan.data.terms.periodHours,
+        plan.data.terms,
         ts,
       )
+      const currentSubscriberCount = subscribers.filter((sub) =>
+        hasMatchingPlanTerms(sub, plan.data.terms),
+      ).length
 
       if (eligible.length === 0) {
-        toast.info('All payments already collected this period')
+        toast.info(
+          currentSubscriberCount === 0 && subscribers.length > 0
+            ? 'Only stale subscriptions found for this plan'
+            : 'All payments already collected this period',
+        )
         setIsCollecting(false)
         return
       }
@@ -95,14 +100,14 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
         {
           onSuccess: (res) => {
             addCollectionRecord(createSuccessRecord(
-              plan.address, planName, res, totalSubs, amountUsd,
+              plan.address, planName, res, currentSubscriberCount, amountUsd,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
           },
           onError: (error) => {
             addCollectionRecord(createFailureRecord(
-              plan.address, planName, totalSubs, amountUsd, error,
+              plan.address, planName, currentSubscriberCount, amountUsd, error,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
@@ -113,7 +118,7 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
       toast.error(err instanceof Error ? err.message : 'Failed to collect')
       setIsCollecting(false)
     }
-  }, [rpcUrl, plan, subscriberCount, planName, amountUsd, collectSubscriptionPayments, progAddr])
+  }, [rpcUrl, plan, planName, amountUsd, collectSubscriptionPayments, progAddr])
 
   return (
     <div className="border border-emerald-500/15 bg-slate-900/60 rounded-xl p-4 space-y-3">

--- a/webapp/src/components/plan/enhanced-collect-payments.tsx
+++ b/webapp/src/components/plan/enhanced-collect-payments.tsx
@@ -16,7 +16,7 @@ import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
 import { fetchPlanSubscriptions } from '@/hooks/use-subscriptions'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
-import { computeEligibleSubscribers } from '@/lib/collect-utils'
+import { computeEligibleSubscribers, hasMatchingPlanTerms } from '@/lib/collect-utils'
 import { getCollectionHistory, addCollectionRecord, createSuccessRecord, createFailureRecord, clearCollectionHistory } from '@/lib/collection-history'
 import { parsePlanMeta, ICON_MAP } from '@/lib/plan-constants'
 import { USDC_MULTIPLIER, ellipsify, fmtDateShort } from '@/lib/utils'
@@ -127,7 +127,7 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const subscribers = await fetchPlanSubscriptions(rpcUrl, pd.plan.address, progAddr!)
         const eligible = computeEligibleSubscribers(
-          subscribers, pd.plan.data.terms.amount, pd.plan.data.terms.periodHours, ts,
+          subscribers, pd.plan.data.terms, ts,
         )
         if (eligible.length === 0) continue
         plans.push({
@@ -159,7 +159,7 @@ function CollectAllButton({
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
         const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
         addCollectionRecord(createSuccessRecord(
-          pd.plan.address, planName, res, pd.subscribers.length, amountUsd,
+          pd.plan.address, planName, res, pd.currentSubscribers.length, amountUsd,
         ))
       }
 
@@ -170,7 +170,7 @@ function CollectAllButton({
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
         const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
         addCollectionRecord(createFailureRecord(
-          pd.plan.address, planName, pd.subscribers.length, amountUsd, err,
+          pd.plan.address, planName, pd.currentSubscribers.length, amountUsd, err,
         ))
       }
       toast.error('Failed to collect payments')
@@ -208,12 +208,16 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
   const progAddr = useProgramAddress()
   const { collectSubscriptionPayments } = useSubscriptionsMutations()
 
-  const { plan, subscribers, eligible } = planData
+  const { plan, subscribers, currentSubscribers, staleSubscribers, eligible } = planData
   const meta = useMemo(() => parsePlanMeta(plan.data.metadataUri), [plan.data.metadataUri])
   const planName = meta.n || `Plan ${ellipsify(plan.address)}`
   const PlanIcon = (meta.i && ICON_MAP[meta.i]) || Star
   const amountUsd = Number(plan.data.terms.amount) / USDC_MULTIPLIER
   const pendingUsd = Number(planData.totalPending) / USDC_MULTIPLIER
+  const staleSubscriberAddresses = useMemo(
+    () => new Set(staleSubscribers.map((sub) => sub.subscriptionAddress)),
+    [staleSubscribers],
+  )
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const history = useMemo(() => getCollectionHistory(plan.address), [plan.address, historyVersion])
@@ -223,10 +227,17 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
     try {
       const subs = await fetchPlanSubscriptions(rpcUrl, plan.address, progAddr!)
       const ts = await getBlockTimestamp(rpcUrl)
-      const elig = computeEligibleSubscribers(subs, plan.data.terms.amount, plan.data.terms.periodHours, ts)
+      const elig = computeEligibleSubscribers(subs, plan.data.terms, ts)
+      const currentSubscriberCount = subs.filter((sub) =>
+        hasMatchingPlanTerms(sub, plan.data.terms),
+      ).length
 
       if (elig.length === 0) {
-        toast.info('All payments already collected this period')
+        toast.info(
+          currentSubscriberCount === 0 && subs.length > 0
+            ? 'Only stale subscriptions found for this plan'
+            : 'All payments already collected this period',
+        )
         setIsCollecting(false)
         return
       }
@@ -245,14 +256,14 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
         {
           onSuccess: (res) => {
             addCollectionRecord(createSuccessRecord(
-              plan.address, planName, res, subscribers.length, amountUsd,
+              plan.address, planName, res, currentSubscriberCount, amountUsd,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
           },
           onError: (error) => {
             addCollectionRecord(createFailureRecord(
-              plan.address, planName, subscribers.length, amountUsd, error,
+              plan.address, planName, currentSubscriberCount, amountUsd, error,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
@@ -263,7 +274,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
       toast.error(err instanceof Error ? err.message : 'Failed to collect')
       setIsCollecting(false)
     }
-  }, [rpcUrl, progAddr, plan, planName, amountUsd, subscribers.length, collectSubscriptionPayments])
+  }, [rpcUrl, progAddr, plan, planName, amountUsd, collectSubscriptionPayments])
 
   const periodHoursSec = Number(plan.data.terms.periodHours) * 3600
 
@@ -278,7 +289,8 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
           <div className="text-left">
             <p className="text-white font-medium">{planName}</p>
             <p className="text-sm text-slate-400">
-              ${amountUsd.toFixed(2)}/period &middot; {eligible.length}/{subscribers.length} eligible
+              ${amountUsd.toFixed(2)}/period &middot; {eligible.length}/{currentSubscribers.length} eligible
+              {staleSubscribers.length > 0 && ` / ${staleSubscribers.length} stale`}
             </p>
           </div>
         </div>
@@ -344,6 +356,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
                       const isCancelled = sub.expiresAtTs !== 0n && blockTs < Number(sub.expiresAtTs)
                       const periodEnd = Number(sub.currentPeriodStartTs) + periodHoursSec
                       const eligEntry = eligible.find((e) => e.subscriptionAddress === sub.subscriptionAddress)
+                      const isStale = staleSubscriberAddresses.has(sub.subscriptionAddress)
                       const collectibleUsd = eligEntry
                         ? Number(eligEntry.collectAmount) / USDC_MULTIPLIER
                         : null
@@ -358,7 +371,11 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
                             />
                           </TableCell>
                           <TableCell>
-                            {isActive ? (
+                            {isStale ? (
+                              <Badge className="bg-amber-500/20 text-amber-400 border-amber-500/30">
+                                Stale Terms
+                              </Badge>
+                            ) : isActive ? (
                               <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">
                                 Active
                               </Badge>
@@ -376,7 +393,9 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
                             {fmtDateShort(Number(sub.currentPeriodStartTs))} - {fmtDateShort(periodEnd)}
                           </TableCell>
                           <TableCell className="text-right">
-                            {collectibleUsd !== null ? (
+                            {isStale ? (
+                              <span className="text-amber-400">Excluded</span>
+                            ) : collectibleUsd !== null ? (
                               <span className="text-emerald-400 font-medium">
                                 ${collectibleUsd.toFixed(2)}
                               </span>

--- a/webapp/src/hooks/use-plan-subscribers.ts
+++ b/webapp/src/hooks/use-plan-subscribers.ts
@@ -4,12 +4,19 @@ import { useSubscriberCounts, fetchPlanSubscriptions, type PlanSubscriber } from
 import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
-import { computeEligibleSubscribers, type EligibleSubscriber } from '@/lib/collect-utils'
+import {
+  computeEligibleSubscribers,
+  getStalePlanSubscribers,
+  hasMatchingPlanTerms,
+  type EligibleSubscriber,
+} from '@/lib/collect-utils'
 import { useMemo } from 'react'
 
 export interface PlanSubscriberData {
   plan: PlanItem
   subscribers: PlanSubscriber[]
+  currentSubscribers: PlanSubscriber[]
+  staleSubscribers: PlanSubscriber[]
   eligible: EligibleSubscriber[]
   totalPending: bigint
   activeCount: number
@@ -44,19 +51,31 @@ export function useAllPlanSubscribers() {
       const planDataArr = await Promise.all(
         plansWithSubs.map(async (plan): Promise<PlanSubscriberData> => {
           const subscribers = await fetchPlanSubscriptions(rpcUrl, plan.address, progAddr!)
+          const staleSubscribers = getStalePlanSubscribers(subscribers, plan.data.terms)
+          const currentSubscribers = subscribers.filter((sub) =>
+            hasMatchingPlanTerms(sub, plan.data.terms),
+          )
           const eligible = computeEligibleSubscribers(
             subscribers,
-            plan.data.terms.amount,
-            plan.data.terms.periodHours,
+            plan.data.terms,
             blockTimestamp,
           )
           const totalPending = eligible.reduce((sum, e) => sum + e.collectAmount, 0n)
-          const activeCount = subscribers.filter((s) => s.expiresAtTs === 0n).length
-          const cancelledCount = subscribers.filter(
+          const activeCount = currentSubscribers.filter((s) => s.expiresAtTs === 0n).length
+          const cancelledCount = currentSubscribers.filter(
             (s) => s.expiresAtTs !== 0n && blockTimestamp < Number(s.expiresAtTs),
           ).length
 
-          return { plan, subscribers, eligible, totalPending, activeCount, cancelledCount }
+          return {
+            plan,
+            subscribers,
+            currentSubscribers,
+            staleSubscribers,
+            eligible,
+            totalPending,
+            activeCount,
+            cancelledCount,
+          }
         }),
       )
 

--- a/webapp/src/lib/collect-utils.ts
+++ b/webapp/src/lib/collect-utils.ts
@@ -1,29 +1,57 @@
-import type { PlanSubscriber } from '@/hooks/use-subscriptions'
-
 export interface EligibleSubscriber {
   subscriptionAddress: string
   delegator: string
   collectAmount: bigint
 }
 
+export interface PlanTermsFingerprint {
+  amount: bigint
+  periodHours: bigint
+  createdAt: bigint
+}
+
+export interface PlanSubscriberForCollection {
+  subscriptionAddress: string
+  delegator: string
+  terms: PlanTermsFingerprint
+  amountPulledInPeriod: bigint
+  currentPeriodStartTs: bigint
+  expiresAtTs: bigint
+}
+
+export function hasMatchingPlanTerms(
+  sub: PlanSubscriberForCollection,
+  planTerms: PlanTermsFingerprint,
+): boolean {
+  return sub.terms.amount === planTerms.amount
+    && sub.terms.periodHours === planTerms.periodHours
+    && sub.terms.createdAt === planTerms.createdAt
+}
+
+export function getStalePlanSubscribers<T extends PlanSubscriberForCollection>(
+  subscribers: T[],
+  planTerms: PlanTermsFingerprint,
+): T[] {
+  return subscribers.filter((sub) => !hasMatchingPlanTerms(sub, planTerms))
+}
+
 export function computeEligibleSubscribers(
-  subscribers: PlanSubscriber[],
-  planAmount: bigint,
-  periodHours: bigint,
+  subscribers: PlanSubscriberForCollection[],
+  planTerms: PlanTermsFingerprint,
   currentTs: number,
 ): EligibleSubscriber[] {
-  if (planAmount <= 0n || periodHours <= 0n) return []
+  if (planTerms.amount <= 0n || planTerms.periodHours <= 0n) return []
 
   const eligible: EligibleSubscriber[] = []
 
   for (const sub of subscribers) {
     if (sub.expiresAtTs !== 0n && currentTs >= Number(sub.expiresAtTs)) continue
-    if (sub.terms.amount !== planAmount || sub.terms.periodHours !== periodHours) continue
+    if (!hasMatchingPlanTerms(sub, planTerms)) continue
 
-    const periodEnd = Number(sub.currentPeriodStartTs) + Number(periodHours) * 3600
+    const periodEnd = Number(sub.currentPeriodStartTs) + Number(planTerms.periodHours) * 3600
     const collectAmount = currentTs >= periodEnd
-      ? planAmount
-      : planAmount - sub.amountPulledInPeriod
+      ? planTerms.amount
+      : planTerms.amount - sub.amountPulledInPeriod
 
     if (collectAmount <= 0n) continue
 


### PR DESCRIPTION
## Summary
- Include `createdAt` in webapp subscription collection eligibility checks.
- Exclude stale same-terms subscriptions from single-plan and collect-all batches.
- Surface stale subscription accounts separately in collection UI totals/table.
- Add a focused regression test for recreated same-terms plan filtering.

## Test Plan
- `pnpm --dir clients/typescript exec vitest run --config vitest.config.ts test/collect-utils.test.ts`
- `pnpm --dir clients/typescript build`
- `pnpm --dir webapp lint`
- `pnpm --dir webapp build`
- Pre-push `fmt-check` and `lint-check` passed.

## Breaking Changes
- None