### PR TITLE
feat(webapp): support vercel prod deploy with dev/prod gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ clients/typescript/docs/
 .vercel
 
 .claude/
+
+# Editor / tool config
+.emdash.json
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ config.json
 
 # Environment secrets
 .env
+.env.local
+**/.env.local
 
 keys/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,7 @@ pnpm-lock.yaml
 
 # TypeDoc generated API docs
 clients/typescript/docs/
+
+# Editor / tool config
+.emdash.json
+.vscode/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,8 @@ export default [
     },
     {
         ignores: [
+            '**/.claude/**',
+            '**/.git/**',
             '**/dist/**',
             '**/node_modules/**',
             '**/target/**',

--- a/justfile
+++ b/justfile
@@ -166,6 +166,30 @@ ensure-surfpool:
     just kill-validator
     exit 1
 
+# Bootstrap localnet (validator + program + mock USDC) and write webapp/.env.local for pnpm dev (no api server)
+dev-local: ensure-surfpool
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    pushd {{webapp_dir}}/scripts > /dev/null
+    pnpm install --silent
+    NETWORK=localnet RPC_URL=http://127.0.0.1:8899 pnpm run init
+    popd > /dev/null
+
+    PROG_ID=$(just program-id)
+    USDC_MINT=$(node -e "const c=JSON.parse(require('fs').readFileSync('{{webapp_dir}}/config.json'));process.stdout.write(c.networks.localnet.tokens.find(t=>t.symbol==='USDC').mint)")
+
+    {
+        echo "VITE_DEFAULT_CLUSTER=solana:localnet"
+        echo "VITE_LOCALNET_PROGRAM=$PROG_ID"
+        echo "VITE_LOCALNET_USDC_MINT=$USDC_MINT"
+    } > {{webapp_dir}}/.env.local
+    echo "✓ {{webapp_dir}}/.env.local written"
+    echo "    VITE_LOCALNET_PROGRAM=$PROG_ID"
+    echo "    VITE_LOCALNET_USDC_MINT=$USDC_MINT"
+    echo ""
+    echo "Next: pnpm --filter webapp dev"
+
 # Stop all validators
 kill-validator:
     #!/usr/bin/env bash

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,4 +1,7 @@
+import { lazy, Suspense } from 'react';
 import { Route, Routes, Navigate, useLocation } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { createSolanaRpc } from '@solana/kit';
 import { AppProviders } from '@/components/app-providers';
 import { AppLayout } from '@/components/app-layout';
 import { Dashboard } from '@/routes/dashboard';
@@ -8,13 +11,12 @@ import { Delegations } from '@/routes/delegations';
 import { Subscriptions } from '@/routes/subscriptions';
 import { Plans } from '@/routes/plans';
 import { CollectPayments } from '@/routes/collect-payments';
-import { Program } from '@/routes/program';
-import { Setup } from '@/routes/setup';
 import { useNetworkConfig } from '@/hooks/use-token-config';
-import { clusterIdToNetwork } from '@/lib/api-client';
+import { clusterIdToNetwork } from '@/lib/cluster';
 import { useClusterConfig } from '@/hooks/use-cluster-config';
-import { useQuery } from '@tanstack/react-query';
-import { createSolanaRpc } from '@solana/kit';
+
+const Setup = lazy(() => import('@/routes/setup').then(m => ({ default: m.Setup })));
+const Program = lazy(() => import('@/routes/program').then(m => ({ default: m.Program })));
 
 function useRpcReachable() {
     const { id, url } = useClusterConfig();
@@ -63,7 +65,7 @@ function useIsSetupValid(): { ready: boolean; loading: boolean } {
     return { ready: true, loading: false };
 }
 
-function SetupGuard({ children }: { children: React.ReactNode }) {
+function DevSetupGuard({ children }: { children: React.ReactNode }) {
     const location = useLocation();
     const { ready } = useIsSetupValid();
     if (!ready && location.pathname !== '/setup') {
@@ -72,78 +74,89 @@ function SetupGuard({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
 }
 
+function ProdSetupGuard({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}
+
+const HAS_LOCALNET_CONFIG = !!import.meta.env.VITE_LOCALNET_USDC_MINT;
+const SetupGuard = import.meta.env.DEV && !HAS_LOCALNET_CONFIG ? DevSetupGuard : ProdSetupGuard;
+
 export default function App() {
     return (
         <AppProviders>
             <SetupGuard>
-                <Routes>
-                    <Route path="/setup" element={<Setup />} />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Dashboard />
-                            </AppLayout>
-                        }
-                        path="/"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Marketplace />
-                            </AppLayout>
-                        }
-                        path="/marketplace"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Delegations />
-                            </AppLayout>
-                        }
-                        path="/delegations"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Subscriptions />
-                            </AppLayout>
-                        }
-                        path="/subscriptions"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Plans />
-                            </AppLayout>
-                        }
-                        path="/plans"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <CollectPayments />
-                            </AppLayout>
-                        }
-                        path="/plans/collect"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Faucet />
-                            </AppLayout>
-                        }
-                        path="/faucet"
-                    />
-                    <Route
-                        element={
-                            <AppLayout>
-                                <Program />
-                            </AppLayout>
-                        }
-                        path="/program"
-                    />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
+                <Suspense fallback={null}>
+                    <Routes>
+                        {import.meta.env.DEV && <Route path="/setup" element={<Setup />} />}
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Dashboard />
+                                </AppLayout>
+                            }
+                            path="/"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Marketplace />
+                                </AppLayout>
+                            }
+                            path="/marketplace"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Delegations />
+                                </AppLayout>
+                            }
+                            path="/delegations"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Subscriptions />
+                                </AppLayout>
+                            }
+                            path="/subscriptions"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Plans />
+                                </AppLayout>
+                            }
+                            path="/plans"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <CollectPayments />
+                                </AppLayout>
+                            }
+                            path="/plans/collect"
+                        />
+                        <Route
+                            element={
+                                <AppLayout>
+                                    <Faucet />
+                                </AppLayout>
+                            }
+                            path="/faucet"
+                        />
+                        {import.meta.env.DEV && (
+                            <Route
+                                element={
+                                    <AppLayout>
+                                        <Program />
+                                    </AppLayout>
+                                }
+                                path="/program"
+                            />
+                        )}
+                        <Route path="*" element={<Navigate to="/" replace />} />
+                    </Routes>
+                </Suspense>
             </SetupGuard>
         </AppProviders>
     );

--- a/webapp/src/components/app-header.tsx
+++ b/webapp/src/components/app-header.tsx
@@ -1,33 +1,70 @@
-import { useState } from 'react';
-import { Button } from '@solana/design-system';
-import { Menu, X, Settings2 } from 'lucide-react';
-import { WalletButton } from './solana/solana-provider';
-import { TimeTravelButton } from './time-travel/time-travel-button';
-import { Link, useLocation, useNavigate } from 'react-router';
 import { useCluster } from '@solana/connector/react';
-import { NAV_ITEMS } from './nav-items';
+import { Button } from '@solana/design-system';
+import { ChevronDown, Menu, RotateCcw, Settings2, X } from 'lucide-react';
+import { useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router';
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { CURRENT_PROGRAM_VERSION } from '@subscriptions/client';
 
-function NetworkButton() {
+import { NAV_ITEMS } from './nav-items';
+import { WalletButton } from './solana/solana-provider';
+import { TimeTravelButton } from './time-travel/time-travel-button';
+
+function ClusterButton() {
+    const { cluster, clusters, setCluster } = useCluster();
     const navigate = useNavigate();
-    const setupCluster = localStorage.getItem('setup-cluster') ?? '';
-    const label =
-        setupCluster === 'solana:devnet' ? 'Devnet' : setupCluster === 'solana:testnet' ? 'Testnet' : 'Localnet';
 
     return (
-        <Button
-            iconLeft={<Settings2 />}
-            onClick={() => {
-                localStorage.removeItem('setup-complete-localnet');
-                localStorage.removeItem('setup-complete-devnet');
-                localStorage.removeItem('setup-cluster');
-                navigate('/setup');
-            }}
-            size="sm"
-            variant="secondary"
-        >
-            {label}
-        </Button>
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    iconLeft={<Settings2 />}
+                    iconRight={<ChevronDown className="opacity-60" />}
+                    size="sm"
+                    variant="secondary"
+                >
+                    {cluster?.label ?? 'Network'}
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuLabel>Network</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {clusters.map(c => (
+                    <DropdownMenuItem
+                        key={c.id}
+                        onClick={() => {
+                            void setCluster(c.id);
+                        }}
+                    >
+                        {c.label}
+                    </DropdownMenuItem>
+                ))}
+                {import.meta.env.DEV && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            onClick={() => {
+                                localStorage.removeItem('setup-complete-localnet');
+                                localStorage.removeItem('setup-complete-devnet');
+                                localStorage.removeItem('setup-cluster');
+                                navigate('/setup');
+                            }}
+                        >
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            Rerun setup
+                        </DropdownMenuItem>
+                    </>
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }
 
@@ -63,7 +100,7 @@ export function AppHeader() {
                 <div className="hidden md:flex items-center gap-4 ml-auto">
                     <TimeTravelButton />
                     <WalletButton />
-                    {import.meta.env.DEV && <NetworkButton />}
+                    <ClusterButton />
                 </div>
 
                 {showMenu && (
@@ -97,7 +134,7 @@ export function AppHeader() {
                             <div className="flex flex-col gap-4">
                                 <TimeTravelButton />
                                 <WalletButton />
-                                {import.meta.env.DEV && <NetworkButton />}
+                                <ClusterButton />
                             </div>
                         </div>
                     </div>

--- a/webapp/src/components/app-header.tsx
+++ b/webapp/src/components/app-header.tsx
@@ -63,7 +63,7 @@ export function AppHeader() {
                 <div className="hidden md:flex items-center gap-4 ml-auto">
                     <TimeTravelButton />
                     <WalletButton />
-                    <NetworkButton />
+                    {import.meta.env.DEV && <NetworkButton />}
                 </div>
 
                 {showMenu && (
@@ -97,7 +97,7 @@ export function AppHeader() {
                             <div className="flex flex-col gap-4">
                                 <TimeTravelButton />
                                 <WalletButton />
-                                <NetworkButton />
+                                {import.meta.env.DEV && <NetworkButton />}
                             </div>
                         </div>
                     </div>

--- a/webapp/src/components/nav-items.ts
+++ b/webapp/src/components/nav-items.ts
@@ -21,5 +21,14 @@ export const NAV_ITEMS: NavItem[] = [
         path: '/plans',
     },
     { clusterFilter: ['solana:localnet', 'solana:devnet'], icon: Droplets, label: 'Faucet', path: '/faucet' },
-    { clusterFilter: ['solana:devnet', 'solana:testnet'], icon: Code2, label: 'Program', path: '/program' },
+    ...(import.meta.env.DEV
+        ? [
+              {
+                  clusterFilter: ['solana:devnet', 'solana:testnet'],
+                  icon: Code2,
+                  label: 'Program',
+                  path: '/program',
+              } satisfies NavItem,
+          ]
+        : []),
 ];

--- a/webapp/src/components/solana/solana-provider.tsx
+++ b/webapp/src/components/solana/solana-provider.tsx
@@ -27,22 +27,28 @@ import { ellipsify } from '@/lib/utils';
 function defaultClusterId(): SolanaClusterId {
     const stored = localStorage.getItem('setup-cluster');
     const configured = import.meta.env.VITE_DEFAULT_CLUSTER;
-    const id = stored || configured || 'solana:localnet';
-    return id === 'solana:devnet' || id === 'solana:testnet' || id === 'solana:localnet'
+    const id = stored || configured || (import.meta.env.DEV ? 'solana:localnet' : 'solana:devnet');
+    return id === 'solana:devnet' || id === 'solana:testnet' || id === 'solana:localnet' || id === 'solana:mainnet'
         ? (id as SolanaClusterId)
-        : 'solana:localnet';
+        : 'solana:devnet';
 }
 
-function networkFromClusterId(clusterId: SolanaClusterId): 'devnet' | 'localnet' | 'testnet' {
+function networkFromClusterId(clusterId: SolanaClusterId): 'devnet' | 'localnet' | 'mainnet' | 'testnet' {
     if (clusterId === 'solana:devnet') return 'devnet';
     if (clusterId === 'solana:testnet') return 'testnet';
+    if (clusterId === 'solana:mainnet') return 'mainnet';
     return 'localnet';
 }
 
 const clusters = [
-    { id: 'solana:localnet' as const, label: 'Localnet', url: '/rpc' },
+    ...(import.meta.env.DEV ? [{ id: 'solana:localnet' as const, label: 'Localnet', url: '/rpc' }] : []),
     { id: 'solana:devnet' as const, label: 'Devnet', url: 'https://api.devnet.solana.com' },
     { id: 'solana:testnet' as const, label: 'Testnet', url: 'https://api.testnet.solana.com' },
+    {
+        id: 'solana:mainnet' as const,
+        label: 'Mainnet',
+        url: import.meta.env.VITE_MAINNET_RPC_URL ?? 'https://api.mainnet-beta.solana.com',
+    },
 ];
 
 export function WalletButton() {

--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -1,0 +1,46 @@
+import type { Network } from '@/lib/cluster';
+
+export interface TokenConfig {
+    symbol: string;
+    name: string;
+    mint: string;
+    decimals: number;
+}
+
+export interface NetworkConfig {
+    programAddress: string | null;
+    tokens: TokenConfig[];
+}
+
+const PROGRAM_ID = 'De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44';
+
+const DEVNET_USDC = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
+const MAINNET_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+export const STATIC_NETWORKS: Record<Network, NetworkConfig> = {
+    localnet: {
+        programAddress: import.meta.env.VITE_LOCALNET_PROGRAM ?? PROGRAM_ID,
+        tokens: import.meta.env.VITE_LOCALNET_USDC_MINT
+            ? [
+                  {
+                      symbol: 'USDC',
+                      name: 'USD Coin (mock)',
+                      mint: import.meta.env.VITE_LOCALNET_USDC_MINT,
+                      decimals: 6,
+                  },
+              ]
+            : [],
+    },
+    devnet: {
+        programAddress: PROGRAM_ID,
+        tokens: [{ symbol: 'USDC', name: 'USD Coin', mint: DEVNET_USDC, decimals: 6 }],
+    },
+    testnet: {
+        programAddress: PROGRAM_ID,
+        tokens: [],
+    },
+    mainnet: {
+        programAddress: PROGRAM_ID,
+        tokens: [{ symbol: 'USDC', name: 'USD Coin', mint: MAINNET_USDC, decimals: 6 }],
+    },
+};

--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -1,10 +1,10 @@
 import type { Network } from '@/lib/cluster';
 
 export interface TokenConfig {
-    symbol: string;
-    name: string;
-    mint: string;
     decimals: number;
+    mint: string;
+    name: string;
+    symbol: string;
 }
 
 export interface NetworkConfig {
@@ -18,29 +18,29 @@ const DEVNET_USDC = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU';
 const MAINNET_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
 export const STATIC_NETWORKS: Record<Network, NetworkConfig> = {
+    devnet: {
+        programAddress: PROGRAM_ID,
+        tokens: [{ decimals: 6, mint: DEVNET_USDC, name: 'USD Coin', symbol: 'USDC' }],
+    },
     localnet: {
         programAddress: import.meta.env.VITE_LOCALNET_PROGRAM ?? PROGRAM_ID,
         tokens: import.meta.env.VITE_LOCALNET_USDC_MINT
             ? [
                   {
-                      symbol: 'USDC',
-                      name: 'USD Coin (mock)',
-                      mint: import.meta.env.VITE_LOCALNET_USDC_MINT,
                       decimals: 6,
+                      mint: import.meta.env.VITE_LOCALNET_USDC_MINT,
+                      name: 'USD Coin (mock)',
+                      symbol: 'USDC',
                   },
               ]
             : [],
     },
-    devnet: {
+    mainnet: {
         programAddress: PROGRAM_ID,
-        tokens: [{ symbol: 'USDC', name: 'USD Coin', mint: DEVNET_USDC, decimals: 6 }],
+        tokens: [{ decimals: 6, mint: MAINNET_USDC, name: 'USD Coin', symbol: 'USDC' }],
     },
     testnet: {
         programAddress: PROGRAM_ID,
         tokens: [],
-    },
-    mainnet: {
-        programAddress: PROGRAM_ID,
-        tokens: [{ symbol: 'USDC', name: 'USD Coin', mint: MAINNET_USDC, decimals: 6 }],
     },
 };

--- a/webapp/src/hooks/use-token-config.ts
+++ b/webapp/src/hooks/use-token-config.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { type NetworkConfig, STATIC_NETWORKS } from '@/config/networks';
 import { useClusterConfig } from '@/hooks/use-cluster-config';
-import { STATIC_NETWORKS, type NetworkConfig } from '@/config/networks';
-import { clusterIdToNetwork } from '@/lib/cluster';
 import { api } from '@/lib/api-client';
+import { clusterIdToNetwork } from '@/lib/cluster';
 
 export function useNetworkConfig() {
     const { id } = useClusterConfig();

--- a/webapp/src/hooks/use-token-config.ts
+++ b/webapp/src/hooks/use-token-config.ts
@@ -1,16 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { useClusterConfig } from '@/hooks/use-cluster-config';
-import type { NetworkConfigResponse } from '@/lib/api-client';
-import { api, clusterIdToNetwork } from '@/lib/api-client';
+import { STATIC_NETWORKS, type NetworkConfig } from '@/config/networks';
+import { clusterIdToNetwork } from '@/lib/cluster';
+import { api } from '@/lib/api-client';
 
 export function useNetworkConfig() {
     const { id } = useClusterConfig();
     const network = clusterIdToNetwork(id);
 
-    return useQuery<NetworkConfigResponse>({
-        queryFn: () => api.config.getNetworkConfig(network),
-        queryKey: ['network-config', network],
+    return useQuery<NetworkConfig>({
+        queryFn: async () => {
+            if (import.meta.env.DEV) {
+                try {
+                    return await api.config.getNetworkConfig(network);
+                } catch {
+                    return STATIC_NETWORKS[network];
+                }
+            }
+            return STATIC_NETWORKS[network];
+        },
+        queryKey: ['network-config', network, import.meta.env.DEV],
         retry: 2,
         staleTime: 30_000,
     });

--- a/webapp/src/lib/cluster.ts
+++ b/webapp/src/lib/cluster.ts
@@ -1,0 +1,8 @@
+export type Network = 'localnet' | 'devnet' | 'testnet' | 'mainnet';
+
+export function clusterIdToNetwork(id: string): Network {
+    if (id.includes('devnet')) return 'devnet';
+    if (id.includes('testnet')) return 'testnet';
+    if (id.includes('mainnet')) return 'mainnet';
+    return 'localnet';
+}

--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "pnpm --filter @subscriptions/client build && pnpm --filter webapp build",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": "dist"
+}

--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "vite",
-  "buildCommand": "pnpm --filter @subscriptions/client build && pnpm --filter webapp build",
-  "installCommand": "pnpm install --frozen-lockfile",
-  "outputDirectory": "dist"
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "framework": "vite",
+    "buildCommand": "pnpm --filter @subscriptions/client build && pnpm --filter webapp build",
+    "installCommand": "pnpm install --frozen-lockfile",
+    "outputDirectory": "dist"
 }


### PR DESCRIPTION
## Summary
- Add `webapp/vercel.json` and static network config so the webapp can deploy to Vercel without the local dev api server
- Lazy-load `Setup` + `Program` routes; render only when `import.meta.env.DEV` (prod build excludes them from the active route table)
- `useNetworkConfig` falls back to static config in DEV and uses static-only in PROD; `SetupGuard` no-ops when `VITE_LOCALNET_USDC_MINT` is set
- New `just dev-local` recipe bootstraps surfpool + program + mock USDC and writes `webapp/.env.local`, so contributors can skip the api server entirely
- ESLint: ignore `.claude/` and `.git/` (was scanning worktree copies of deleted `apps/`)

## Test Plan
- `pnpm --filter @subscriptions/client build && pnpm --filter webapp build` → succeeds
- `just lint-check` → passes
- `just fmt-check` → passes
- Vercel: import repo, set Root Directory `webapp`, deploy → static config picks up devnet program ID + USDC mint
- Local CLI path: `just dev-local && pnpm --filter webapp dev` → loads localnet config from `.env.local`, skips setup wizard
- Local api path: `pnpm --filter subscriptions-api dev & pnpm --filter webapp dev` → setup wizard still runs as before