### PR TITLE
fix: include rust client readme in crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,7 +5287,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "borsh 1.6.0",
  "num-derive",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "subscriptions"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }
 repository = { workspace = true }
-include = ["Cargo.toml", "src/**/*.rs"]
+readme = "../../README.md"
+include = ["Cargo.toml", "../../README.md", "src/**/*.rs"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- Point the Rust client crate at the repo-root README, matching Kora's crate metadata pattern.
- Include the repo-root README in the crate package allowlist while keeping generated Rust sources included despite generated/ being gitignored.
- Bump the Rust client crate to 0.1.2 so the README can appear on crates.io in the next immutable release.

## Test Plan
- cargo check -p subscriptions --locked
- cargo package --list --allow-dirty
- cargo publish --dry-run --locked --allow-dirty
- git diff --check
- pre-push hook: format check and lint check