### PR TITLE
ci: disambiguate release program target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PROGRAM: subscriptions
+  PROGRAM: subscriptions_program
   PROGRAM_ID: De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44
   REPO_URL: https://github.com/solana-program/subscriptions
 
@@ -108,19 +108,6 @@ jobs:
           keypair: ${{ env.DEPLOYER_KEYPAIR }}
           idl-path: idl/subscriptions.json
           priority-fees: ${{ inputs.priority-fee }}
-
-      - if: inputs.network == 'devnet'
-        name: Verify build (devnet)
-        uses: solana-developers/github-actions/verify-build@eb606791e11d06eb92593dfd3404bf0d4c809121
-        with:
-          program: ${{ env.PROGRAM }}
-          program-id: ${{ env.PROGRAM_ID }}
-          rpc-url: ${{ env.RPC_URL }}
-          keypair: ${{ env.DEPLOYER_KEYPAIR }}
-          repo-url: ${{ env.REPO_URL }}
-          network: devnet
-          commit-hash: ${{ github.sha }}
-          skip-build: 'false'
 
       # ============================================
       # mainnet: prepare Squads-owned buffers

--- a/docs/004-program-upgrade-mechanism.md
+++ b/docs/004-program-upgrade-mechanism.md
@@ -53,7 +53,7 @@ solana-verify build
 ### 2. Hash the local build
 
 ```bash
-solana-verify get-executable-hash target/deploy/subscriptions.so
+solana-verify get-executable-hash target/deploy/subscriptions_program.so
 ```
 
 ### 3. Hash the on-chain buffer

--- a/justfile
+++ b/justfile
@@ -347,7 +347,7 @@ verify-mainnet: check-solana-verify
     solana-verify verify-from-repo \
         https://github.com/solana-program/subscriptions \
         --program-id "$PROG_ID" \
-        --library-name subscriptions \
+        --library-name subscriptions_program \
         --mount-path program \
         --remote \
         -um

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [lib]
-name = "subscriptions"
+name = "subscriptions_program"
 crate-type = ["lib", "cdylib"]
 
 [lints]

--- a/runbooks/deployment/main.tx
+++ b/runbooks/deployment/main.tx
@@ -13,7 +13,7 @@ action "deploy_subscriptions" "svm::deploy_program" {
         "subscriptions",
         input.program_keypair_path,
         null,
-        "target/deploy/subscriptions.so"
+        "target/deploy/subscriptions_program.so"
     )
     authority = signer.authority
     payer = signer.payer

--- a/runbooks/surfnet-setup/main.tx
+++ b/runbooks/surfnet-setup/main.tx
@@ -9,6 +9,6 @@ action "install_subscriptions" "svm::setup_surfnet" {
 
     deploy_program {
         program_id = "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44"
-        binary_path = "target/deploy/subscriptions.so"
+        binary_path = "target/deploy/subscriptions_program.so"
     }
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,7 +3,7 @@
 
 # Configuration (can be overridden via environment)
 KEYPAIR_FILE="${KEYPAIR_FILE:-keys/subscriptions-keypair.json}"
-PROGRAM_SO="${PROGRAM_SO:-target/deploy/subscriptions.so}"
+PROGRAM_SO="${PROGRAM_SO:-target/deploy/subscriptions_program.so}"
 LEDGER_DIR="${LEDGER_DIR:-.validator-ledger}"
 RPC_PORT="${RPC_PORT:-8899}"
 
@@ -156,7 +156,7 @@ wait_for_http() {
 prepare_deploy_keys() {
   mkdir -p "target/deploy"
   if [[ -f "$KEYPAIR_FILE" ]]; then
-    cp "$KEYPAIR_FILE" "target/deploy/subscriptions-keypair.json"
+    cp "$KEYPAIR_FILE" "target/deploy/subscriptions_program-keypair.json"
     echo -e "  ${GREEN}Deploy key copied${NC}"
   else
     # Post-rotation (#30) the canonical keypair lives only on the deploy

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -76,7 +76,7 @@ pub fn get_ata_balance(litesvm: &LiteSVM, ata: &Pubkey) -> u64 {
 pub fn setup() -> (LiteSVM, Keypair) {
     let mut litesvm = LiteSVM::new();
 
-    let so_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/deploy/subscriptions.so");
+    let so_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/deploy/subscriptions_program.so");
     litesvm.add_program_from_file(PROGRAM_ID.to_bytes(), so_path).unwrap();
 
     let mut initial_clock = litesvm.get_sysvar::<Clock>();

--- a/webapp/api/server.ts
+++ b/webapp/api/server.ts
@@ -21,7 +21,7 @@ let deployingProgram = false;
 const MIN_SOL_AIRDROP = 0.1;
 const MAX_SOL_AIRDROP = 10;
 
-const SO_PATH = join(__dirname, '../../target/deploy/subscriptions.so');
+const SO_PATH = join(__dirname, '../../target/deploy/subscriptions_program.so');
 const KEYPAIR_PATH = join(__dirname, '../../keys/subscriptions-keypair.json');
 
 const PROGRAM_ADDRESS = 'De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44';


### PR DESCRIPTION
## Summary
- Rename the on-chain program library target to `subscriptions_program` so release tooling no longer collides with the Rust client crate `subscriptions`.
- Update release/runbook/test/webapp artifact references to `target/deploy/subscriptions_program.so`.
- Keep `idl/subscriptions.json` and public client names unchanged, and remove the unsupported devnet verify step.

## Test Plan
- `cargo metadata --format-version 1 --no-deps`
- `cargo build-sbf --manifest-path program/Cargo.toml -- --locked`
- `just generate-clients`
- `cargo test -p subscriptions-program`
- `cargo test -p tests-subscriptions`
- `git diff --check`
- `just fmt-check`
- `just lint-check`

## Notes
- `solana-verify build --library-name subscriptions_program -- --locked` now selects `/build//program/`, confirming the client collision is gone. The full local Docker run still fails on this machine with a Docker mount/path issue that also reproduces in the rewards checkout.