### PR TITLE
ci: configure Solana CLI before devnet verify build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
           PUBKEY=$(solana-keygen pubkey /tmp/deployer.json)
           echo "pubkey=$PUBKEY" >> "$GITHUB_OUTPUT"
 
+      - name: Configure Solana CLI
+        run: solana config set --url "$RPC_URL" --keypair "$HOME/.config/solana/id.json"
+
       - name: Generate IDL
         run: just generate-idl
 


### PR DESCRIPTION
## Summary
- Add a `solana config set` step so `~/.config/solana/cli/config.yml` exists before the devnet `verify-build` step runs.

## Root Cause
`solana-verify` (Ellipsis-Labs/solana-verifiable-build) loads the CLI config in `process_otter_verify_ixs` even when `-k <keypair>` is provided. The relevant snippet from upstream `src/solana_program.rs`:

```rust
let user_config = get_user_config_with_path(config_path)?;
let signer = if let Some(path_to_keypair) = path_to_keypair {
    get_keypair_from_path(&path_to_keypair)?
} else {
    user_config.0
};
```

`get_user_config_with_path(None)` calls `Config::load(solana_cli_config::CONFIG_FILE)`, i.e. `~/.config/solana/cli/config.yml`. The shared setup action only creates `~/.config/solana/id.json`; no step in the workflow ever called `solana config set`, so `config.yml` was never materialized. The upload phase therefore aborted with `Error: No such file or directory (os error 2)` after the build had already succeeded and the on-chain hash had matched.

`solana config set --url "$RPC_URL" --keypair "$HOME/.config/solana/id.json"` materializes the config file with a `keypair_path` that exists. The deployer keypair from Doppler is still passed to every sub-action via the `keypair` input and remains the actual transaction signer; this just satisfies `solana-verify`'s unconditional config load.

## Test Plan
- [ ] Trigger `Release` workflow against `devnet` from this branch.
- [ ] Confirm `Verify build (devnet)` clears the upload phase and writes the verification PDA for `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`.

Failing run for reference: https://github.com/solana-program/subscriptions/actions/runs/25185255771