### PR TITLE
fix: update repo name references after rename to subscriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ clients/typescript/src/generated/  (auto-generated; wrapped by hand-written SDK 
 
 ### Architecture Decision Records
 
-- [docs/001-multi-delegator-architecture.md](docs/001-multi-delegator-architecture.md) — Subscription Authority + delegations + PDA design
+- [docs/001-program-architecture.md](docs/001-program-architecture.md) — Subscription Authority + delegations + PDA design
 - [docs/002-subscriptions-architecture.md](docs/002-subscriptions-architecture.md) — Plans + pull-payment subscriptions
 - [docs/003-versioning-migration-architecture.md](docs/003-versioning-migration-architecture.md) — Three-tier account versioning/migration
 - [docs/004-program-upgrade-mechanism.md](docs/004-program-upgrade-mechanism.md) — Upgrade authority and deployment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/solana-program/multi-delegator"
+repository = "https://github.com/solana-program/subscriptions"
 
 [workspace.lints.rust]
 unused_imports = "deny"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **DO NOT CREATE A GITHUB ISSUE** to report a security problem.
 
-Instead please use this [Report a Vulnerability](https://github.com/solana-program/multi-delegator/security/advisories/new) link.
+Instead please use this [Report a Vulnerability](https://github.com/solana-program/subscriptions/security/advisories/new) link.
 Provide a helpful title and detailed description of the problem.
 Expect a response as fast as possible in the advisory, typically within 72 hours.
 

--- a/justfile
+++ b/justfile
@@ -337,7 +337,7 @@ verify-mainnet: check-solana-verify
     set -euo pipefail
     PROG_ID=$(sed -n 's/.*declare_id!("\([^"]*\)").*/\1/p' "{{program_dir}}/src/lib.rs")
     solana-verify verify-from-repo \
-        https://github.com/solana-program/multi-delegator \
+        https://github.com/solana-program/subscriptions \
         --program-id "$PROG_ID" \
         --library-name subscriptions \
         --mount-path program \

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -54,9 +54,9 @@ use solana_security_txt::security_txt;
 #[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Subscriptions Program",
-    project_url: "https://github.com/solana-program/multi-delegator",
-    contacts: "link:https://github.com/solana-program/multi-delegator/security/advisories/new",
-    policy: "https://github.com/solana-program/multi-delegator/security/policy",
-    source_code: "https://github.com/solana-program/multi-delegator",
+    project_url: "https://github.com/solana-program/subscriptions",
+    contacts: "link:https://github.com/solana-program/subscriptions/security/advisories/new",
+    policy: "https://github.com/solana-program/subscriptions/security/policy",
+    source_code: "https://github.com/solana-program/subscriptions",
     auditors: "Cantina"
 }


### PR DESCRIPTION
## Summary

- Updates every remaining canonical `multi-delegator` reference outside of audit artifacts to `subscriptions` after the GitHub rename
- `Cargo.toml` `workspace.package.repository`
- `SECURITY.md` advisory reporting link
- `CLAUDE.md` ADR link (also fixes a stale path: actual file is `docs/001-program-architecture.md`)
- `justfile` `verify-mainnet` recipe (`solana-verify verify-from-repo` URL)
- `program/src/lib.rs` `solana-security-txt` macro: `project_url`, `contacts`, `policy`, `source_code`

## Intentionally not changed

- `audits/AUDIT_STATUS.md` and `audits/report-...-solana-multi-delegator.pdf` are signed audit artifacts. `AUDIT_STATUS.md` already documents the rename and notes that the old name is preserved verbatim

## Heads up — on-chain redeploy required

The `program/src/lib.rs` `security_txt!` macro is compiled into the program. Updating those four URLs changes the `.so` bytes, so the corrected URLs only land on-chain after the next mainnet redeploy. Until then the old URLs remain in the deployed program metadata.

## Test Plan

- [x] `cargo check -p subscriptions` succeeds with the new URLs
- [x] `just lint-check` clean locally
- [ ] CI green
- [ ] After merge, run the new `Release` workflow on mainnet (PR #63) so the on-chain `security_txt` URLs are updated