### PR TITLE
ci: bump rust client publish version

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -94,9 +94,22 @@ jobs:
       - name: Get current version
         id: version
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "subscriptions") | .version')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not find subscriptions crate version"
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing subscriptions v$VERSION"
+
+      - name: Check crates.io version availability
+        if: ${{ inputs.publish-to-crates }}
+        run: |
+          REGISTRY_CHECK_DIR="${RUNNER_TEMP:-/tmp}"
+          if (cd "$REGISTRY_CHECK_DIR" && cargo info "subscriptions@${{ steps.version.outputs.version }}" >/dev/null 2>&1); then
+            echo "::error::subscriptions v${{ steps.version.outputs.version }} already exists on crates.io. Bump clients/rust/Cargo.toml before publishing."
+            exit 1
+          fi
 
       - name: Check if prerelease
         id: prerelease

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,7 +5287,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh 1.6.0",
  "num-derive",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump the Rust client crate `subscriptions` to `0.1.1` because `0.1.0` already exists on crates.io
- Read the `subscriptions` package version explicitly in the Rust publish workflow instead of relying on Cargo metadata package order
- Add an early crates.io availability check so already-published versions fail before trusted publishing auth/publish

## Test Plan
- `cargo check -p subscriptions --locked`
- `cargo publish --dry-run --locked --allow-dirty` from `clients/rust`
- `pnpm exec prettier --check .github/workflows/publish-rust.yml`
- YAML parse check for `.github/workflows/publish-rust.yml`
- pre-push hook: format check and lint check