### PR TITLE
fix(webapp): keep cleanup available when approval is off

### DIFF
--- a/webapp/src/components/delegation/active-delegations.tsx
+++ b/webapp/src/components/delegation/active-delegations.tsx
@@ -30,10 +30,13 @@ import type { TokenAccountEntry } from '@/lib/types'
 import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { getBlockTimestamp } from '@/hooks/use-time-travel'
 import { useMySubscriptions } from '@/hooks/use-subscriptions'
+import { getDelegationApprovalState } from '@/lib/delegation-approval-state'
 
 interface ActiveDelegationsProps {
   tokenMint: string
+  isInitialized: boolean
   isApproved: boolean
+  subscriptionAuthorityPayer?: string | null
   subscriptionAuthorityInitId?: bigint | null
   onInitSuccess?: () => void
 }
@@ -80,7 +83,6 @@ function formatAmount(amount: bigint | number): string {
     maximumFractionDigits: 2,
   })
 }
-
 
 interface RevokeDelegationButtonProps {
   delegation: DelegationItem
@@ -469,7 +471,13 @@ function FilterCard({ active, onClick, label, count, subLabel, isActiveCard = tr
   )
 }
 
-function InitPrompt({ tokenMint, onSuccess }: { tokenMint: string; onSuccess?: () => void }) {
+function InitPrompt({ tokenMint, onSuccess, isReapproval = false, subscriptionAuthorityInitId, compact = false }: {
+  tokenMint: string
+  onSuccess?: () => void
+  isReapproval?: boolean
+  subscriptionAuthorityInitId?: bigint | null
+  compact?: boolean
+}) {
   const { account } = useWalletUi()
   const { initSubscriptionAuthority } = useSubscriptionsMutations()
   const queryClient = useQueryClient()
@@ -511,12 +519,28 @@ function InitPrompt({ tokenMint, onSuccess }: { tokenMint: string; onSuccess?: (
 
   const hasAta = !!userAtaAddress
 
+  const containerClass = compact
+    ? 'flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-3 py-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20'
+    : 'flex flex-col items-center justify-center py-8 text-center space-y-3'
+  const iconClass = compact ? 'h-5 w-5 text-amber-500 shrink-0' : 'h-10 w-10 text-amber-500/60'
+  const reapprovalText = subscriptionAuthorityInitId == null
+    ? 'Enabling Delegations reapproves this authority and can reactivate existing grants that match its current delegation ID. Revoke or disable first if you do not want those grants usable.'
+    : `Enabling Delegations reapproves this authority and can reactivate existing grants with delegation ID ${subscriptionAuthorityInitId.toString()}. Revoke or disable first if you do not want those grants usable.`
+
   return (
-    <div className="flex flex-col items-center justify-center py-8 text-center space-y-3">
-      <ShieldAlert className="h-10 w-10 text-amber-500/60" />
-      <div>
-        <p className="text-sm font-medium text-muted-foreground">Approval required to create delegations</p>
-        <p className="text-xs text-muted-foreground/70 mt-1">One-time setup to enable the delegation program</p>
+    <div className={containerClass}>
+      <div className={compact ? 'flex items-start gap-2' : 'flex flex-col items-center gap-3'}>
+        <ShieldAlert className={iconClass} />
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">
+            {isReapproval ? 'Token approval is off' : 'Approval required to create delegations'}
+          </p>
+          <p className="text-xs text-muted-foreground/70 mt-1">
+            {isReapproval
+              ? reapprovalText
+              : 'One-time setup to enable the delegation program'}
+          </p>
+        </div>
       </div>
       {!hasAta && !tokenAccountsLoading && (
         <p className="text-xs text-destructive">No token account found. Get some USDC first.</p>
@@ -532,8 +556,9 @@ function InitPrompt({ tokenMint, onSuccess }: { tokenMint: string; onSuccess?: (
   )
 }
 
-function CloseSubscriptionAuthorityDialog({ tokenMint, open, onOpenChange }: {
+function CloseSubscriptionAuthorityDialog({ tokenMint, payer, open, onOpenChange }: {
   tokenMint: string
+  payer?: string | null
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
@@ -561,7 +586,7 @@ function CloseSubscriptionAuthorityDialog({ tokenMint, open, onOpenChange }: {
 
   const handleClose = async () => {
     try {
-      await closeSubscriptionAuthority.mutateAsync({ tokenMint })
+      await closeSubscriptionAuthority.mutateAsync({ tokenMint, payer: payer ?? undefined })
       handleOpenChange(false)
     } catch {
       // error handled by toast
@@ -616,7 +641,14 @@ function CloseSubscriptionAuthorityDialog({ tokenMint, open, onOpenChange }: {
   )
 }
 
-export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthorityInitId, onInitSuccess }: ActiveDelegationsProps) {
+export function ActiveDelegations({
+  tokenMint,
+  isInitialized,
+  isApproved,
+  subscriptionAuthorityPayer,
+  subscriptionAuthorityInitId,
+  onInitSuccess,
+}: ActiveDelegationsProps) {
   const [activeTab, setActiveTab] = useState<TabType>('outgoing')
   const [outgoingSubTab, setOutgoingSubTab] = useState<OutgoingSubTab>('active')
   const [closeDialogOpen, setCloseDialogOpen] = useState(false)
@@ -661,6 +693,11 @@ export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthority
   }, [outgoing.all, subscriptionAuthorityInitId])
 
   const { revokeMultipleDelegations } = useSubscriptionsMutations()
+  const approvalState = getDelegationApprovalState({
+    isInitialized,
+    isApproved,
+    outgoingDelegationCount: outgoing.all.length,
+  })
 
   const handleRevokeAllStale = async () => {
     if (staleDelegations.length === 0) return
@@ -687,7 +724,7 @@ export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthority
   }
 
   const renderOutgoingContent = () => {
-    if (!isApproved) {
+    if (approvalState.shouldShowApprovalPromptAsContent) {
       return <InitPrompt tokenMint={tokenMint} onSuccess={onInitSuccess} />
     }
 
@@ -731,7 +768,7 @@ export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthority
             {revokeMultipleDelegations.isPending ? 'Revoking...' : `Revoke ${staleDelegations.length} Stale`}
           </Button>
         )}
-        {isApproved && (
+        {approvalState.canCloseSubscriptionAuthority && (
           <Button
             variant="outline"
             size="sm"
@@ -777,11 +814,14 @@ export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthority
         />
       </div>
 
-      {activeTab === 'outgoing' && !isApproved && (
-        <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
-          <ShieldAlert className="h-4 w-4 text-amber-500" />
-          <p className="text-xs text-amber-500">Approval required to create outgoing delegations</p>
-        </div>
+      {activeTab === 'outgoing' && approvalState.shouldShowApprovalRecoveryBanner && (
+        <InitPrompt
+          tokenMint={tokenMint}
+          onSuccess={onInitSuccess}
+          isReapproval={isInitialized}
+          subscriptionAuthorityInitId={subscriptionAuthorityInitId}
+          compact
+        />
       )}
 
       {isLoading ? (
@@ -795,9 +835,14 @@ export function ActiveDelegations({ tokenMint, isApproved, subscriptionAuthority
       )}
       
       <div className="flex justify-end">
-        <CreateDelegationDialog tokenMint={tokenMint} disabled={!isApproved} />
+        <CreateDelegationDialog tokenMint={tokenMint} disabled={!approvalState.canCreateDelegations} />
       </div>
-      <CloseSubscriptionAuthorityDialog tokenMint={tokenMint} open={closeDialogOpen} onOpenChange={setCloseDialogOpen} />
+      <CloseSubscriptionAuthorityDialog
+        tokenMint={tokenMint}
+        payer={subscriptionAuthorityPayer}
+        open={closeDialogOpen}
+        onOpenChange={setCloseDialogOpen}
+      />
     </div>
   )
 }

--- a/webapp/src/components/delegation/delegation-management-panel.tsx
+++ b/webapp/src/components/delegation/delegation-management-panel.tsx
@@ -51,7 +51,14 @@ function StatusError({ onRetry }: { onRetry: () => void }) {
 
 export function DelegationManagementPanel() {
   const { mint: usdcMint, isLoading: isMintLoading } = useUsdcMintRaw()
-  const { isLoading: statusLoading, isError, isApproved, data: statusData, refetch: refetchStatus } = useSubscriptionAuthorityStatus(usdcMint)
+  const {
+    isLoading: statusLoading,
+    isError,
+    isInitialized,
+    isApproved,
+    data: statusData,
+    refetch: refetchStatus,
+  } = useSubscriptionAuthorityStatus(usdcMint)
 
   if (isMintLoading || statusLoading) {
     return <LoadingState />
@@ -66,6 +73,7 @@ export function DelegationManagementPanel() {
   }
 
   const subscriptionAuthorityInitId = statusData?.data?.initId ?? null
+  const subscriptionAuthorityPayer = statusData?.data?.payer ?? null
 
   return (
     <div className="w-full">
@@ -77,7 +85,14 @@ export function DelegationManagementPanel() {
           <div className="h-px flex-1 bg-gradient-to-r from-transparent via-gray-700/40 to-transparent" />
         </div>
       )}
-      <ActiveDelegations tokenMint={usdcMint} isApproved={isApproved} subscriptionAuthorityInitId={subscriptionAuthorityInitId} onInitSuccess={refetchStatus} />
+      <ActiveDelegations
+        tokenMint={usdcMint}
+        isInitialized={isInitialized}
+        isApproved={isApproved}
+        subscriptionAuthorityPayer={subscriptionAuthorityPayer}
+        subscriptionAuthorityInitId={subscriptionAuthorityInitId}
+        onInitSuccess={refetchStatus}
+      />
     </div>
   )
 }

--- a/webapp/src/hooks/use-subscription-authority-status.ts
+++ b/webapp/src/hooks/use-subscription-authority-status.ts
@@ -7,7 +7,7 @@ import { useClusterConfig } from '@/hooks/use-cluster-config'
 import { useProgramAddress } from '@/hooks/use-token-config'
 
 export interface SubscriptionAuthorityData {
-  owner: string
+  user: string
   tokenMint: string
   payer: string
   bump: number

--- a/webapp/src/lib/delegation-approval-state.ts
+++ b/webapp/src/lib/delegation-approval-state.ts
@@ -1,0 +1,30 @@
+export interface DelegationApprovalStateInput {
+  readonly isInitialized: boolean
+  readonly isApproved: boolean
+  readonly outgoingDelegationCount: number
+}
+
+export interface DelegationApprovalState {
+  readonly canCreateDelegations: boolean
+  readonly canCloseSubscriptionAuthority: boolean
+  readonly shouldShowOutgoingDelegations: boolean
+  readonly shouldShowApprovalPromptAsContent: boolean
+  readonly shouldShowApprovalRecoveryBanner: boolean
+}
+
+export function getDelegationApprovalState({
+  isInitialized,
+  isApproved,
+  outgoingDelegationCount,
+}: DelegationApprovalStateInput): DelegationApprovalState {
+  const hasOutgoingDelegations = outgoingDelegationCount > 0
+  const hasCleanupSurface = isInitialized || hasOutgoingDelegations
+
+  return {
+    canCreateDelegations: isApproved,
+    canCloseSubscriptionAuthority: isInitialized,
+    shouldShowOutgoingDelegations: isApproved || hasCleanupSurface,
+    shouldShowApprovalPromptAsContent: !isApproved && !hasCleanupSurface,
+    shouldShowApprovalRecoveryBanner: !isApproved && hasCleanupSurface,
+  }
+}

--- a/webapp/test/delegation-approval-state.test.ts
+++ b/webapp/test/delegation-approval-state.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { getDelegationApprovalState } from '../src/lib/delegation-approval-state.ts'
+
+describe('getDelegationApprovalState', () => {
+  test('keeps cleanup visible when authority exists but token approval is off', () => {
+    assert.deepEqual(getDelegationApprovalState({
+      isInitialized: true,
+      isApproved: false,
+      outgoingDelegationCount: 2,
+    }), {
+      canCreateDelegations: false,
+      canCloseSubscriptionAuthority: true,
+      shouldShowOutgoingDelegations: true,
+      shouldShowApprovalPromptAsContent: false,
+      shouldShowApprovalRecoveryBanner: true,
+    })
+  })
+
+  test('shows setup as content only when there is no cleanup surface', () => {
+    assert.equal(getDelegationApprovalState({
+      isInitialized: false,
+      isApproved: false,
+      outgoingDelegationCount: 0,
+    }).shouldShowApprovalPromptAsContent, true)
+  })
+
+  test('shows old outgoing delegation accounts even after authority close', () => {
+    const state = getDelegationApprovalState({
+      isInitialized: false,
+      isApproved: false,
+      outgoingDelegationCount: 1,
+    })
+
+    assert.equal(state.canCloseSubscriptionAuthority, false)
+    assert.equal(state.shouldShowOutgoingDelegations, true)
+    assert.equal(state.shouldShowApprovalPromptAsContent, false)
+    assert.equal(state.shouldShowApprovalRecoveryBanner, true)
+  })
+
+  test('allows creation only while token approval is active', () => {
+    const state = getDelegationApprovalState({
+      isInitialized: true,
+      isApproved: true,
+      outgoingDelegationCount: 0,
+    })
+
+    assert.equal(state.canCreateDelegations, true)
+    assert.equal(state.canCloseSubscriptionAuthority, true)
+    assert.equal(state.shouldShowApprovalRecoveryBanner, false)
+  })
+})


### PR DESCRIPTION
## Summary
- Keep outgoing delegation cleanup visible when the authority exists but token approval is off
- Keep Disable Delegations available in approval-off recovery state
- Add a reapproval warning for existing same-init_id grants and focused approval-state tests

## Test Plan
- node --disable-warning=ExperimentalWarning --experimental-strip-types --test webapp/test/delegation-approval-state.test.ts
- pnpm --filter webapp lint
- pnpm --filter webapp build
- pnpm --filter webapp test *(fails on existing test/collection-history.test.ts import resolution: src/lib/collect-utils.ts imports ./tx-packer without an extension)*