### PR TITLE
ci: pass deployer pubkey as buffer authority for devnet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
           install -m 600 /dev/null /tmp/deployer.json
           printf '%s' "$DEPLOYER_KEYPAIR" > /tmp/deployer.json
 
+      - name: Derive deployer pubkey
+        id: deployer
+        run: |
+          PUBKEY=$(solana-keygen pubkey /tmp/deployer.json)
+          echo "pubkey=$PUBKEY" >> "$GITHUB_OUTPUT"
+
       - name: Generate IDL
         run: just generate-idl
 
@@ -74,7 +80,7 @@ jobs:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
           keypair: ${{ env.DEPLOYER_KEYPAIR }}
-          buffer-authority-address: ${{ inputs.network == 'mainnet' && env.SQUADS_VAULT || '' }}
+          buffer-authority-address: ${{ inputs.network == 'mainnet' && env.SQUADS_VAULT || steps.deployer.outputs.pubkey }}
           priority-fee: ${{ inputs.priority-fee }}
 
       # ============================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           idl-path: idl/subscriptions.json
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
           buffer-authority: ${{ env.SQUADS_VAULT }}
           priority-fees: ${{ inputs.priority-fee }}
 
@@ -142,7 +142,7 @@ jobs:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
-          keypair: /tmp/deployer.json
+          keypair: ${{ env.DEPLOYER_KEYPAIR }}
           repo-url: ${{ env.REPO_URL }}
           network: mainnet
           mount-path: program


### PR DESCRIPTION
## Summary
- Derive the deployer pubkey from the materialized keypair and pass it as `buffer-authority-address` for devnet releases.
- Unblocks `Write program buffer` on devnet, which was retrying 50× then failing.

## Root Cause
`solana-developers/github-actions/write-program-buffer` runs an internal `Transfer buffer authority` step whenever `steps.check-program.outputs.exists == 'true'`:

```yaml
solana program set-buffer-authority $BUFFER \
  --keypair ./deploy-keypair.json \
  --new-buffer-authority ${{ inputs.buffer-authority-address }} \
  --url ${{ inputs.rpc-url }}
```

We were passing an empty `buffer-authority-address` on devnet, so the CLI rejected the call:

```
error: The argument '--new-buffer-authority <NEW_BUFFER_AUTHORITY>' requires a value but none was supplied
```

The action has no flag to skip this step, so we satisfy it by transferring authority to the deployer itself (effective no-op).

## Test Plan
- [ ] Trigger `Release` workflow against `devnet` from this branch.
- [ ] Confirm `Write program buffer` succeeds (including the `Transfer buffer authority` sub-step).
- [ ] Confirm `Upgrade program (devnet)` proceeds and the program upgrade lands.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25179831115