### PR TITLE
fix!: bind delegations to authority domain

### DIFF
--- a/programs/subscriptions/idl/subscriptions.json
+++ b/programs/subscriptions/idl/subscriptions.json
@@ -16,6 +16,20 @@
             },
             {
               "kind": "structFieldTypeNode",
+              "name": "subscriptionAuthority",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
               "name": "amount",
               "type": {
                 "endian": "le",
@@ -98,6 +112,20 @@
               "type": {
                 "kind": "definedTypeLinkNode",
                 "name": "header"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "subscriptionAuthority",
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "mint",
+              "type": {
+                "kind": "publicKeyTypeNode"
               }
             },
             {

--- a/programs/subscriptions/src/instructions/create_fixed_delegation.rs
+++ b/programs/subscriptions/src/instructions/create_fixed_delegation.rs
@@ -64,7 +64,7 @@ pub fn process(accounts: &[AccountView], call_data: &CreateFixedDelegationData) 
 
     let accounts = CreateDelegationAccounts::try_from(accounts)?;
 
-    let (bump, init_id) =
+    let (bump, init_id, mint) =
         create_delegation_account(&accounts, call_data.nonce, FixedDelegation::LEN)?;
 
     let binding = &mut accounts.delegation_account.try_borrow_mut()?;
@@ -80,6 +80,8 @@ pub fn process(accounts: &[AccountView], call_data: &CreateFixedDelegationData) 
         accounts.payer.address(),
         init_id,
     );
+    delegation.subscription_authority = *accounts.subscription_authority.address();
+    delegation.mint = mint;
     delegation.amount = call_data.amount;
     delegation.expiry_ts = call_data.expiry_ts;
 

--- a/programs/subscriptions/src/instructions/create_recurring_delegation.rs
+++ b/programs/subscriptions/src/instructions/create_recurring_delegation.rs
@@ -79,7 +79,7 @@ pub fn process(
 
     let accounts = CreateDelegationAccounts::try_from(accounts)?;
 
-    let (bump, init_id) =
+    let (bump, init_id, mint) =
         create_delegation_account(&accounts, call_data.nonce, RecurringDelegation::LEN)?;
 
     let binding = &mut accounts.delegation_account.try_borrow_mut()?;
@@ -95,6 +95,8 @@ pub fn process(
         accounts.payer.address(),
         init_id,
     );
+    delegation.subscription_authority = *accounts.subscription_authority.address();
+    delegation.mint = mint;
     delegation.current_period_start_ts = call_data.start_ts;
     delegation.period_length_s = call_data.period_length_s;
     delegation.expiry_ts = call_data.expiry_ts;

--- a/programs/subscriptions/src/instructions/helpers/delegation.rs
+++ b/programs/subscriptions/src/instructions/helpers/delegation.rs
@@ -60,22 +60,24 @@ impl<'a> TryFrom<&'a [AccountView]> for CreateDelegationAccounts<'a> {
 /// Creates and allocates a delegation PDA.
 ///
 /// Verifies the delegator owns the [`SubscriptionAuthority`], derives the expected PDA,
-/// and creates the account via CPI. Returns `(bump, init_id)` on success.
+/// and creates the account via CPI. Returns `(bump, init_id, mint)` on success.
 pub fn create_delegation_account(
     accounts: &CreateDelegationAccounts,
     nonce: u64,
     space: usize,
-) -> Result<(u8, i64), ProgramError> {
+) -> Result<(u8, i64, Address), ProgramError> {
     if accounts.delegation_account.data_len() > 0 {
         return Err(SubscriptionsError::DelegationAlreadyExists.into());
     }
 
     let init_id;
+    let mint;
     {
         let md_data = accounts.subscription_authority.try_borrow()?;
         let subscription_authority = SubscriptionAuthority::load(&md_data)?;
         subscription_authority.check_owner(accounts.delegator.address())?;
         init_id = subscription_authority.init_id;
+        mint = subscription_authority.token_mint;
     }
 
     let nonce_bytes = nonce.to_le_bytes();
@@ -103,7 +105,7 @@ pub fn create_delegation_account(
 
     ProgramAccount::init::<()>(accounts.payer, accounts.delegation_account, &seeds, space)?;
 
-    Ok((bump, init_id))
+    Ok((bump, init_id, mint))
 }
 
 /// Populates a delegation [`Header`] with the standard fields.

--- a/programs/subscriptions/src/instructions/helpers/transfer_utils.rs
+++ b/programs/subscriptions/src/instructions/helpers/transfer_utils.rs
@@ -93,6 +93,18 @@ pub fn transfer_with_delegate(
         check_token_account_owner(&ata_data, delegator)?;
         check_token_account_mint(&ata_data, mint)?;
     }
+    let expected_ata = Address::find_program_address(
+        &[
+            delegator.as_ref(),
+            accounts.token_program.address().as_ref(),
+            mint.as_ref(),
+        ],
+        &pinocchio_associated_token_account::ID,
+    )
+    .0;
+    if expected_ata != *accounts.delegator_ata.address() {
+        return Err(SubscriptionsError::InvalidAssociatedTokenAccountDerivedAddress.into());
+    }
 
     {
         let to_data = accounts.to_ata.try_borrow()?;

--- a/programs/subscriptions/src/instructions/initialize_subscription_authority.rs
+++ b/programs/subscriptions/src/instructions/initialize_subscription_authority.rs
@@ -10,9 +10,9 @@ use pinocchio_token_2022::instructions::Approve as Approve2022;
 
 use crate::{
     check_token_account_mint, check_token_account_owner, constants::TOKEN_2022_PROGRAM_ID,
-    AccountCheck, MintInterface, ProgramAccount, ProgramAccountInit, SignerAccount,
-    SubscriptionAuthority, SubscriptionsError, SystemAccount, TokenAccountInterface,
-    TokenProgramInterface, WritableAccount,
+    AccountCheck, AssociatedTokenAccount, AssociatedTokenAccountCheck, MintInterface,
+    ProgramAccount, ProgramAccountInit, SignerAccount, SubscriptionAuthority, SubscriptionsError,
+    SystemAccount, TokenAccountInterface, TokenProgramInterface, WritableAccount,
 };
 
 /// Validated accounts for the [`InitSubscriptionAuthority`](crate::SubscriptionsInstruction::InitSubscriptionAuthority) instruction.
@@ -125,6 +125,12 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
         check_token_account_owner(&ata_data, accounts.user.address())?;
         check_token_account_mint(&ata_data, accounts.token_mint.address())?;
     }
+    AssociatedTokenAccount::check(
+        accounts.user_ata,
+        accounts.user,
+        accounts.token_mint,
+        accounts.token_program,
+    )?;
 
     // Approve delegation on the correct token program (SPL Token vs Token-2022).
     // The instruction data is the same, but the program id differs.
@@ -157,18 +163,25 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use solana_account::Account;
+    use solana_instruction::{AccountMeta, Instruction};
+    use solana_pubkey::Pubkey;
     use solana_signer::Signer;
     use spl_token_2022::extension::ExtensionType;
 
     use crate::{
+        instructions::initialize_subscription_authority,
         tests::{
             asserts::TransactionResultExt,
             constants::{
-                MINT_DECIMALS, SYSTEM_PROGRAM_ID, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID,
+                MINT_DECIMALS, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_2022_PROGRAM_ID,
+                TOKEN_PROGRAM_ID,
             },
+            idl,
+            pda::get_subscription_authority_pda,
             utils::{
-                fetch_account, init_ata, init_mint, init_wallet,
-                initialize_subscription_authority_action,
+                build_and_send_transaction, fetch_account, init_ata, init_aux_token_account,
+                init_mint, init_wallet, initialize_subscription_authority_action,
                 initialize_subscription_authority_action_with_sponsor, setup,
             },
         },
@@ -221,6 +234,38 @@ mod tests {
         assert!(ata_account.delegate.is_some());
         assert_eq!(ata_account.delegate.unwrap(), subscription_authority_pda);
         assert_eq!(ata_account.delegated_amount, u64::MAX);
+    }
+
+    #[test]
+    fn initialize_subscription_authority_rejects_non_canonical_token_account() {
+        let (litesvm, user) = &mut setup();
+
+        let mint = init_mint(
+            litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(user.pubkey()),
+            &[],
+        );
+        let aux_token_account = init_aux_token_account(litesvm, mint, user.pubkey(), 1_000_000);
+        let (subscription_authority_pda, _) = get_subscription_authority_pda(&user.pubkey(), &mint);
+
+        let ix = Instruction {
+            program_id: PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new(user.pubkey(), true),
+                AccountMeta::new(subscription_authority_pda, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new(aux_token_account, false),
+                AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+                AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
+            ],
+            data: vec![*initialize_subscription_authority::DISCRIMINATOR],
+        };
+
+        build_and_send_transaction(litesvm, &[user], &user.pubkey(), &ix)
+            .assert_err(SubscriptionsError::InvalidAssociatedTokenAccountDerivedAddress);
     }
 
     #[test]
@@ -359,17 +404,6 @@ mod tests {
 
     #[test]
     fn wrong_token_program_returns_error() {
-        use solana_instruction::{AccountMeta, Instruction};
-        use solana_signer::Signer;
-
-        use crate::{
-            instructions::initialize_subscription_authority,
-            tests::{
-                constants::PROGRAM_ID, constants::SYSTEM_PROGRAM_ID,
-                pda::get_subscription_authority_pda, utils::build_and_send_transaction,
-            },
-        };
-
         let (litesvm, user) = &mut setup();
 
         let mint = init_mint(
@@ -408,8 +442,6 @@ mod tests {
     /// does not prevent the legitimate user from creating the account.
     #[test]
     fn initialize_subscription_authority_with_prefunded_pda() {
-        use solana_account::Account;
-
         let (litesvm, user) = &mut setup();
 
         let mint = init_mint(
@@ -469,8 +501,6 @@ mod tests {
 
     #[test]
     fn initialize_subscription_authority_with_overfunded_pda() {
-        use solana_account::Account;
-
         let (litesvm, user) = &mut setup();
 
         let mint = init_mint(
@@ -527,18 +557,6 @@ mod tests {
 
     #[test]
     fn writable_accounts_must_be_writable() {
-        use solana_instruction::{AccountMeta, Instruction};
-
-        use crate::{
-            instructions::initialize_subscription_authority,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
-        };
-
         let writable = idl::writable_account_indices("initSubscriptionAuthority");
 
         let (litesvm, user) = &mut setup();
@@ -583,18 +601,6 @@ mod tests {
 
     #[test]
     fn signer_accounts_must_be_signers() {
-        use solana_instruction::{AccountMeta, Instruction};
-
-        use crate::{
-            instructions::initialize_subscription_authority,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
-        };
-
         let signers = idl::signer_account_indices("initSubscriptionAuthority");
 
         let (litesvm, user) = &mut setup();
@@ -645,18 +651,6 @@ mod tests {
     /// signer.
     #[test]
     fn non_signer_payer_rejected() {
-        use solana_instruction::{AccountMeta, Instruction};
-        use solana_pubkey::Pubkey;
-        use solana_signer::Signer;
-
-        use crate::{
-            instructions::initialize_subscription_authority,
-            tests::{
-                constants::PROGRAM_ID, constants::TOKEN_PROGRAM_ID,
-                pda::get_subscription_authority_pda, utils::build_and_send_transaction,
-            },
-        };
-
         let (litesvm, user) = &mut setup();
 
         let mint = init_mint(

--- a/programs/subscriptions/src/instructions/transfer_fixed_delegation.rs
+++ b/programs/subscriptions/src/instructions/transfer_fixed_delegation.rs
@@ -42,6 +42,12 @@ pub fn process(accounts: &[AccountView], transfer: &TransferData) -> ProgramResu
             &transfer.delegator,
             accounts_struct.delegatee.address(),
         )?;
+        if delegation.subscription_authority != *accounts_struct.subscription_authority.address() {
+            return Err(SubscriptionsError::InvalidDelegatePda.into());
+        }
+        if delegation.mint != transfer.mint {
+            return Err(SubscriptionsError::MintMismatch.into());
+        }
 
         delegatee_address = *accounts_struct.delegatee.address();
 
@@ -158,24 +164,31 @@ impl<'a> TryFrom<&'a [AccountView]> for FixedTransferAccounts<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::utils::move_clock_forward;
     use crate::{
-        state::FixedDelegation,
+        event_engine::event_authority_pda,
+        instructions::transfer_fixed_delegation,
+        state::{header::VERSION_OFFSET, FixedDelegation},
         tests::{
             asserts::TransactionResultExt,
-            constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
+            constants::{MINT_DECIMALS, PROGRAM_ID, TOKEN_PROGRAM_ID},
+            idl,
+            pda::get_subscription_authority_pda,
             utils::{
-                current_ts, days, get_ata_balance, init_ata, init_mint,
-                initialize_subscription_authority_action, setup, CreateDelegation,
-                TransferDelegation,
+                build_and_send_transaction, current_ts, days, get_ata_balance, init_ata,
+                init_aux_token_account, init_mint, init_wallet,
+                initialize_subscription_authority_action, move_clock_forward, setup,
+                CloseSubscriptionAuthority, CreateDelegation, RevokeDelegation, TransferDelegation,
             },
         },
         SubscriptionsError,
     };
     use litesvm::LiteSVM;
+    use solana_instruction::{AccountMeta, Instruction};
     use solana_keypair::Keypair;
     use solana_pubkey::Pubkey;
     use solana_signer::Signer;
+    use spl_associated_token_account::get_associated_token_address_with_program_id;
+    use spl_token::instruction::TokenInstruction::Approve;
 
     fn setup_fixed_delegation(
         amount: u64,
@@ -407,21 +420,126 @@ mod tests {
     }
 
     #[test]
-    fn writable_accounts_must_be_writable() {
-        use solana_instruction::{AccountMeta, Instruction};
-        use spl_associated_token_account::get_associated_token_address_with_program_id;
+    fn fixed_delegation_rejects_transfer_with_different_mint_authority() {
+        let (mut litesvm, alice) = setup();
+        let bob = Keypair::new();
+        litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
 
-        use crate::{
-            event_engine::event_authority_pda,
-            instructions::transfer_fixed_delegation,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
+        let low_value_mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+        let high_value_mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+
+        let _alice_low_ata = init_ata(&mut litesvm, low_value_mint, alice.pubkey(), 100_000_000);
+        let alice_high_ata = init_ata(&mut litesvm, high_value_mint, alice.pubkey(), 100_000_000);
+        let _bob_low_ata = init_ata(&mut litesvm, low_value_mint, bob.pubkey(), 0);
+        let bob_high_ata = init_ata(&mut litesvm, high_value_mint, bob.pubkey(), 0);
+
+        initialize_subscription_authority_action(&mut litesvm, &alice, low_value_mint)
+            .0
+            .assert_ok();
+        initialize_subscription_authority_action(&mut litesvm, &alice, high_value_mint)
+            .0
+            .assert_ok();
+
+        let fixed_allowance = 50_000_000;
+        let (res, low_value_delegation_pda) =
+            CreateDelegation::new(&mut litesvm, &alice, low_value_mint, bob.pubkey())
+                .nonce(89)
+                .fixed(fixed_allowance, current_ts() + days(1) as i64);
+        res.assert_ok();
+
+        TransferDelegation::new(
+            &mut litesvm,
+            &bob,
+            alice.pubkey(),
+            high_value_mint,
+            low_value_delegation_pda,
+        )
+        .amount(20_000_000)
+        .fixed()
+        .assert_err(SubscriptionsError::InvalidDelegatePda);
+
+        assert_eq!(get_ata_balance(&litesvm, &alice_high_ata), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &bob_high_ata), 0);
+
+        let delegation_account = litesvm.get_account(&low_value_delegation_pda).unwrap();
+        let remaining_allowance = FixedDelegation::load(&delegation_account.data)
+            .unwrap()
+            .amount;
+        assert_eq!(remaining_allowance, fixed_allowance);
+    }
+
+    #[test]
+    fn fixed_transfer_rejects_approved_non_canonical_source() {
+        let (mut litesvm, alice) = setup();
+        let bob = Keypair::new();
+        litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
+
+        let mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+        let alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 5_000_000);
+        let alice_aux = init_aux_token_account(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+        let bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
+
+        let (res, subscription_authority_pda, _) =
+            initialize_subscription_authority_action(&mut litesvm, &alice, mint);
+        res.assert_ok();
+
+        let fixed_allowance = 60_000_000;
+        let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey())
+            .nonce(87)
+            .fixed(fixed_allowance, current_ts() + days(1) as i64);
+        res.assert_ok();
+
+        let ix = Instruction {
+            program_id: TOKEN_PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new(alice_aux, false),
+                AccountMeta::new(subscription_authority_pda, false),
+                AccountMeta::new(alice.pubkey(), true),
+            ],
+            data: Approve { amount: u64::MAX }.pack(),
         };
+        build_and_send_transaction(&mut litesvm, &[&alice], &alice.pubkey(), &ix).assert_ok();
 
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+            .from(alice_aux)
+            .amount(10_000_000)
+            .fixed()
+            .assert_err(SubscriptionsError::InvalidAssociatedTokenAccountDerivedAddress);
+
+        assert_eq!(get_ata_balance(&litesvm, &alice_ata), 5_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &alice_aux), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+
+        let delegation_account = litesvm.get_account(&delegation_pda).unwrap();
+        let remaining_allowance = FixedDelegation::load(&delegation_account.data)
+            .unwrap()
+            .amount;
+        assert_eq!(remaining_allowance, fixed_allowance);
+    }
+
+    #[test]
+    fn writable_accounts_must_be_writable() {
         let writable = idl::writable_account_indices("transferFixed");
 
         let amount: u64 = 50_000_000;
@@ -483,20 +601,6 @@ mod tests {
 
     #[test]
     fn signer_accounts_must_be_signers() {
-        use solana_instruction::{AccountMeta, Instruction};
-        use spl_associated_token_account::get_associated_token_address_with_program_id;
-
-        use crate::{
-            event_engine::event_authority_pda,
-            instructions::transfer_fixed_delegation,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
-        };
-
         let signers = idl::signer_account_indices("transferFixed");
 
         let amount: u64 = 50_000_000;
@@ -601,8 +705,6 @@ mod tests {
 
     #[test]
     fn test_fixed_transfer_version_mismatch() {
-        use crate::state::header::VERSION_OFFSET;
-
         let amount: u64 = 50_000_000;
         let expiry_ts: i64 = current_ts() + days(1) as i64;
         let nonce = 0;
@@ -625,10 +727,6 @@ mod tests {
 
     #[test]
     fn test_fixed_transfer_stale_subscription_authority() {
-        use crate::tests::utils::{
-            move_clock_forward, CloseSubscriptionAuthority, RevokeDelegation,
-        };
-
         let amount: u64 = 50_000_000;
         let expiry_ts: i64 = current_ts() + days(1) as i64;
         let nonce = 0;
@@ -662,8 +760,6 @@ mod tests {
 
     #[test]
     fn test_close_subscription_authority_blocks_all_transfers() {
-        use crate::tests::utils::{CloseSubscriptionAuthority, RevokeDelegation};
-
         let amount: u64 = 50_000_000;
         let expiry_ts: i64 = current_ts() + days(1) as i64;
 

--- a/programs/subscriptions/src/instructions/transfer_recurring_delegation.rs
+++ b/programs/subscriptions/src/instructions/transfer_recurring_delegation.rs
@@ -45,6 +45,14 @@ pub fn process(accounts: &[AccountView], transfer_data: &TransferData) -> Progra
             &transfer_data.delegator,
             accounts_struct.delegatee.address(),
         )?;
+        if delegation_mut.subscription_authority
+            != *accounts_struct.subscription_authority.address()
+        {
+            return Err(SubscriptionsError::InvalidDelegatePda.into());
+        }
+        if delegation_mut.mint != transfer_data.mint {
+            return Err(SubscriptionsError::MintMismatch.into());
+        }
 
         delegatee_address = *accounts_struct.delegatee.address();
         period_length_s = delegation_mut.period_length_s;
@@ -167,16 +175,20 @@ impl<'a> TryFrom<&'a [AccountView]> for RecurringTransferAccounts<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::utils::build_and_send_transaction;
     use crate::{
-        state::RecurringDelegation,
+        event_engine::event_authority_pda,
+        instructions::transfer_recurring_delegation,
+        state::{header::VERSION_OFFSET, RecurringDelegation},
         tests::{
             asserts::TransactionResultExt,
-            constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
+            constants::{MINT_DECIMALS, PROGRAM_ID, TOKEN_PROGRAM_ID},
+            idl,
+            pda::get_subscription_authority_pda,
             utils::{
-                current_ts, days, get_ata_balance, hours, init_ata, init_mint,
+                build_and_send_transaction, current_ts, days, get_ata_balance, hours, init_ata,
+                init_aux_token_account, init_mint, init_wallet,
                 initialize_subscription_authority_action, minutes, move_clock_forward, setup,
-                CreateDelegation, TransferDelegation,
+                CloseSubscriptionAuthority, CreateDelegation, TransferDelegation,
             },
         },
         SubscriptionsError,
@@ -187,6 +199,7 @@ mod tests {
     use solana_pubkey::Pubkey;
     use solana_signer::Signer;
     use solana_transaction_error::TransactionError::InstructionError;
+    use spl_associated_token_account::get_associated_token_address_with_program_id;
     use spl_token::instruction::TokenInstruction::{Approve, Revoke};
 
     fn setup_recurring_delegation(
@@ -538,20 +551,127 @@ mod tests {
     }
 
     #[test]
-    fn writable_accounts_must_be_writable() {
-        use spl_associated_token_account::get_associated_token_address_with_program_id;
+    fn recurring_delegation_rejects_transfer_with_different_mint_authority() {
+        let (mut litesvm, alice) = setup();
+        let bob = Keypair::new();
+        litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
 
-        use crate::{
-            event_engine::event_authority_pda,
-            instructions::transfer_recurring_delegation,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
+        let low_value_mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+        let high_value_mint = init_mint(
+            &mut litesvm,
+            TOKEN_PROGRAM_ID,
+            MINT_DECIMALS,
+            1_000_000_000,
+            Some(alice.pubkey()),
+            &[],
+        );
+
+        let _alice_low_ata = init_ata(&mut litesvm, low_value_mint, alice.pubkey(), 100_000_000);
+        let alice_high_ata = init_ata(&mut litesvm, high_value_mint, alice.pubkey(), 100_000_000);
+        let _bob_low_ata = init_ata(&mut litesvm, low_value_mint, bob.pubkey(), 0);
+        let bob_high_ata = init_ata(&mut litesvm, high_value_mint, bob.pubkey(), 0);
+
+        initialize_subscription_authority_action(&mut litesvm, &alice, low_value_mint)
+            .0
+            .assert_ok();
+        initialize_subscription_authority_action(&mut litesvm, &alice, high_value_mint)
+            .0
+            .assert_ok();
+
+        let amount_per_period = 50_000_000;
+        let period_length_s = hours(1);
+        let start_ts = current_ts();
+        let expiry_ts = start_ts + days(1) as i64;
+        let (res, low_value_delegation_pda) =
+            CreateDelegation::new(&mut litesvm, &alice, low_value_mint, bob.pubkey())
+                .nonce(7)
+                .recurring(amount_per_period, period_length_s, start_ts, expiry_ts);
+        res.assert_ok();
+
+        TransferDelegation::new(
+            &mut litesvm,
+            &bob,
+            alice.pubkey(),
+            high_value_mint,
+            low_value_delegation_pda,
+        )
+        .amount(10_000_000)
+        .recurring()
+        .assert_err(SubscriptionsError::InvalidDelegatePda);
+
+        assert_eq!(get_ata_balance(&litesvm, &alice_high_ata), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &bob_high_ata), 0);
+
+        let delegation_account = litesvm.get_account(&low_value_delegation_pda).unwrap();
+        let amount_pulled = RecurringDelegation::load(&delegation_account.data)
+            .unwrap()
+            .amount_pulled_in_period;
+        assert_eq!(amount_pulled, 0);
+    }
+
+    #[test]
+    fn recurring_transfer_rejects_approved_non_canonical_source() {
+        let amount_per_period: u64 = 50_000_000;
+        let period_length_s: u64 = hours(1);
+        let start_ts: i64 = current_ts();
+        let expiry_ts: i64 = current_ts() + days(1) as i64;
+        let nonce = 0;
+
+        let (
+            mut litesvm,
+            alice,
+            bob,
+            delegation_pda,
+            mint,
+            alice_ata,
+            bob_ata,
+            subscription_authority_pda,
+        ) = setup_recurring_delegation(
+            amount_per_period,
+            period_length_s,
+            start_ts,
+            expiry_ts,
+            nonce,
+        );
+
+        let alice_aux = init_aux_token_account(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+        let ix = Instruction {
+            program_id: TOKEN_PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new(alice_aux, false),
+                AccountMeta::new(subscription_authority_pda, false),
+                AccountMeta::new(alice.pubkey(), true),
+            ],
+            data: Approve { amount: u64::MAX }.pack(),
         };
+        build_and_send_transaction(&mut litesvm, &[&alice], &alice.pubkey(), &ix).assert_ok();
 
+        TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+            .from(alice_aux)
+            .amount(10_000_000)
+            .recurring()
+            .assert_err(SubscriptionsError::InvalidAssociatedTokenAccountDerivedAddress);
+
+        assert_eq!(get_ata_balance(&litesvm, &alice_ata), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &alice_aux), 100_000_000);
+        assert_eq!(get_ata_balance(&litesvm, &bob_ata), 0);
+
+        let delegation_account = litesvm.get_account(&delegation_pda).unwrap();
+        let amount_pulled = RecurringDelegation::load(&delegation_account.data)
+            .unwrap()
+            .amount_pulled_in_period;
+        assert_eq!(amount_pulled, 0);
+    }
+
+    #[test]
+    fn writable_accounts_must_be_writable() {
         let writable = idl::writable_account_indices("transferRecurring");
 
         let amount_per_period: u64 = 50_000_000;
@@ -620,19 +740,6 @@ mod tests {
 
     #[test]
     fn signer_accounts_must_be_signers() {
-        use spl_associated_token_account::get_associated_token_address_with_program_id;
-
-        use crate::{
-            event_engine::event_authority_pda,
-            instructions::transfer_recurring_delegation,
-            tests::{
-                constants::PROGRAM_ID,
-                idl,
-                pda::get_subscription_authority_pda,
-                utils::{build_and_send_transaction, init_wallet},
-            },
-        };
-
         let signers = idl::signer_account_indices("transferRecurring");
 
         let amount_per_period: u64 = 50_000_000;
@@ -897,8 +1004,6 @@ mod tests {
 
     #[test]
     fn test_recurring_transfer_version_mismatch() {
-        use crate::state::header::VERSION_OFFSET;
-
         let amount_per_period: u64 = 50_000_000;
         let period_length_s: u64 = hours(1);
         let start_ts: i64 = current_ts();
@@ -929,8 +1034,6 @@ mod tests {
 
     #[test]
     fn test_recurring_transfer_stale_subscription_authority() {
-        use crate::tests::utils::{move_clock_forward, CloseSubscriptionAuthority};
-
         let amount_per_period: u64 = 50_000_000;
         let period_length_s = days(1);
         let start_ts = current_ts();

--- a/programs/subscriptions/src/state/fixed_delegation.rs
+++ b/programs/subscriptions/src/state/fixed_delegation.rs
@@ -2,7 +2,7 @@
 
 use codama::CodamaAccount;
 use core::mem::{size_of, transmute};
-use pinocchio::error::ProgramError;
+use pinocchio::{error::ProgramError, Address};
 
 use crate::{
     check_min_account_size, state::common::AccountDiscriminator,
@@ -22,6 +22,10 @@ use crate::{
 pub struct FixedDelegation {
     /// Common delegation header (discriminator, version, bump, delegator, delegatee, payer).
     pub header: Header,
+    /// The exact SubscriptionAuthority PDA used when this delegation was created.
+    pub subscription_authority: Address,
+    /// The token mint this delegation authorizes.
+    pub mint: Address,
     /// Remaining token amount the delegatee is allowed to transfer.
     pub amount: u64,
     /// Unix timestamp after which this delegation is no longer valid.
@@ -68,5 +72,5 @@ impl FixedDelegation {
     }
 }
 
-pub const FIXED_DELEGATION_LEN_V1: usize = 123;
-const _: () = assert!(FixedDelegation::LEN == FIXED_DELEGATION_LEN_V1);
+pub const FIXED_DELEGATION_LEN: usize = 187;
+const _: () = assert!(FixedDelegation::LEN == FIXED_DELEGATION_LEN);

--- a/programs/subscriptions/src/state/recurring_delegation.rs
+++ b/programs/subscriptions/src/state/recurring_delegation.rs
@@ -2,7 +2,7 @@
 
 use codama::CodamaAccount;
 use core::mem::{size_of, transmute};
-use pinocchio::error::ProgramError;
+use pinocchio::{error::ProgramError, Address};
 
 use crate::{
     check_min_account_size, state::common::AccountDiscriminator,
@@ -22,6 +22,10 @@ use crate::{
 pub struct RecurringDelegation {
     /// Common delegation header (discriminator, version, bump, delegator, delegatee, payer).
     pub header: Header,
+    /// The exact SubscriptionAuthority PDA used when this delegation was created.
+    pub subscription_authority: Address,
+    /// The token mint this delegation authorizes.
+    pub mint: Address,
     /// Unix timestamp marking the start of the current period.
     pub current_period_start_ts: i64,
     /// Length of each period in seconds.
@@ -74,5 +78,5 @@ impl RecurringDelegation {
     }
 }
 
-pub const RECURRING_DELEGATION_LEN_V1: usize = 147;
-const _: () = assert!(RecurringDelegation::LEN == RECURRING_DELEGATION_LEN_V1);
+pub const RECURRING_DELEGATION_LEN: usize = 211;
+const _: () = assert!(RecurringDelegation::LEN == RECURRING_DELEGATION_LEN);

--- a/programs/subscriptions/src/tests/utils.rs
+++ b/programs/subscriptions/src/tests/utils.rs
@@ -232,7 +232,26 @@ pub fn init_mint(
 pub fn init_ata(litesvm: &mut LiteSVM, mint: Pubkey, owner: Pubkey, amount: u64) -> Pubkey {
     let token_program = litesvm.get_account(&mint).unwrap().owner;
     let ata = get_associated_token_address_with_program_id(&owner, &mint, &token_program);
+    init_token_account_at(litesvm, ata, mint, owner, amount)
+}
 
+pub fn init_aux_token_account(
+    litesvm: &mut LiteSVM,
+    mint: Pubkey,
+    owner: Pubkey,
+    amount: u64,
+) -> Pubkey {
+    init_token_account_at(litesvm, Pubkey::new_unique(), mint, owner, amount)
+}
+
+fn init_token_account_at(
+    litesvm: &mut LiteSVM,
+    token_account: Pubkey,
+    mint: Pubkey,
+    owner: Pubkey,
+    amount: u64,
+) -> Pubkey {
+    let token_program = litesvm.get_account(&mint).unwrap().owner;
     let ata_state = TokenAccount {
         mint,
         owner,
@@ -249,7 +268,7 @@ pub fn init_ata(litesvm: &mut LiteSVM, mint: Pubkey, owner: Pubkey, amount: u64)
 
     litesvm
         .set_account(
-            ata,
+            token_account,
             Account {
                 lamports,
                 data: ata_data,
@@ -260,7 +279,7 @@ pub fn init_ata(litesvm: &mut LiteSVM, mint: Pubkey, owner: Pubkey, amount: u64)
         )
         .unwrap();
 
-    ata
+    token_account
 }
 
 pub fn initialize_subscription_authority_action(
@@ -439,6 +458,7 @@ pub struct TransferDelegation<'a> {
     mint: Pubkey,
     delegation_pda: Pubkey,
     amount: u64,
+    source: Option<Pubkey>,
     receiver: Option<Pubkey>,
 }
 
@@ -457,6 +477,7 @@ impl<'a> TransferDelegation<'a> {
             mint,
             delegation_pda,
             amount: 0,
+            source: None,
             receiver: None,
         }
     }
@@ -468,6 +489,11 @@ impl<'a> TransferDelegation<'a> {
 
     pub fn to(mut self, receiver: Pubkey) -> Self {
         self.receiver = Some(receiver);
+        self
+    }
+
+    pub fn from(mut self, source: Pubkey) -> Self {
+        self.source = Some(source);
         self
     }
 
@@ -486,11 +512,13 @@ impl<'a> TransferDelegation<'a> {
         let token_program = self.litesvm.get_account(&self.mint).unwrap().owner;
         let (subscription_authority_pda, _) =
             get_subscription_authority_pda(&self.delegator, &self.mint);
-        let delegator_ata = get_associated_token_address_with_program_id(
-            &self.delegator,
-            &self.mint,
-            &token_program,
-        );
+        let delegator_ata = self.source.unwrap_or_else(|| {
+            get_associated_token_address_with_program_id(
+                &self.delegator,
+                &self.mint,
+                &token_program,
+            )
+        });
 
         // Default receiver is the signer's (delegatee's) ATA
         let receiver_ata = self.receiver.unwrap_or_else(|| {


### PR DESCRIPTION
## Summary
- Bind fixed and recurring delegations to the exact SubscriptionAuthority PDA and mint used at creation.
- Reject delegated transfers when supplied authority or mint differs from stored delegation state.
- Require SubscriptionAuthority initialization and delegated source transfers to use the canonical ATA.
- Regenerate the subscriptions IDL for the new delegation account layouts.

## Test Plan
- cargo fmt
- cargo build-sbf
- cargo test -p subscriptions
- cargo test-sbf
- pnpm run generate
- git diff --check

## Breaking Changes
- FixedDelegation account size changes from 123 to 187 bytes.
- RecurringDelegation account size changes from 147 to 211 bytes.
- Existing delegation account layouts are incompatible and need recreation or migration.