### PR TITLE
fix(webapp): isolate unpayable collection transfers

### DIFF
--- a/clients/typescript/test/webapp-collect-utils.test.ts
+++ b/clients/typescript/test/webapp-collect-utils.test.ts
@@ -1,0 +1,125 @@
+import { address, createNoopSigner, type Instruction } from 'gill';
+import { describe, expect, test } from 'vitest';
+import {
+  filterPayableSubscribers,
+  sendBatchedSubscriberInstructions,
+} from '../../../webapp/src/lib/collect-utils.ts';
+
+const PROGRAM_ADDRESS = address('11111111111111111111111111111111');
+
+function instruction(id: number): Instruction {
+  return {
+    programAddress: PROGRAM_ADDRESS,
+    accounts: [],
+    data: new Uint8Array([id]),
+  };
+}
+
+describe('webapp collection utilities', () => {
+  test('filters a zero-balance subscriber before transfer batching', async () => {
+    const mint = address('11111111111111111111111111111111');
+    const delegator = address('11111111111111111111111111111112');
+    const subscriber = {
+      subscriptionAddress: 'sub-zero-balance',
+      delegator,
+      amount: 1n,
+    };
+    const rpc = {
+      getAccountInfo: () => ({
+        send: async () => ({
+          value: {
+            data: {
+              parsed: {
+                info: {
+                  mint,
+                  owner: delegator,
+                  tokenAmount: { amount: '0' },
+                  delegate: '11111111111111111111111111111113',
+                  delegatedAmount: { amount: '18446744073709551615' },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    };
+
+    const result = await filterPayableSubscribers({
+      rpc,
+      subscribers: [subscriber],
+      mint,
+      tokenProgram: PROGRAM_ADDRESS,
+      programAddress: PROGRAM_ADDRESS,
+    });
+
+    expect(result.payable).toEqual([]);
+    expect(result.failures).toEqual([
+      {
+        subscriber,
+        reason: 'insufficient-balance',
+        message:
+          'Subscriber token account balance is below the collectible amount',
+      },
+    ]);
+  });
+
+  test('isolates a failing subscriber and continues sending valid transfers', async () => {
+    const signer = createNoopSigner(
+      address('11111111111111111111111111111112'),
+    );
+    const failingInstruction = instruction(2);
+    const sentInstructionIds: number[][] = [];
+
+    const result = await sendBatchedSubscriberInstructions({
+      feePayer: signer,
+      transfers: [
+        {
+          subscriber: {
+            subscriptionAddress: 'sub-1',
+            delegator: 'delegator-1',
+            amount: 1n,
+          },
+          instruction: instruction(1),
+        },
+        {
+          subscriber: {
+            subscriptionAddress: 'sub-2',
+            delegator: 'delegator-2',
+            amount: 1n,
+          },
+          instruction: failingInstruction,
+        },
+        {
+          subscriber: {
+            subscriptionAddress: 'sub-3',
+            delegator: 'delegator-3',
+            amount: 1n,
+          },
+          instruction: instruction(3),
+        },
+      ],
+      sendInstructions: async (instructions) => {
+        sentInstructionIds.push(instructions.map((ix) => ix.data[0] ?? -1));
+        if (instructions.includes(failingInstruction)) {
+          throw new Error('insufficient funds');
+        }
+        return `sig-${sentInstructionIds.length}`;
+      },
+    });
+
+    expect(result.collected).toBe(2);
+    expect(result.signatures).toEqual(['sig-2', 'sig-5']);
+    expect(result.failures).toEqual([
+      {
+        subscriber: {
+          subscriptionAddress: 'sub-2',
+          delegator: 'delegator-2',
+          amount: 1n,
+        },
+        reason: 'transfer-failed',
+        message: 'insufficient funds',
+      },
+    ]);
+    expect(sentInstructionIds).toEqual([[1, 2, 3], [1], [2, 3], [2], [3]]);
+  });
+});

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { address, type Instruction } from "gill";
+import { toast as sonnerToast } from "sonner";
+import { address, createSolanaRpc, type Instruction } from "gill";
 import {
   findAssociatedTokenPda,
   TOKEN_2022_PROGRAM_ADDRESS,
@@ -25,14 +26,20 @@ import {
   ZERO_ADDRESS,
   PlanStatus,
 } from "@subscriptions/client";
-import { createSolanaRpc } from "gill";
 import { useClusterConfig } from "@/hooks/use-cluster-config";
 import { useWalletUiSigner } from "../components/solana/use-wallet-ui-signer";
 import { useWalletTransactionSignAndSend } from "../components/solana/use-wallet-transaction-sign-and-send";
 import { useTransactionToast } from "../components/use-transaction-toast";
 import { invalidateWithDelay } from "@/lib/utils";
 import { createAllPlanPaymentCollectionResult, type ConfirmedPlanTransfer } from "@/lib/collect-all-results";
-import { packInstructionBatches, packInstructionBatchesWithItems } from "@/lib/tx-packer";
+import { packInstructionBatches } from "@/lib/tx-packer";
+import {
+  filterPayableSubscribers,
+  sendBatchedSubscriberInstructions,
+  type CollectableSubscriber,
+  type SubscriberPaymentFailure,
+  type SubscriberTransfer,
+} from "@/lib/collect-utils";
 import { getBlockTimestamp } from "@/hooks/use-time-travel";
 import { useProgramAddress } from "@/hooks/use-token-config";
 
@@ -572,6 +579,7 @@ export function useSubscriptionsMutations() {
 
       const mintAddr = address(mint);
       const planPda = address(planAddress);
+      const rpc = createSolanaRpc(rpcUrl);
 
       const firstDest = destinations.find((d) => d !== ZERO_ADDRESS);
       const receiverOwner = firstDest ? address(firstDest) : signer.address;
@@ -589,8 +597,16 @@ export function useSubscriptionsMutations() {
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
       });
 
-      const transferIxs = await Promise.all(
-        subscribers.map(async (sub) => {
+      const { payable, failures: preflightFailures } = await filterPayableSubscribers({
+        rpc,
+        subscribers,
+        mint: mintAddr,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        programAddress: progId,
+      });
+
+      const transferEntries: SubscriberTransfer[] = await Promise.all(
+        payable.map(async (sub) => {
           const { instructions } = await buildTransferSubscription({
             caller: signer,
             delegator: address(sub.delegator),
@@ -602,42 +618,49 @@ export function useSubscriptionsMutations() {
             tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
             programAddress: progId,
           });
-          return instructions[0];
+          return { subscriber: sub, instruction: instructions[0] };
         })
       );
 
       const signatures: string[] = [];
       const transfers: Array<{ subscriptionAddress: string; amount: bigint; signature: string }> = [];
+      const failures: SubscriberPaymentFailure[] = [...preflightFailures];
       let collected = 0;
-      const batches = packInstructionBatches(transferIxs, signer, [createAtaIx]);
 
-      for (let b = 0; b < batches.length; b++) {
-        try {
-          const signature = await signAndSend(batches[b], signer);
-          const batchTransferCount = batches[b].length - (b === 0 ? 1 : 0);
-          signatures.push(signature);
-          transfers.push(
-            ...subscribers.slice(collected, collected + batchTransferCount).map((sub) => ({
-              subscriptionAddress: sub.subscriptionAddress,
-              amount: sub.amount,
-              signature,
-            })),
-          );
-          collected += batchTransferCount;
-        } catch (err) {
-          if (collected === 0) throw err;
-          console.warn(
-            `Batch failed after collecting ${collected}/${subscribers.length}:`,
-            err instanceof Error ? err.message : err,
-          );
-          return { signatures, collected, partial: true, transfers };
-        }
+      if (transferEntries.length > 0) {
+        signatures.push(await signAndSend([createAtaIx], signer));
+        const result = await sendBatchedSubscriberInstructions({
+          transfers: transferEntries,
+          feePayer: signer,
+          sendInstructions: (instructions) => signAndSend(instructions, signer),
+        });
+        signatures.push(...result.signatures);
+        failures.push(...result.failures);
+        collected = result.collected;
+        transfers.push(
+          ...result.confirmed.map(({ subscriber, signature }) => ({
+            subscriptionAddress: subscriber.subscriptionAddress,
+            amount: subscriber.amount,
+            signature,
+          })),
+        );
       }
 
-      return { signatures, collected, partial: false, transfers };
+      return {
+        signatures,
+        collected,
+        total: subscribers.length,
+        partial: failures.length > 0,
+        failures,
+        transfers,
+      };
     },
     onSuccess: (res) => {
-      toast.onSuccess(res.signatures[0]);
+      if (res.signatures[0]) toast.onSuccess(res.signatures[0]);
+      if (res.failures.length > 0) {
+        sonnerToast.warning(`Skipped ${res.failures.length} unpayable subscriber payment${res.failures.length === 1 ? "" : "s"}`);
+        console.warn(`Skipped ${res.failures.length} unpayable subscriber payments`, res.failures);
+      }
       invalidateWithDelay(queryClient, [
         ["subscriberCounts"],
         ["get-token-accounts"],
@@ -660,17 +683,13 @@ export function useSubscriptionsMutations() {
       if (!signer) throw new Error("Wallet not connected");
       if (!progId) throw new Error("Program address not configured");
 
-      type PendingTransferInstruction = {
-        planAddress: string;
-        subscriptionAddress: string;
-        delegator: string;
-        amount: bigint;
-        instruction: Instruction;
-      };
+      type PlanTransferSubscriber = CollectableSubscriber & { planAddress: string };
 
+      const rpc = createSolanaRpc(rpcUrl);
       const ataIxs: Instruction[] = [];
-      const pendingTransfers: PendingTransferInstruction[] = [];
+      const transferEntries: SubscriberTransfer<PlanTransferSubscriber>[] = [];
       const seenAtas = new Set<string>();
+      const preflightFailures: SubscriberPaymentFailure<PlanTransferSubscriber>[] = [];
       const planTotals = plans.map((plan) => ({
         planAddress: plan.planAddress,
         total: plan.subscribers.length,
@@ -679,6 +698,20 @@ export function useSubscriptionsMutations() {
       for (const plan of plans) {
         const mintAddr = address(plan.mint);
         const planPda = address(plan.planAddress);
+        const subscribersWithPlan = plan.subscribers.map((sub) => ({
+          ...sub,
+          planAddress: plan.planAddress,
+        }));
+        const { payable, failures } = await filterPayableSubscribers({
+          rpc,
+          subscribers: subscribersWithPlan,
+          mint: mintAddr,
+          tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+          programAddress: progId,
+        });
+        preflightFailures.push(...failures);
+        if (payable.length === 0) continue;
+
         const firstDest = plan.destinations.find((d) => d !== ZERO_ADDRESS);
         const receiverOwner = firstDest ? address(firstDest) : signer.address;
         const [receiverAta] = await findAssociatedTokenPda({
@@ -701,7 +734,7 @@ export function useSubscriptionsMutations() {
           );
         }
 
-        for (const sub of plan.subscribers) {
+        for (const sub of payable) {
           const { instructions } = await buildTransferSubscription({
             caller: signer,
             delegator: address(sub.delegator),
@@ -713,58 +746,55 @@ export function useSubscriptionsMutations() {
             tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
             programAddress: progId,
           });
-          pendingTransfers.push({
-            planAddress: plan.planAddress,
-            subscriptionAddress: sub.subscriptionAddress,
-            delegator: sub.delegator,
-            amount: sub.amount,
-            instruction: instructions[0],
-          });
+          transferEntries.push({ subscriber: sub, instruction: instructions[0] });
         }
       }
 
       const signatures: string[] = [];
       const confirmedTransfers: ConfirmedPlanTransfer[] = [];
-      const batches = packInstructionBatchesWithItems(pendingTransfers, signer, ataIxs);
+      const failures: SubscriberPaymentFailure<PlanTransferSubscriber>[] = [...preflightFailures];
 
-      for (let b = 0; b < batches.length; b++) {
-        try {
-          const signature = await signAndSend(batches[b].instructions, signer);
-          signatures.push(signature);
-          confirmedTransfers.push(
-            ...batches[b].items.map((transfer) => ({
-              planAddress: transfer.planAddress,
-              subscriptionAddress: transfer.subscriptionAddress,
-              delegator: transfer.delegator,
-              amount: transfer.amount,
-              batchIndex: b,
-              signature,
-            })),
-          );
-        } catch (err) {
-          if (confirmedTransfers.length === 0) throw err;
-          console.warn(
-            `Batch failed after collecting ${confirmedTransfers.length}/${pendingTransfers.length}:`,
-            err instanceof Error ? err.message : err,
-          );
-          return createAllPlanPaymentCollectionResult(
-            planTotals,
-            confirmedTransfers,
-            signatures,
-            true,
-          );
+      if (transferEntries.length > 0) {
+        const ataBatches = packInstructionBatches(ataIxs, signer);
+        for (const batch of ataBatches) {
+          signatures.push(await signAndSend(batch, signer));
         }
+
+        const result = await sendBatchedSubscriberInstructions({
+          transfers: transferEntries,
+          feePayer: signer,
+          sendInstructions: (instructions) => signAndSend(instructions, signer),
+        });
+        signatures.push(...result.signatures);
+        failures.push(...result.failures);
+        confirmedTransfers.push(
+          ...result.confirmed.map(({ subscriber, signature }) => ({
+            planAddress: subscriber.planAddress,
+            subscriptionAddress: subscriber.subscriptionAddress,
+            delegator: subscriber.delegator,
+            amount: subscriber.amount,
+            batchIndex: signatures.indexOf(signature),
+            signature,
+          })),
+        );
       }
 
-      return createAllPlanPaymentCollectionResult(
-        planTotals,
-        confirmedTransfers,
-        signatures,
-        false,
-      );
+      return {
+        ...createAllPlanPaymentCollectionResult(
+          planTotals,
+          confirmedTransfers,
+          signatures,
+          failures.length > 0,
+        ),
+        failures,
+      };
     },
     onSuccess: (res) => {
       if (res.signatures[0]) toast.onSuccess(res.signatures[0]);
+      if (res.failures.length > 0) {
+        sonnerToast.warning(`Skipped ${res.failures.length} unpayable subscriber payment${res.failures.length === 1 ? "" : "s"}`);
+        console.warn(`Skipped ${res.failures.length} unpayable subscriber payments`, res.failures);
+      }
       invalidateWithDelay(queryClient, [
         ["subscriberCounts"],
         ["get-token-accounts"],

--- a/webapp/src/lib/collect-utils.ts
+++ b/webapp/src/lib/collect-utils.ts
@@ -1,3 +1,20 @@
+import {
+  address,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+  type Address,
+  type Instruction,
+  type TransactionSendingSigner,
+} from 'gill'
+import { findAssociatedTokenPda } from 'gill/programs/token'
+import { packInstructionBatches } from './tx-packer'
+
+const SUBSCRIPTION_AUTHORITY_SEED = 'SubscriptionAuthority'
+const FAILURE_CACHE_STORAGE_KEY = 'collect-payments-subscriber-failures'
+
+const addressEncoder = getAddressEncoder()
+const textEncoder = new TextEncoder()
+
 export interface EligibleSubscriber {
   subscriptionAddress: string
   delegator: string
@@ -17,6 +34,75 @@ export interface PlanSubscriberForCollection {
   amountPulledInPeriod: bigint
   currentPeriodStartTs: bigint
   expiresAtTs: bigint
+}
+
+export interface CollectableSubscriber {
+  subscriptionAddress: string
+  delegator: string
+  amount: bigint
+}
+
+export interface SubscriberTransfer<TSubscriber extends CollectableSubscriber = CollectableSubscriber> {
+  subscriber: TSubscriber
+  instruction: Instruction
+}
+
+export interface ConfirmedSubscriberTransfer<TSubscriber extends CollectableSubscriber = CollectableSubscriber> {
+  subscriber: TSubscriber
+  signature: string
+}
+
+export type SubscriberPaymentFailureReason =
+  | 'known-unpayable-token-state'
+  | 'missing-token-account'
+  | 'invalid-token-account'
+  | 'wrong-mint'
+  | 'wrong-owner'
+  | 'insufficient-balance'
+  | 'wrong-delegate'
+  | 'insufficient-delegated-amount'
+  | 'transfer-failed'
+
+export interface SubscriberPaymentFailure<TSubscriber extends CollectableSubscriber = CollectableSubscriber> {
+  subscriber: TSubscriber
+  reason: SubscriberPaymentFailureReason
+  message: string
+}
+
+export interface PayableSubscribersResult<TSubscriber extends CollectableSubscriber = CollectableSubscriber> {
+  payable: TSubscriber[]
+  failures: SubscriberPaymentFailure<TSubscriber>[]
+}
+
+export interface SubscriberInstructionSendResult<TSubscriber extends CollectableSubscriber = CollectableSubscriber> {
+  signatures: string[]
+  confirmed: ConfirmedSubscriberTransfer<TSubscriber>[]
+  collected: number
+  failures: SubscriberPaymentFailure<TSubscriber>[]
+}
+
+interface TokenAccountRpc {
+  getAccountInfo(
+    account: Address,
+    config: { encoding: 'jsonParsed'; commitment: 'confirmed' },
+  ): {
+    send(): Promise<{ value: unknown }>
+  }
+}
+
+interface ParsedTokenAccount {
+  mint: string
+  owner: string
+  balance: bigint
+  delegate: string | null
+  delegatedAmount: bigint
+}
+
+interface CachedFailure {
+  reason: SubscriberPaymentFailureReason
+  message: string
+  stateHash: string
+  failedAt: number
 }
 
 export function hasMatchingPlanTerms(
@@ -63,4 +149,320 @@ export function computeEligibleSubscribers(
   }
 
   return eligible
+}
+
+export async function filterPayableSubscribers<TSubscriber extends CollectableSubscriber>({
+  rpc,
+  subscribers,
+  mint,
+  tokenProgram,
+  programAddress,
+}: {
+  rpc: TokenAccountRpc
+  subscribers: TSubscriber[]
+  mint: Address
+  tokenProgram: Address
+  programAddress: Address
+}): Promise<PayableSubscribersResult<TSubscriber>> {
+  const results = await Promise.all(
+    subscribers.map((subscriber) =>
+      checkSubscriberTokenReadiness({
+        rpc,
+        subscriber,
+        mint,
+        tokenProgram,
+        programAddress,
+      }),
+    ),
+  )
+
+  const payable: TSubscriber[] = []
+  const failures: SubscriberPaymentFailure<TSubscriber>[] = []
+
+  for (const result of results) {
+    if (result.failure) {
+      failures.push(result.failure)
+    } else {
+      payable.push(result.subscriber)
+    }
+  }
+
+  return { payable, failures }
+}
+
+export async function sendBatchedSubscriberInstructions<TSubscriber extends CollectableSubscriber>({
+  transfers,
+  feePayer,
+  sendInstructions,
+}: {
+  transfers: SubscriberTransfer<TSubscriber>[]
+  feePayer: TransactionSendingSigner
+  sendInstructions: (instructions: Instruction[]) => Promise<string>
+}): Promise<SubscriberInstructionSendResult<TSubscriber>> {
+  const signatures: string[] = []
+  const confirmed: ConfirmedSubscriberTransfer<TSubscriber>[] = []
+  const failures: SubscriberPaymentFailure<TSubscriber>[] = []
+  let collected = 0
+  const transferByInstruction = new Map<Instruction, SubscriberTransfer<TSubscriber>>()
+
+  for (const transfer of transfers) {
+    transferByInstruction.set(transfer.instruction, transfer)
+  }
+
+  const batches = packInstructionBatches(
+    transfers.map((transfer) => transfer.instruction),
+    feePayer,
+  )
+
+  async function sendGroup(group: SubscriberTransfer<TSubscriber>[]): Promise<void> {
+    if (group.length === 0) return
+
+    try {
+      const signature = await sendInstructions(group.map((transfer) => transfer.instruction))
+      signatures.push(signature)
+      collected += group.length
+      for (const transfer of group) {
+        confirmed.push({ subscriber: transfer.subscriber, signature })
+        clearCachedFailure(transfer.subscriber)
+      }
+    } catch (err) {
+      if (group.length === 1) {
+        const [transfer] = group
+        failures.push({
+          subscriber: transfer.subscriber,
+          reason: 'transfer-failed',
+          message: errorMessage(err),
+        })
+        return
+      }
+
+      const mid = Math.floor(group.length / 2)
+      await sendGroup(group.slice(0, mid))
+      await sendGroup(group.slice(mid))
+    }
+  }
+
+  for (const batch of batches) {
+    const group = batch
+      .map((instruction) => transferByInstruction.get(instruction))
+      .filter((transfer): transfer is SubscriberTransfer<TSubscriber> => transfer !== undefined)
+    await sendGroup(group)
+  }
+
+  return { signatures, confirmed, collected, failures }
+}
+
+async function checkSubscriberTokenReadiness<TSubscriber extends CollectableSubscriber>({
+  rpc,
+  subscriber,
+  mint,
+  tokenProgram,
+  programAddress,
+}: {
+  rpc: TokenAccountRpc
+  subscriber: TSubscriber
+  mint: Address
+  tokenProgram: Address
+  programAddress: Address
+}): Promise<{ subscriber: TSubscriber; failure: SubscriberPaymentFailure<TSubscriber> | null }> {
+  const delegator = address(subscriber.delegator)
+  const [delegatorAta] = await findAssociatedTokenPda({
+    mint,
+    owner: delegator,
+    tokenProgram,
+  })
+  const [subscriptionAuthority] = await getSubscriptionAuthorityPda(delegator, mint, programAddress)
+  const account = await rpc
+    .getAccountInfo(delegatorAta, { encoding: 'jsonParsed', commitment: 'confirmed' })
+    .send()
+
+  if (!account.value) {
+    return failReadiness(
+      subscriber,
+      'missing-token-account',
+      `Subscriber token account ${delegatorAta} does not exist`,
+      `missing:${delegatorAta}:${subscriber.amount}`,
+    )
+  }
+
+  const parsed = parseTokenAccount(account.value)
+  if (!parsed) {
+    return failReadiness(
+      subscriber,
+      'invalid-token-account',
+      `Subscriber token account ${delegatorAta} is not a parsed token account`,
+      `invalid:${delegatorAta}:${subscriber.amount}`,
+    )
+  }
+
+  const stateHash = tokenStateHash(parsed, subscriber.amount)
+  const cached = readCachedFailure(subscriber)
+  if (cached?.stateHash === stateHash) {
+    return {
+      subscriber,
+      failure: {
+        subscriber,
+        reason: 'known-unpayable-token-state',
+        message: cached.message,
+      },
+    }
+  }
+
+  if (parsed.mint !== String(mint)) {
+    return failReadiness(subscriber, 'wrong-mint', 'Subscriber token account mint does not match the plan mint', stateHash)
+  }
+  if (parsed.owner !== String(delegator)) {
+    return failReadiness(subscriber, 'wrong-owner', 'Subscriber token account owner does not match the subscriber', stateHash)
+  }
+  if (parsed.balance < subscriber.amount) {
+    return failReadiness(subscriber, 'insufficient-balance', 'Subscriber token account balance is below the collectible amount', stateHash)
+  }
+  if (parsed.delegate !== String(subscriptionAuthority)) {
+    return failReadiness(subscriber, 'wrong-delegate', 'Subscriber token account is not delegated to the subscription authority', stateHash)
+  }
+  if (parsed.delegatedAmount < subscriber.amount) {
+    return failReadiness(subscriber, 'insufficient-delegated-amount', 'Subscriber delegated amount is below the collectible amount', stateHash)
+  }
+
+  clearCachedFailure(subscriber)
+  return { subscriber, failure: null }
+}
+
+async function getSubscriptionAuthorityPda(
+  user: Address,
+  tokenMint: Address,
+  programAddress: Address,
+): Promise<readonly [Address, number]> {
+  return getProgramDerivedAddress({
+    programAddress,
+    seeds: [
+      textEncoder.encode(SUBSCRIPTION_AUTHORITY_SEED),
+      addressEncoder.encode(user),
+      addressEncoder.encode(tokenMint),
+    ],
+  })
+}
+
+function failReadiness<TSubscriber extends CollectableSubscriber>(
+  subscriber: TSubscriber,
+  reason: SubscriberPaymentFailureReason,
+  message: string,
+  stateHash: string,
+): { subscriber: TSubscriber; failure: SubscriberPaymentFailure<TSubscriber> } {
+  writeCachedFailure(subscriber, { reason, message, stateHash, failedAt: Date.now() })
+  return { subscriber, failure: { subscriber, reason, message } }
+}
+
+function parseTokenAccount(value: unknown): ParsedTokenAccount | null {
+  if (!isRecord(value)) return null
+  const data = value.data
+  if (!isRecord(data)) return null
+  const parsed = data.parsed
+  if (!isRecord(parsed)) return null
+  const info = parsed.info
+  if (!isRecord(info)) return null
+
+  const mint = stringField(info, 'mint')
+  const owner = stringField(info, 'owner')
+  const balance = amountField(info, 'tokenAmount')
+  if (mint === null || owner === null || balance === null) return null
+
+  return {
+    mint,
+    owner,
+    balance,
+    delegate: stringField(info, 'delegate'),
+    delegatedAmount: amountField(info, 'delegatedAmount') ?? 0n,
+  }
+}
+
+function amountField(record: Record<string, unknown>, key: string): bigint | null {
+  const field = record[key]
+  if (!isRecord(field) || typeof field.amount !== 'string') return null
+  try {
+    return BigInt(field.amount)
+  } catch {
+    return null
+  }
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const field = record[key]
+  return typeof field === 'string' ? field : null
+}
+
+function tokenStateHash(account: ParsedTokenAccount, amount: bigint): string {
+  return [
+    account.mint,
+    account.owner,
+    account.balance.toString(),
+    account.delegate ?? '',
+    account.delegatedAmount.toString(),
+    amount.toString(),
+  ].join(':')
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function cacheKey(subscriber: CollectableSubscriber): string {
+  return `${subscriber.subscriptionAddress}:${subscriber.delegator}`
+}
+
+function readCachedFailure(subscriber: CollectableSubscriber): CachedFailure | null {
+  const cache = readFailureCache()
+  return cache[cacheKey(subscriber)] ?? null
+}
+
+function writeCachedFailure(subscriber: CollectableSubscriber, failure: CachedFailure): void {
+  const cache = readFailureCache()
+  cache[cacheKey(subscriber)] = failure
+  writeFailureCache(cache)
+}
+
+function clearCachedFailure(subscriber: CollectableSubscriber): void {
+  const cache = readFailureCache()
+  const key = cacheKey(subscriber)
+  if (!(key in cache)) return
+  delete cache[key]
+  writeFailureCache(cache)
+}
+
+function readFailureCache(): Record<string, CachedFailure> {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(FAILURE_CACHE_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    return isCachedFailureMap(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeFailureCache(cache: Record<string, CachedFailure>): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(FAILURE_CACHE_STORAGE_KEY, JSON.stringify(cache))
+  } catch {
+    return
+  }
+}
+
+function isCachedFailureMap(value: unknown): value is Record<string, CachedFailure> {
+  if (!isRecord(value)) return false
+  return Object.values(value).every((entry) => {
+    if (!isRecord(entry)) return false
+    return (
+      typeof entry.reason === 'string' &&
+      typeof entry.message === 'string' &&
+      typeof entry.stateHash === 'string' &&
+      typeof entry.failedAt === 'number'
+    )
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }


### PR DESCRIPTION
## Summary
- filter candidate subscription payments against subscriber token balance and delegate state before batching
- recursively split failed transfer batches to isolate unpayable subscribers and continue valid collection
- preserve per-plan collection history while warning when subscribers are skipped

## Test Plan
- pnpm --dir clients/typescript exec vitest run --config vitest.config.ts test/webapp-collect-utils.test.ts
- pnpm --dir clients/typescript exec biome check test/webapp-collect-utils.test.ts
- pnpm --dir webapp run lint
- pnpm --dir webapp run build
- git push hook format/lint checks