### PR TITLE
fix: install just with setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -77,9 +77,10 @@ runs:
       shell: bash
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - name: Install Just
-      shell: bash
-      run: command -v just || curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin
+    - name: Install just
+      uses: extractions/setup-just@v4
+      with:
+        just-version: "1.50.0"
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Replace the brittle just.systems curl installer with extractions/setup-just@v4.
- Pin just to 1.50.0 in the shared CI setup action.

## Test Plan
- git diff --check
- pre-push hook passed: just fmt-check and just lint-check

## Context
- Fixes the main CI rust-integration-test setup failure where just.systems returned HTTP 403.