### PR TITLE
refactor: split subscriptions entrypoint

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,0 +1,49 @@
+use pinocchio::{account::AccountView, entrypoint, Address, ProgramResult};
+
+use crate::instructions::{
+    cancel_subscription, close_subscription_authority, create_fixed_delegation, create_plan,
+    create_recurring_delegation, delete_plan, emit_event, initialize_subscription_authority,
+    revoke_delegation, subscribe, transfer_fixed_delegation, transfer_recurring_delegation,
+    transfer_subscription, update_plan, SubscriptionsInstruction,
+};
+
+entrypoint!(process_instruction);
+
+pub fn process_instruction(
+    program_id: &Address,
+    accounts: &[AccountView],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let instruction = SubscriptionsInstruction::from_bytes(instruction_data)?;
+
+    match instruction {
+        SubscriptionsInstruction::InitSubscriptionAuthority => {
+            initialize_subscription_authority::process(accounts)
+        }
+        SubscriptionsInstruction::CreateFixedDelegation(data) => {
+            create_fixed_delegation::process(accounts, &data)
+        }
+        SubscriptionsInstruction::CreateRecurringDelegation(data) => {
+            create_recurring_delegation::process(accounts, &data)
+        }
+        SubscriptionsInstruction::RevokeDelegation => revoke_delegation::process(accounts),
+        SubscriptionsInstruction::TransferFixed(data) => {
+            transfer_fixed_delegation::process(accounts, &data)
+        }
+        SubscriptionsInstruction::TransferRecurring(data) => {
+            transfer_recurring_delegation::process(accounts, &data)
+        }
+        SubscriptionsInstruction::CloseSubscriptionAuthority => {
+            close_subscription_authority::process(accounts)
+        }
+        SubscriptionsInstruction::CreatePlan(data) => create_plan::process(accounts, &data),
+        SubscriptionsInstruction::UpdatePlan(data) => update_plan::process(accounts, &data),
+        SubscriptionsInstruction::DeletePlan => delete_plan::process(accounts),
+        SubscriptionsInstruction::TransferSubscription(data) => {
+            transfer_subscription::process(accounts, &data)
+        }
+        SubscriptionsInstruction::Subscribe(data) => subscribe::process(accounts, &data),
+        SubscriptionsInstruction::CancelSubscription => cancel_subscription::process(accounts),
+        SubscriptionsInstruction::EmitEvent => emit_event::process(program_id, accounts),
+    }
+}

--- a/program/src/event_engine.rs
+++ b/program/src/event_engine.rs
@@ -6,6 +6,7 @@
 
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use codama::CodamaAccount;
 use const_crypto::ed25519;
 use pinocchio::cpi::{invoke_signed, Seed, Signer};

--- a/program/src/events/fixed_transfer.rs
+++ b/program/src/events/fixed_transfer.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use pinocchio::Address;
 
 use crate::event_engine::{EventDiscriminator, EventDiscriminators, EventSerialize};

--- a/program/src/events/recurring_transfer.rs
+++ b/program/src/events/recurring_transfer.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use pinocchio::Address;
 
 use crate::event_engine::{EventDiscriminator, EventDiscriminators, EventSerialize};

--- a/program/src/events/subscription_cancelled.rs
+++ b/program/src/events/subscription_cancelled.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use pinocchio::Address;
 
 use crate::event_engine::{EventDiscriminator, EventDiscriminators, EventSerialize};

--- a/program/src/events/subscription_created.rs
+++ b/program/src/events/subscription_created.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use pinocchio::Address;
 
 use crate::event_engine::{EventDiscriminator, EventDiscriminators, EventSerialize};

--- a/program/src/events/subscription_transfer.rs
+++ b/program/src/events/subscription_transfer.rs
@@ -1,5 +1,6 @@
 use core::mem::size_of;
 
+use alloc::vec::Vec;
 use pinocchio::Address;
 
 use crate::event_engine::{EventDiscriminator, EventDiscriminators, EventSerialize};

--- a/program/src/instructions/transfer_subscription.rs
+++ b/program/src/instructions/transfer_subscription.rs
@@ -214,6 +214,8 @@ impl<'a> TryFrom<&'a [AccountView]> for TransferSubscriptionAccounts<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
+
     use crate::{
         event_engine::event_authority_pda,
         state::{plan::Plan, subscription_delegation::SubscriptionDelegation},

--- a/program/src/instructions/update_plan.rs
+++ b/program/src/instructions/update_plan.rs
@@ -115,6 +115,8 @@ pub fn process(accounts: &[AccountView], data: &UpdatePlanData) -> ProgramResult
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
+
     use solana_pubkey::Pubkey;
     use solana_signer::Signer;
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -15,10 +15,15 @@
 //! built on the [Pinocchio](https://docs.rs/pinocchio) runtime for minimal compute
 //! overhead and uses [Codama](https://github.com/codama-idl/codama) for IDL generation.
 
-use pinocchio::{address::declare_id, AccountView, Address, ProgramResult};
+#![no_std]
 
-#[cfg(not(feature = "no-entrypoint"))]
-pinocchio::entrypoint!(process_instruction);
+extern crate alloc;
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+use pinocchio::address::declare_id;
 
 pub mod instructions;
 pub use instructions::*;
@@ -35,6 +40,10 @@ pub mod events;
 pub mod constants;
 pub use constants::*;
 
+#[cfg(not(feature = "no-entrypoint"))]
+pub mod entrypoint;
+
+#[cfg(test)]
 pub mod tests;
 
 declare_id!("De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44");
@@ -50,45 +59,4 @@ security_txt! {
     policy: "https://github.com/solana-program/multi-delegator/security/policy",
     source_code: "https://github.com/solana-program/multi-delegator",
     auditors: "Cantina"
-}
-
-/// Program entrypoint: deserializes the instruction discriminator and dispatches
-/// to the appropriate instruction processor.
-fn process_instruction(
-    program_id: &Address,
-    accounts: &[AccountView],
-    instruction_data: &[u8],
-) -> ProgramResult {
-    let instruction = SubscriptionsInstruction::from_bytes(instruction_data)?;
-
-    match instruction {
-        SubscriptionsInstruction::InitSubscriptionAuthority => {
-            initialize_subscription_authority::process(accounts)
-        }
-        SubscriptionsInstruction::CreateFixedDelegation(data) => {
-            create_fixed_delegation::process(accounts, &data)
-        }
-        SubscriptionsInstruction::CreateRecurringDelegation(data) => {
-            create_recurring_delegation::process(accounts, &data)
-        }
-        SubscriptionsInstruction::RevokeDelegation => revoke_delegation::process(accounts),
-        SubscriptionsInstruction::TransferFixed(data) => {
-            transfer_fixed_delegation::process(accounts, &data)
-        }
-        SubscriptionsInstruction::TransferRecurring(data) => {
-            transfer_recurring_delegation::process(accounts, &data)
-        }
-        SubscriptionsInstruction::CloseSubscriptionAuthority => {
-            close_subscription_authority::process(accounts)
-        }
-        SubscriptionsInstruction::CreatePlan(data) => create_plan::process(accounts, &data),
-        SubscriptionsInstruction::UpdatePlan(data) => update_plan::process(accounts, &data),
-        SubscriptionsInstruction::DeletePlan => delete_plan::process(accounts),
-        SubscriptionsInstruction::TransferSubscription(data) => {
-            transfer_subscription::process(accounts, &data)
-        }
-        SubscriptionsInstruction::Subscribe(data) => subscribe::process(accounts, &data),
-        SubscriptionsInstruction::CancelSubscription => cancel_subscription::process(accounts),
-        SubscriptionsInstruction::EmitEvent => emit_event::process(program_id, accounts),
-    }
 }

--- a/program/src/state/versioning/mod.rs
+++ b/program/src/state/versioning/mod.rs
@@ -81,6 +81,8 @@ pub fn check_min_account_size(data_len: usize, expected_len: usize) -> Result<()
 
 #[cfg(test)]
 mod tests {
+    use std::vec::Vec;
+
     use pinocchio::error::ProgramError;
 
     use super::*;

--- a/program/src/tests/asserts.rs
+++ b/program/src/tests/asserts.rs
@@ -1,3 +1,5 @@
+use std::string::String;
+
 use crate::errors::SubscriptionsError;
 
 use litesvm::types::{FailedTransactionMetadata, TransactionMetadata, TransactionResult};

--- a/program/src/tests/cu_tracker.rs
+++ b/program/src/tests/cu_tracker.rs
@@ -14,11 +14,14 @@
 //! // Report is automatically output when tests complete if CU_REPORT is set
 //! ```
 
+use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
+use std::string::{String, ToString};
 use std::sync::Mutex;
 use std::sync::OnceLock;
+use std::vec::Vec;
 
 use litesvm::types::TransactionResult;
 use solana_instruction::Instruction;

--- a/program/src/tests/idl.rs
+++ b/program/src/tests/idl.rs
@@ -1,3 +1,6 @@
+use std::string::{String, ToString};
+use std::vec::Vec;
+
 use serde_json::Value;
 
 const IDL_JSON: &str = include_str!("../../../idl/subscriptions.json");

--- a/program/src/tests/utils.rs
+++ b/program/src/tests/utils.rs
@@ -1,4 +1,5 @@
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::vec::Vec;
 
 use litesvm::{types::TransactionResult, LiteSVM};
 use solana_account::Account;


### PR DESCRIPTION
## Summary
- Move the Pinocchio entrypoint macro and instruction dispatch from `lib.rs` into `program/src/entrypoint.rs`.
- Make the program crate `#![no_std]` with `alloc` support, matching the escrow and rewards program shape.
- Add explicit alloc/std imports needed by event serialization and test-only modules under `no_std`.

## Test Plan
- `cargo check -p subscriptions --features no-entrypoint`
- `pnpm run generate-idl`
- `just build-program`
- `just test-program`
- `just check`