### PR TITLE
ci: pass keypair content (not path) to devnet release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
           buffer-authority-address: ${{ inputs.network == 'mainnet' && env.SQUADS_VAULT || '' }}
           priority-fee: ${{ inputs.priority-fee }}
 
@@ -88,7 +88,7 @@ jobs:
           program-id: ${{ env.PROGRAM_ID }}
           buffer: ${{ steps.write-buffer.outputs.buffer }}
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
 
       - if: inputs.network == 'devnet'
         name: Upload IDL via program-metadata (devnet)
@@ -96,7 +96,7 @@ jobs:
         with:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
           idl-path: idl/subscriptions.json
           priority-fees: ${{ inputs.priority-fee }}
 
@@ -107,7 +107,7 @@ jobs:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
           repo-url: ${{ env.REPO_URL }}
           network: devnet
           mount-path: program


### PR DESCRIPTION
## Summary
- Fixes `Write program buffer` failing in the release workflow with `Input must be a JSON array`.
- Pass `${{ env.DEPLOYER_KEYPAIR }}` (Doppler-injected content) to the devnet sub-actions instead of the file path `/tmp/deployer.json`.

## Root Cause
The `solana-developers/github-actions/{write-program-buffer, program-upgrade, metadata-upload, verify-build}` actions all internally do:

```yaml
- name: Write keypair
  run: echo "$DEPLOY_KEYPAIR" > ./deploy-keypair.json
  env:
    DEPLOY_KEYPAIR: ${{ inputs.keypair }}
```

i.e. they treat `inputs.keypair` as the keypair **content**, not a file path. We were passing `/tmp/deployer.json`, so the action wrote the literal string `/tmp/deployer.json` into `./deploy-keypair.json` and `solana program write-buffer` rejected it.

## Scope
- Devnet path only (lines 76, 91, 99, 110).
- Mainnet/Squads steps (lines 127, 139, 157) and the `Materialize deployer keypair` step are intentionally left in place — they will be migrated when next exercised on a real mainnet release.

## Test Plan
- [ ] Trigger `Release` workflow against `devnet` from this branch.
- [ ] Confirm `Write program buffer`, `Upgrade program (devnet)`, `Upload IDL via program-metadata (devnet)`, `Verify build (devnet)` all succeed.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25178912188