### PR TITLE
ci: drop mount-path for devnet verify build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,6 @@ jobs:
           keypair: ${{ env.DEPLOYER_KEYPAIR }}
           repo-url: ${{ env.REPO_URL }}
           network: devnet
-          mount-path: program
           commit-hash: ${{ github.sha }}
           skip-build: 'false'
 


### PR DESCRIPTION
## Summary
- Remove `mount-path: program` from the devnet `verify-build` step.

## Root Cause
`solana-verify` expects a `Cargo.lock` at the directory it mounts/builds. With `mount-path: program` it looked for `program/Cargo.lock`, which does not exist — the workspace `Cargo.lock` lives at the repo root. Pre-flight failed with:

```
Mount directory must contain a Cargo.lock file
Error: Error verifying program: Missing Cargo.lock file at
'/tmp/solana-verify/<id>/subscriptions/program/Cargo.lock'
```

Dropping `mount-path` lets solana-verify use the repo root and resolve the program via `--library-name subscriptions`, matching how the earlier `Build verified program` step invokes solana-verify.

## Test Plan
- [ ] Trigger `Release` workflow against `devnet` from this branch.
- [ ] Confirm `Verify build (devnet)` clears pre-flight, builds, and writes the verification PDA.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25183322572