### PR TITLE
ci: pin solana release tooling

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,9 +27,9 @@ inputs:
     required: false
     default: 'true'
   solana-version:
-    description: "Solana CLI version to install (e.g., '4.0.0')"
+    description: "Solana CLI version to install (e.g., 'v4.0.0')"
     required: false
-    default: '4.0.0'
+    default: 'v4.0.0'
 
 runs:
   using: 'composite'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ env:
   PROGRAM: subscriptions
   PROGRAM_ID: De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44
   REPO_URL: https://github.com/solana-program/subscriptions
-  SOLANA_VERSION: '4.0.0'
 
 jobs:
   release:
@@ -49,7 +48,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust-cache-key: 'release-${{ inputs.network }}'
-          solana-version: ${{ env.SOLANA_VERSION }}
+          solana-version: 'v4.0.0'
 
       - name: Install solana-verify
         run: cargo install solana-verify --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-program/subscriptions"
 
+[workspace.metadata.cli]
+solana = "3.1.10"
+
 [workspace.lints.rust]
 unused_imports = "deny"
 dead_code = "warn"


### PR DESCRIPTION
## Summary
- Pin the release workflow Solana CLI install to `v4.0.0`
- Update the shared setup action default Solana CLI version to `v4.0.0`
- Add `workspace.metadata.cli.solana = "3.1.10"` so `solana-verify` selects the supported verifiable-build image instead of inferring from `Cargo.lock`

## Test Plan
- `cargo metadata --format-version 1 --no-deps`
- `solana-verify build --library-name subscriptions -- --locked` prints `Found docker image for Solana version 3.1.10`
- pre-push hook: `just fmt-check`
- pre-push hook: `just lint-check`

## Notes
- The local `solana-verify` build still resolves `subscriptions` to `clients/rust` after image selection; that appears to be the existing library-name collision seen in the failed release run, separate from the Solana image metadata fix.