### PR TITLE
fix(webapp): record collect-all history per plan

### DIFF
--- a/justfile
+++ b/justfile
@@ -190,6 +190,9 @@ kill-validator:
 webapp-run:
     ./scripts/start-webapp.sh
 
+webapp-test:
+    cd {{webapp_dir}} && node --experimental-strip-types --test test/*.test.ts
+
 # Kill all webapp processes and remove all generated state
 webapp-clean:
     #!/usr/bin/env bash

--- a/webapp/src/components/plan/enhanced-collect-payments.tsx
+++ b/webapp/src/components/plan/enhanced-collect-payments.tsx
@@ -115,14 +115,17 @@ function CollectAllButton({
     setCollecting(true)
     setProgress('Fetching subscribers...')
 
+    const plans: Array<{
+      planAddress: string
+      subscribers: Array<{ subscriptionAddress: string; delegator: string; amount: bigint }>
+      mint: string
+      destinations: string[]
+    }> = []
+    let submittedPlans: typeof plans = []
+    const planDataByAddress = new Map(eligiblePlans.map((pd) => [pd.plan.address, pd]))
+
     try {
       const ts = await getBlockTimestamp(rpcUrl)
-      const plans: Array<{
-        planAddress: string
-        subscribers: Array<{ subscriptionAddress: string; delegator: string; amount: bigint }>
-        mint: string
-        destinations: string[]
-      }> = []
 
       for (const pd of eligiblePlans) {
         const subscribers = await fetchPlanSubscriptions(rpcUrl, pd.plan.address, progAddr!)
@@ -152,28 +155,33 @@ function CollectAllButton({
       const totalIxs = plans.reduce((sum, p) => sum + p.subscribers.length, 0)
       setProgress(`Batching ${totalIxs} transfers across ${plans.length} plans...`)
 
+      submittedPlans = plans
       const res = await collectAllPlanPayments.mutateAsync({ plans })
 
-      for (const pd of eligiblePlans) {
+      for (const plan of plans) {
+        const pd = planDataByAddress.get(plan.planAddress)
+        const planResult = res.plans[plan.planAddress]
+        if (!pd || !planResult) continue
+
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
-        const planTransfers = res.transfers
-          .filter((transfer) => transfer.planAddress === pd.plan.address)
+        const planTransfers = planResult.transfers
           .map(({ subscriptionAddress, amount, signature }) => ({
             subscriptionAddress,
             amount,
             signature,
           }))
-        const attempted = plans.find((plan) => plan.planAddress === pd.plan.address)?.subscribers.length ?? 0
-        if (attempted === 0) continue
         addCollectionRecord(createSuccessRecord(
-          pd.plan.address, planName, planTransfers, pd.currentSubscribers.length, attempted,
+          pd.plan.address, planName, planTransfers, pd.currentSubscribers.length, planResult.total,
         ))
       }
 
       toast.success(`Collected ${res.collected}/${res.total} payments`)
     } catch (err) {
-      for (const pd of eligiblePlans) {
+      for (const plan of submittedPlans) {
+        const pd = planDataByAddress.get(plan.planAddress)
+        if (!pd) continue
+
         const meta = parsePlanMeta(pd.plan.data.metadataUri)
         const planName = meta.n || `Plan ${ellipsify(pd.plan.address)}`
         addCollectionRecord(createFailureRecord(

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { address } from "gill";
+import { address, type Instruction } from "gill";
 import {
   findAssociatedTokenPda,
   TOKEN_2022_PROGRAM_ADDRESS,
@@ -31,7 +31,8 @@ import { useWalletUiSigner } from "../components/solana/use-wallet-ui-signer";
 import { useWalletTransactionSignAndSend } from "../components/solana/use-wallet-transaction-sign-and-send";
 import { useTransactionToast } from "../components/use-transaction-toast";
 import { invalidateWithDelay } from "@/lib/utils";
-import { packInstructionBatches } from "@/lib/tx-packer";
+import { createAllPlanPaymentCollectionResult, type ConfirmedPlanTransfer } from "@/lib/collect-all-results";
+import { packInstructionBatches, packInstructionBatchesWithItems } from "@/lib/tx-packer";
 import { getBlockTimestamp } from "@/hooks/use-time-travel";
 import { useProgramAddress } from "@/hooks/use-token-config";
 
@@ -659,12 +660,21 @@ export function useSubscriptionsMutations() {
       if (!signer) throw new Error("Wallet not connected");
       if (!progId) throw new Error("Program address not configured");
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ataIxs: any[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const transferIxs: any[] = [];
-      const transferRequests: Array<{ planAddress: string; subscriptionAddress: string; amount: bigint }> = [];
+      type PendingTransferInstruction = {
+        planAddress: string;
+        subscriptionAddress: string;
+        delegator: string;
+        amount: bigint;
+        instruction: Instruction;
+      };
+
+      const ataIxs: Instruction[] = [];
+      const pendingTransfers: PendingTransferInstruction[] = [];
       const seenAtas = new Set<string>();
+      const planTotals = plans.map((plan) => ({
+        planAddress: plan.planAddress,
+        total: plan.subscribers.length,
+      }));
 
       for (const plan of plans) {
         const mintAddr = address(plan.mint);
@@ -703,46 +713,58 @@ export function useSubscriptionsMutations() {
             tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
             programAddress: progId,
           });
-          transferIxs.push(instructions[0]);
-          transferRequests.push({
+          pendingTransfers.push({
             planAddress: plan.planAddress,
             subscriptionAddress: sub.subscriptionAddress,
+            delegator: sub.delegator,
             amount: sub.amount,
+            instruction: instructions[0],
           });
         }
       }
 
       const signatures: string[] = [];
-      const transfers: Array<{ planAddress: string; subscriptionAddress: string; amount: bigint; signature: string }> = [];
-      let collected = 0;
-      const batches = packInstructionBatches(transferIxs, signer, ataIxs);
+      const confirmedTransfers: ConfirmedPlanTransfer[] = [];
+      const batches = packInstructionBatchesWithItems(pendingTransfers, signer, ataIxs);
 
       for (let b = 0; b < batches.length; b++) {
         try {
-          const signature = await signAndSend(batches[b], signer);
-          const batchTransferCount = batches[b].length - (b === 0 ? ataIxs.length : 0);
+          const signature = await signAndSend(batches[b].instructions, signer);
           signatures.push(signature);
-          transfers.push(
-            ...transferRequests.slice(collected, collected + batchTransferCount).map((transfer) => ({
-              ...transfer,
+          confirmedTransfers.push(
+            ...batches[b].items.map((transfer) => ({
+              planAddress: transfer.planAddress,
+              subscriptionAddress: transfer.subscriptionAddress,
+              delegator: transfer.delegator,
+              amount: transfer.amount,
+              batchIndex: b,
               signature,
             })),
           );
-          collected += batchTransferCount;
         } catch (err) {
-          if (collected === 0) throw err;
+          if (confirmedTransfers.length === 0) throw err;
           console.warn(
-            `Batch failed after collecting ${collected}/${transferIxs.length}:`,
+            `Batch failed after collecting ${confirmedTransfers.length}/${pendingTransfers.length}:`,
             err instanceof Error ? err.message : err,
           );
-          return { signatures, collected, total: transferIxs.length, partial: true, transfers };
+          return createAllPlanPaymentCollectionResult(
+            planTotals,
+            confirmedTransfers,
+            signatures,
+            true,
+          );
         }
       }
 
-      return { signatures, collected, total: transferIxs.length, partial: false, transfers };
+      return createAllPlanPaymentCollectionResult(
+        planTotals,
+        confirmedTransfers,
+        signatures,
+        false,
+      );
     },
     onSuccess: (res) => {
-      toast.onSuccess(res.signatures[0]);
+      if (res.signatures[0]) toast.onSuccess(res.signatures[0]);
       invalidateWithDelay(queryClient, [
         ["subscriberCounts"],
         ["get-token-accounts"],

--- a/webapp/src/lib/collect-all-results.ts
+++ b/webapp/src/lib/collect-all-results.ts
@@ -1,0 +1,91 @@
+export type ConfirmedPlanTransfer = {
+  planAddress: string
+  subscriptionAddress: string
+  delegator: string
+  amount: bigint
+  batchIndex: number
+  signature: string
+}
+
+export type PlanCollectionTotal = {
+  planAddress: string
+  total: number
+}
+
+export type PlanPaymentCollectionResult = {
+  planAddress: string
+  collected: number
+  total: number
+  partial: boolean
+  signatures: string[]
+  transfers: ConfirmedPlanTransfer[]
+}
+
+export type AllPlanPaymentCollectionResult = {
+  signatures: string[]
+  collected: number
+  total: number
+  partial: boolean
+  plans: Record<string, PlanPaymentCollectionResult>
+  transfers: ConfirmedPlanTransfer[]
+}
+
+export function createAllPlanPaymentCollectionResult(
+  planTotals: PlanCollectionTotal[],
+  transfers: ConfirmedPlanTransfer[],
+  signatures: string[],
+  partial: boolean,
+): AllPlanPaymentCollectionResult {
+  const plans: Record<string, PlanPaymentCollectionResult> = {}
+
+  for (const { planAddress, total } of planTotals) {
+    const existing = plans[planAddress]
+    if (existing) {
+      existing.total += total
+    } else {
+      plans[planAddress] = {
+        planAddress,
+        collected: 0,
+        total,
+        partial: false,
+        signatures: [],
+        transfers: [],
+      }
+    }
+  }
+
+  for (const transfer of transfers) {
+    plans[transfer.planAddress] ??= {
+      planAddress: transfer.planAddress,
+      collected: 0,
+      total: 0,
+      partial: false,
+      signatures: [],
+      transfers: [],
+    }
+
+    const plan = plans[transfer.planAddress]
+    plan.collected += 1
+    plan.transfers.push(transfer)
+    if (!plan.signatures.includes(transfer.signature)) {
+      plan.signatures.push(transfer.signature)
+    }
+  }
+
+  for (const plan of Object.values(plans)) {
+    plan.collected = Math.min(plan.collected, plan.total)
+    plan.partial = plan.collected < plan.total
+  }
+
+  const total = planTotals.reduce((sum, plan) => sum + plan.total, 0)
+  const collected = Object.values(plans).reduce((sum, plan) => sum + plan.collected, 0)
+
+  return {
+    signatures,
+    collected,
+    total,
+    partial: partial || collected < total,
+    plans,
+    transfers,
+  }
+}

--- a/webapp/src/lib/collection-history.ts
+++ b/webapp/src/lib/collection-history.ts
@@ -57,23 +57,25 @@ export function createSuccessRecord(
   subscribersTotal: number,
   subscribersAttempted: number,
 ): CollectionRecord {
-  const storedTransfers = transfers.map((transfer) => ({
+  const storedTransfers = transfers.slice(0, subscribersTotal).map((transfer) => ({
     subscriptionAddress: transfer.subscriptionAddress,
     amount: transfer.amount.toString(),
     signature: transfer.signature,
   }))
-  const totalAmount = transfers.reduce((sum, transfer) => sum + transfer.amount, 0n)
+  const totalAmount = storedTransfers.reduce((sum, transfer) => sum + BigInt(transfer.amount), 0n)
+  const subscribersCollected = storedTransfers.length
+  const attempted = Math.min(subscribersAttempted, subscribersTotal)
 
   return {
     id: crypto.randomUUID(),
     timestamp: Math.floor(Date.now() / 1000),
     planAddress,
     planName,
-    subscribersCollected: transfers.length,
+    subscribersCollected,
     subscribersTotal,
     totalAmount: totalAmount.toString(),
     transfers: storedTransfers,
-    status: transfers.length < subscribersAttempted ? 'partial' : 'success',
+    status: subscribersCollected < attempted ? 'partial' : 'success',
     signatures: Array.from(new Set(storedTransfers.map((transfer) => transfer.signature))),
   }
 }

--- a/webapp/src/lib/tx-packer.ts
+++ b/webapp/src/lib/tx-packer.ts
@@ -28,36 +28,57 @@ function txByteSize(instructions: Instruction[], feePayer: TransactionSendingSig
   }
 }
 
+export type InstructionBatch<T> = {
+  instructions: Instruction[]
+  items: T[]
+}
+
+export function packInstructionBatchesWithItems<T extends { instruction: Instruction }>(
+  items: T[],
+  feePayer: TransactionSendingSigner,
+  prefixIxs: Instruction[] = [],
+): InstructionBatch<T>[] {
+  if (items.length === 0) {
+    return prefixIxs.length > 0 ? [{ instructions: prefixIxs, items: [] }] : []
+  }
+
+  const batches: InstructionBatch<T>[] = []
+  let cursor = 0
+  let isFirst = true
+
+  while (cursor < items.length) {
+    const prefix = isFirst ? prefixIxs : []
+    let count = 0
+
+    for (let i = cursor; i < items.length; i++) {
+      const candidate = [
+        ...prefix,
+        ...items.slice(cursor, i + 1).map((item) => item.instruction),
+      ]
+      if (txByteSize(candidate, feePayer) > MAX_TX_BYTES) break
+      count = i - cursor + 1
+    }
+
+    const batchItems = items.slice(cursor, cursor + Math.max(count, 1))
+    batches.push({
+      instructions: [...prefix, ...batchItems.map((item) => item.instruction)],
+      items: batchItems,
+    })
+    cursor += batchItems.length
+    isFirst = false
+  }
+
+  return batches
+}
+
 export function packInstructionBatches(
   ixs: Instruction[],
   feePayer: TransactionSendingSigner,
   prefixIxs: Instruction[] = [],
 ): Instruction[][] {
-  if (ixs.length === 0) return prefixIxs.length > 0 ? [prefixIxs] : []
-
-  const batches: Instruction[][] = []
-  let cursor = 0
-  let isFirst = true
-
-  while (cursor < ixs.length) {
-    const prefix = isFirst ? prefixIxs : []
-    let count = 0
-
-    for (let i = cursor; i < ixs.length; i++) {
-      const candidate = [...prefix, ...ixs.slice(cursor, i + 1)]
-      if (txByteSize(candidate, feePayer) > MAX_TX_BYTES) break
-      count = i - cursor + 1
-    }
-
-    if (count === 0) {
-      batches.push([...prefix, ixs[cursor]])
-      cursor++
-    } else {
-      batches.push([...prefix, ...ixs.slice(cursor, cursor + count)])
-      cursor += count
-    }
-    isFirst = false
-  }
-
-  return batches
+  return packInstructionBatchesWithItems(
+    ixs.map((instruction) => ({ instruction })),
+    feePayer,
+    prefixIxs,
+  ).map((batch) => batch.instructions)
 }

--- a/webapp/test/collect-all-results.test.ts
+++ b/webapp/test/collect-all-results.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createAllPlanPaymentCollectionResult,
+  type ConfirmedPlanTransfer,
+} from '../src/lib/collect-all-results.ts'
+
+function transfer(
+  planAddress: string,
+  subscriptionAddress: string,
+  signature: string,
+  batchIndex: number,
+): ConfirmedPlanTransfer {
+  return {
+    planAddress,
+    subscriptionAddress,
+    delegator: `${subscriptionAddress}-delegator`,
+    amount: 1n,
+    batchIndex,
+    signature,
+  }
+}
+
+test('aggregates successful collect-all transfers by plan', () => {
+  const result = createAllPlanPaymentCollectionResult(
+    [
+      { planAddress: 'plan-a', total: 1 },
+      { planAddress: 'plan-b', total: 1 },
+    ],
+    [
+      transfer('plan-a', 'sub-a', 'sig-a', 0),
+      transfer('plan-b', 'sub-b', 'sig-b', 1),
+    ],
+    ['sig-a', 'sig-b'],
+    false,
+  )
+
+  assert.equal(result.collected, 2)
+  assert.equal(result.total, 2)
+  assert.equal(result.partial, false)
+  assert.equal(result.plans['plan-a'].collected, 1)
+  assert.equal(result.plans['plan-a'].total, 1)
+  assert.deepEqual(result.plans['plan-a'].signatures, ['sig-a'])
+  assert.equal(result.plans['plan-b'].collected, 1)
+  assert.equal(result.plans['plan-b'].total, 1)
+  assert.deepEqual(result.plans['plan-b'].signatures, ['sig-b'])
+})
+
+test('does not attach earlier plan signatures to plans skipped by a later failed batch', () => {
+  const result = createAllPlanPaymentCollectionResult(
+    [
+      { planAddress: 'plan-a', total: 1 },
+      { planAddress: 'plan-b', total: 1 },
+    ],
+    [transfer('plan-a', 'sub-a', 'sig-a', 0)],
+    ['sig-a'],
+    true,
+  )
+
+  assert.equal(result.collected, 1)
+  assert.equal(result.total, 2)
+  assert.equal(result.partial, true)
+  assert.equal(result.plans['plan-a'].partial, false)
+  assert.deepEqual(result.plans['plan-a'].signatures, ['sig-a'])
+  assert.equal(result.plans['plan-b'].collected, 0)
+  assert.equal(result.plans['plan-b'].total, 1)
+  assert.equal(result.plans['plan-b'].partial, true)
+  assert.deepEqual(result.plans['plan-b'].signatures, [])
+})
+
+test('marks a plan partial only for its own uncollected transfers', () => {
+  const result = createAllPlanPaymentCollectionResult(
+    [
+      { planAddress: 'plan-a', total: 2 },
+      { planAddress: 'plan-b', total: 1 },
+    ],
+    [
+      transfer('plan-a', 'sub-a-1', 'sig-a-1', 0),
+      transfer('plan-b', 'sub-b', 'sig-b', 0),
+    ],
+    ['sig-a-1', 'sig-b'],
+    true,
+  )
+
+  assert.equal(result.plans['plan-a'].collected, 1)
+  assert.equal(result.plans['plan-a'].partial, true)
+  assert.equal(result.plans['plan-b'].collected, 1)
+  assert.equal(result.plans['plan-b'].partial, false)
+})


### PR DESCRIPTION
## Summary
- Preserve transfer-to-plan metadata through collect-all batching
- Return plan-keyed collect-all results and write history from each plan's own transfers
- Clamp collection history counts and add regression coverage for partial collect-all failures

## Test Plan
- just webapp-test
- pnpm run lint
- pnpm run build

## Breaking Changes
- None