### PR TITLE
ci: run generate-idl before verified build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,13 @@ jobs:
           install -m 600 /dev/null /tmp/deployer.json
           printf '%s' "$DEPLOYER_KEYPAIR" > /tmp/deployer.json
 
+      - name: Generate IDL
+        run: just generate-idl
+
       - name: Build verified program
         uses: solana-developers/github-actions/build-verified@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
           program: ${{ env.PROGRAM }}
-
-      - name: Generate IDL
-        run: just generate-idl
 
       - id: write-buffer
         name: Write program buffer


### PR DESCRIPTION
## Summary
- Reorder `Generate IDL` to run before `Build verified program` in `release.yml`.
- Fixes the release workflow failing at `Generate IDL` with `Permission denied` when creating `target/debug`.

## Root Cause
`solana-developers/github-actions/build-verified` runs `solana-verify` inside a Docker container as root, leaving `target/` root-owned on the runner. The next step (`Generate IDL` → `cargo check` as the runner user) cannot create `target/debug` and fails with `os error 13`.

The `subscriptions/subscriptions` segment in the error path is the standard GitHub Actions checkout layout (`/home/runner/work/<repo>/<repo>/`), not a duplicated path bug.

IDL generation has no dependency on the verified `.so` artifact, so swapping the order is safe and avoids a `sudo chown` workaround tied to action internals.

## Test Plan
- [ ] Trigger `Release` workflow manually against `devnet` from this branch.
- [ ] Confirm `Generate IDL` step succeeds and produces `idl/subscriptions.json`.
- [ ] Confirm `Build verified program` and `Write program buffer` continue to succeed.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25178325752