### PR TITLE
ci: rebuild inside cloned repo for devnet verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           network: devnet
           mount-path: program
           commit-hash: ${{ github.sha }}
-          skip-build: 'true'
+          skip-build: 'false'
 
       # ============================================
       # mainnet: bundle into Squads multisig proposal


### PR DESCRIPTION
## Summary
- Set `skip-build: 'false'` for the devnet `verify-build` step so `solana-verify` performs its own Docker build inside the freshly cloned repo before uploading the verification PDA.

## Root Cause
`solana-verify verify-from-repo` always re-clones the target repo into `/tmp/solana-verify/<uuid>/...`. With `--skip-build` the upload step expects the `.so` to already exist in that clone, but our `Build verified program` step writes artifacts to the workflow workspace (`/home/runner/work/...`), not the clone. The upload then failed with:

```
Skipping local build and writing verify data on chain
Uploading the program verification params to the Solana blockchain...
Error: No such file or directory (os error 2)
```

Letting solana-verify do its own Docker build inside the cloned repo costs a few extra minutes but makes the verification PDA upload work.

## Test Plan
- [ ] Trigger `Release` workflow against `devnet` from this branch.
- [ ] Confirm `Verify build (devnet)` succeeds and a verification PDA is written for `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25182511963