### PR TITLE
fix(collection-history): record actual collection amounts

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --disable-warning=ExperimentalWarning --experimental-strip-types --test test/*.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/webapp/src/components/plan/collect-payments-panel.tsx
+++ b/webapp/src/components/plan/collect-payments-panel.tsx
@@ -13,12 +13,20 @@ import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
 import { computeEligibleSubscribers, hasMatchingPlanTerms } from '@/lib/collect-utils'
-import { getCollectionHistory, addCollectionRecord, createSuccessRecord, createFailureRecord, type CollectionRecord } from '@/lib/collection-history'
+import {
+  getCollectionHistory,
+  addCollectionRecord,
+  createSuccessRecord,
+  createFailureRecord,
+  getCollectionRecordTotalDisplayAmount,
+  type CollectionRecord,
+} from '@/lib/collection-history'
 import { parsePlanMeta, ICON_MAP } from '@/lib/plan-constants'
 import { Star } from 'lucide-react'
 
 export function HistoryEntry({ record }: { record: CollectionRecord }) {
   const isSuccess = record.status === 'success' || record.status === 'partial'
+  const totalAmount = getCollectionRecordTotalDisplayAmount(record, USDC_MULTIPLIER)
 
   return (
     <div className="flex items-center gap-3 bg-slate-800/50 border border-emerald-500/10 rounded-lg p-2 text-sm">
@@ -29,7 +37,7 @@ export function HistoryEntry({ record }: { record: CollectionRecord }) {
       )}
       <span className="text-slate-400 shrink-0">{fmtDateTime(record.timestamp)}</span>
       <span className="text-white">
-        ${record.amountPerSubscriber.toFixed(2)} from {record.subscribersCollected}/{record.subscribersTotal} subs
+        ${totalAmount.toFixed(2)} total from {record.subscribersCollected}/{record.subscribersTotal} subs
       </span>
       {isSuccess && record.signatures[0] && (
         <span className="ml-auto">
@@ -100,14 +108,14 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
         {
           onSuccess: (res) => {
             addCollectionRecord(createSuccessRecord(
-              plan.address, planName, res, currentSubscriberCount, amountUsd,
+              plan.address, planName, res.transfers, currentSubscriberCount, eligible.length,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
           },
           onError: (error) => {
             addCollectionRecord(createFailureRecord(
-              plan.address, planName, currentSubscriberCount, amountUsd, error,
+              plan.address, planName, currentSubscriberCount, error,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
@@ -118,7 +126,7 @@ function CollectPlanCard({ plan, subscriberCount, progAddr }: { plan: PlanItem; 
       toast.error(err instanceof Error ? err.message : 'Failed to collect')
       setIsCollecting(false)
     }
-  }, [rpcUrl, plan, planName, amountUsd, collectSubscriptionPayments, progAddr])
+  }, [rpcUrl, plan, planName, collectSubscriptionPayments, progAddr])
 
   return (
     <div className="border border-emerald-500/15 bg-slate-900/60 rounded-xl p-4 space-y-3">

--- a/webapp/src/components/plan/enhanced-collect-payments.tsx
+++ b/webapp/src/components/plan/enhanced-collect-payments.tsx
@@ -157,9 +157,17 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
-        const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
+        const planTransfers = res.transfers
+          .filter((transfer) => transfer.planAddress === pd.plan.address)
+          .map(({ subscriptionAddress, amount, signature }) => ({
+            subscriptionAddress,
+            amount,
+            signature,
+          }))
+        const attempted = plans.find((plan) => plan.planAddress === pd.plan.address)?.subscribers.length ?? 0
+        if (attempted === 0) continue
         addCollectionRecord(createSuccessRecord(
-          pd.plan.address, planName, res, pd.currentSubscribers.length, amountUsd,
+          pd.plan.address, planName, planTransfers, pd.currentSubscribers.length, attempted,
         ))
       }
 
@@ -168,9 +176,8 @@ function CollectAllButton({
       for (const pd of eligiblePlans) {
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
-        const amountUsd = Number(pd.plan.data.terms.amount) / USDC_MULTIPLIER
         addCollectionRecord(createFailureRecord(
-          pd.plan.address, planName, pd.currentSubscribers.length, amountUsd, err,
+          pd.plan.address, planName, pd.currentSubscribers.length, err,
         ))
       }
       toast.error('Failed to collect payments')
@@ -256,14 +263,14 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
         {
           onSuccess: (res) => {
             addCollectionRecord(createSuccessRecord(
-              plan.address, planName, res, currentSubscriberCount, amountUsd,
+              plan.address, planName, res.transfers, currentSubscriberCount, elig.length,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
           },
           onError: (error) => {
             addCollectionRecord(createFailureRecord(
-              plan.address, planName, currentSubscriberCount, amountUsd, error,
+              plan.address, planName, currentSubscriberCount, error,
             ))
             setHistoryVersion((v) => v + 1)
             setIsCollecting(false)
@@ -274,7 +281,7 @@ function EnhancedPlanCard({ planData, blockTs }: { planData: PlanSubscriberData;
       toast.error(err instanceof Error ? err.message : 'Failed to collect')
       setIsCollecting(false)
     }
-  }, [rpcUrl, progAddr, plan, planName, amountUsd, collectSubscriptionPayments])
+  }, [rpcUrl, progAddr, plan, planName, collectSubscriptionPayments])
 
   const periodHoursSec = Number(plan.data.terms.periodHours) * 3600
 

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -606,24 +606,34 @@ export function useSubscriptionsMutations() {
       );
 
       const signatures: string[] = [];
+      const transfers: Array<{ subscriptionAddress: string; amount: bigint; signature: string }> = [];
       let collected = 0;
       const batches = packInstructionBatches(transferIxs, signer, [createAtaIx]);
 
       for (let b = 0; b < batches.length; b++) {
         try {
-          signatures.push(await signAndSend(batches[b], signer));
-          collected += batches[b].length - (b === 0 ? 1 : 0);
+          const signature = await signAndSend(batches[b], signer);
+          const batchTransferCount = batches[b].length - (b === 0 ? 1 : 0);
+          signatures.push(signature);
+          transfers.push(
+            ...subscribers.slice(collected, collected + batchTransferCount).map((sub) => ({
+              subscriptionAddress: sub.subscriptionAddress,
+              amount: sub.amount,
+              signature,
+            })),
+          );
+          collected += batchTransferCount;
         } catch (err) {
           if (collected === 0) throw err;
           console.warn(
             `Batch failed after collecting ${collected}/${subscribers.length}:`,
             err instanceof Error ? err.message : err,
           );
-          return { signatures, collected, partial: true };
+          return { signatures, collected, partial: true, transfers };
         }
       }
 
-      return { signatures, collected, partial: false };
+      return { signatures, collected, partial: false, transfers };
     },
     onSuccess: (res) => {
       toast.onSuccess(res.signatures[0]);
@@ -653,6 +663,7 @@ export function useSubscriptionsMutations() {
       const ataIxs: any[] = [];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const transferIxs: any[] = [];
+      const transferRequests: Array<{ planAddress: string; subscriptionAddress: string; amount: bigint }> = [];
       const seenAtas = new Set<string>();
 
       for (const plan of plans) {
@@ -693,28 +704,42 @@ export function useSubscriptionsMutations() {
             programAddress: progId,
           });
           transferIxs.push(instructions[0]);
+          transferRequests.push({
+            planAddress: plan.planAddress,
+            subscriptionAddress: sub.subscriptionAddress,
+            amount: sub.amount,
+          });
         }
       }
 
       const signatures: string[] = [];
+      const transfers: Array<{ planAddress: string; subscriptionAddress: string; amount: bigint; signature: string }> = [];
       let collected = 0;
       const batches = packInstructionBatches(transferIxs, signer, ataIxs);
 
       for (let b = 0; b < batches.length; b++) {
         try {
-          signatures.push(await signAndSend(batches[b], signer));
-          collected += batches[b].length - (b === 0 ? ataIxs.length : 0);
+          const signature = await signAndSend(batches[b], signer);
+          const batchTransferCount = batches[b].length - (b === 0 ? ataIxs.length : 0);
+          signatures.push(signature);
+          transfers.push(
+            ...transferRequests.slice(collected, collected + batchTransferCount).map((transfer) => ({
+              ...transfer,
+              signature,
+            })),
+          );
+          collected += batchTransferCount;
         } catch (err) {
           if (collected === 0) throw err;
           console.warn(
             `Batch failed after collecting ${collected}/${transferIxs.length}:`,
             err instanceof Error ? err.message : err,
           );
-          return { signatures, collected, total: transferIxs.length, partial: true };
+          return { signatures, collected, total: transferIxs.length, partial: true, transfers };
         }
       }
 
-      return { signatures, collected, total: transferIxs.length, partial: false };
+      return { signatures, collected, total: transferIxs.length, partial: false, transfers };
     },
     onSuccess: (res) => {
       toast.onSuccess(res.signatures[0]);

--- a/webapp/src/lib/collection-history.ts
+++ b/webapp/src/lib/collection-history.ts
@@ -8,10 +8,24 @@ export interface CollectionRecord {
   planName: string
   subscribersCollected: number
   subscribersTotal: number
-  amountPerSubscriber: number
+  amountPerSubscriber?: number
+  totalAmount?: string
+  transfers?: CollectionTransfer[]
   status: 'success' | 'partial' | 'failed'
   signatures: string[]
   error?: string
+}
+
+export interface CollectionTransfer {
+  subscriptionAddress: string
+  amount: string
+  signature: string
+}
+
+export interface CollectionTransferInput {
+  subscriptionAddress: string
+  amount: bigint
+  signature: string
 }
 
 export function getCollectionHistory(planAddress?: string): CollectionRecord[] {
@@ -39,20 +53,28 @@ export function addCollectionRecord(record: CollectionRecord): void {
 export function createSuccessRecord(
   planAddress: string,
   planName: string,
-  res: { collected: number; partial: boolean; signatures: string[] },
+  transfers: CollectionTransferInput[],
   subscribersTotal: number,
-  amountPerSubscriber: number,
+  subscribersAttempted: number,
 ): CollectionRecord {
+  const storedTransfers = transfers.map((transfer) => ({
+    subscriptionAddress: transfer.subscriptionAddress,
+    amount: transfer.amount.toString(),
+    signature: transfer.signature,
+  }))
+  const totalAmount = transfers.reduce((sum, transfer) => sum + transfer.amount, 0n)
+
   return {
     id: crypto.randomUUID(),
     timestamp: Math.floor(Date.now() / 1000),
     planAddress,
     planName,
-    subscribersCollected: res.collected,
+    subscribersCollected: transfers.length,
     subscribersTotal,
-    amountPerSubscriber,
-    status: res.partial ? 'partial' : 'success',
-    signatures: res.signatures,
+    totalAmount: totalAmount.toString(),
+    transfers: storedTransfers,
+    status: transfers.length < subscribersAttempted ? 'partial' : 'success',
+    signatures: Array.from(new Set(storedTransfers.map((transfer) => transfer.signature))),
   }
 }
 
@@ -60,7 +82,6 @@ export function createFailureRecord(
   planAddress: string,
   planName: string,
   subscribersTotal: number,
-  amountPerSubscriber: number,
   error: unknown,
 ): CollectionRecord {
   return {
@@ -70,9 +91,21 @@ export function createFailureRecord(
     planName,
     subscribersCollected: 0,
     subscribersTotal,
-    amountPerSubscriber,
+    totalAmount: '0',
+    transfers: [],
     status: 'failed',
     signatures: [],
     error: error instanceof Error ? error.message : 'Unknown error',
   }
+}
+
+export function getCollectionRecordTotalDisplayAmount(
+  record: CollectionRecord,
+  amountMultiplier: number,
+): number {
+  if (record.totalAmount !== undefined) {
+    return Number(record.totalAmount) / amountMultiplier
+  }
+
+  return (record.amountPerSubscriber ?? 0) * record.subscribersCollected
 }

--- a/webapp/test/collection-history.test.ts
+++ b/webapp/test/collection-history.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { computeEligibleSubscribers } from '../src/lib/collect-utils.ts'
+import {
+  createSuccessRecord,
+  getCollectionRecordTotalDisplayAmount,
+} from '../src/lib/collection-history.ts'
+
+const USDC = 1_000_000n
+const USDC_MULTIPLIER = Number(USDC)
+
+describe('collection history', () => {
+  test('records same-period partial pulls using the actual remaining transfer amount', () => {
+    const planAmount = 10n * USDC
+    const currentTs = 1_700_000_000
+    const planTerms = { amount: planAmount, periodHours: 24n, createdAt: BigInt(currentTs - 3600) }
+    const subscriptionAddress = 'Sub111111111111111111111111111111111111111'
+
+    const eligible = computeEligibleSubscribers(
+      [{
+        subscriptionAddress,
+        delegator: 'Delegator1111111111111111111111111111111111',
+        terms: planTerms,
+        amountPulledInPeriod: 9n * USDC,
+        currentPeriodStartTs: BigInt(currentTs - 3600),
+        expiresAtTs: 0n,
+      }],
+      planTerms,
+      currentTs,
+    )
+    const transfer = eligible[0]
+
+    assert.ok(transfer)
+    assert.equal(transfer.collectAmount, 1n * USDC)
+
+    const record = createSuccessRecord(
+      'Plan111111111111111111111111111111111111111',
+      'Partial Plan',
+      [{
+        subscriptionAddress: transfer.subscriptionAddress,
+        amount: transfer.collectAmount,
+        signature: 'signature',
+      }],
+      1,
+      eligible.length,
+    )
+
+    assert.equal(record.totalAmount, (1n * USDC).toString())
+    assert.equal(record.amountPerSubscriber, undefined)
+    assert.deepEqual(record.transfers, [{
+      subscriptionAddress,
+      amount: (1n * USDC).toString(),
+      signature: 'signature',
+    }])
+    assert.equal(getCollectionRecordTotalDisplayAmount(record, USDC_MULTIPLIER), 1)
+    assert.equal(record.status, 'success')
+  })
+
+  test('marks partially completed collection attempts without counting uncollected subscribers', () => {
+    const record = createSuccessRecord(
+      'Plan111111111111111111111111111111111111111',
+      'Partial Batch Plan',
+      [{
+        subscriptionAddress: 'Sub111111111111111111111111111111111111111',
+        amount: 3n * USDC,
+        signature: 'signature-1',
+      }],
+      2,
+      2,
+    )
+
+    assert.equal(record.subscribersCollected, 1)
+    assert.equal(record.totalAmount, (3n * USDC).toString())
+    assert.equal(getCollectionRecordTotalDisplayAmount(record, USDC_MULTIPLIER), 3)
+    assert.equal(record.status, 'partial')
+  })
+})


### PR DESCRIPTION
## Summary
- persist actual successful subscription transfer amounts in collection history
- return transfer amount/signature metadata from single-plan and bulk collection mutations
- display collected totals in history and cover same-period partial pulls with a regression test

## Test Plan
- pnpm --dir webapp test
- pnpm --dir webapp lint
- git push pre-push hooks ran format and lint checks
- pnpm --dir webapp build currently fails in this checkout because @subscriptions/client generated/dist files are missing