### PR TITLE
ci: squads release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   release:
     name: Release ${{ inputs.network }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
         with:
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@846ab7323c93503ea7b8634fc313313726b83afa
+        uses: dev-jodee/github-actions/prepare-squads-release@c759fc72445a201cdba17ea652a803b81c2553db
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -125,6 +125,10 @@ jobs:
           squads-vault: ${{ env.SQUADS_VAULT }}
           metadata-path: idl/subscriptions.json
           priority-fee: ${{ inputs.priority-fee }}
+          program-buffer-max-sign-attempts: '80'
+          program-buffer-write-timeout-minutes: '80'
+          program-buffer-retry-timeout-minutes: '85'
+          program-buffer-retry-attempts: '1'
           export-verify-pda: 'true'
           repo-url: ${{ env.REPO_URL }}
           commit-hash: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@46df7c5278561de5967cb5878e6eff2a531a8064
+        uses: dev-jodee/github-actions/prepare-squads-release@46df7c5ea1b1da3af494ab2d0a4ace694831c73a
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@5119dacc0f2af4880ceb8fd2406158d979b38d0c
+        uses: dev-jodee/github-actions/prepare-squads-release@46df7c5278561de5967cb5878e6eff2a531a8064
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@d8eb51a3909f455c6b2132b1d0d9e7b98a231dcd
+        uses: dev-jodee/github-actions/prepare-squads-release@5211ef3784cf89d8bfa9bf2bbcd9c704220278cf
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -127,6 +127,7 @@ jobs:
           priority-fee: ${{ inputs.priority-fee }}
           program-buffer-max-sign-attempts: '20'
           program-buffer-write-timeout-minutes: '15'
+          program-buffer-retry-attempts: '4'
           export-verify-pda: 'true'
           repo-url: ${{ env.REPO_URL }}
           commit-hash: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@c759fc72445a201cdba17ea652a803b81c2553db
+        uses: dev-jodee/github-actions/prepare-squads-release@d8eb51a3909f455c6b2132b1d0d9e7b98a231dcd
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -125,10 +125,8 @@ jobs:
           squads-vault: ${{ env.SQUADS_VAULT }}
           metadata-path: idl/subscriptions.json
           priority-fee: ${{ inputs.priority-fee }}
-          program-buffer-max-sign-attempts: '80'
-          program-buffer-write-timeout-minutes: '80'
-          program-buffer-retry-timeout-minutes: '85'
-          program-buffer-retry-attempts: '1'
+          program-buffer-max-sign-attempts: '20'
+          program-buffer-write-timeout-minutes: '15'
           export-verify-pda: 'true'
           repo-url: ${{ env.REPO_URL }}
           commit-hash: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           program: ${{ env.PROGRAM }}
 
       - id: write-buffer
+        if: inputs.network == 'devnet'
         name: Write program buffer
         uses: solana-developers/github-actions/write-program-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
         with:
@@ -83,7 +84,7 @@ jobs:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
           keypair: ${{ env.DEPLOYER_KEYPAIR }}
-          buffer-authority-address: ${{ inputs.network == 'mainnet' && env.SQUADS_VAULT || steps.deployer.outputs.pubkey }}
+          buffer-authority-address: ${{ steps.deployer.outputs.pubkey }}
           priority-fee: ${{ inputs.priority-fee }}
 
       # ============================================
@@ -113,15 +114,20 @@ jobs:
       # mainnet: prepare Squads-owned buffers
       # ============================================
       - if: inputs.network == 'mainnet'
-        id: metadata-buffer
-        name: Write IDL metadata buffer (mainnet)
-        uses: solana-developers/github-actions/write-metadata-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        id: prepare-squads-release
+        name: Prepare Squads release buffers (mainnet)
+        uses: dev-jodee/github-actions/prepare-squads-release@846ab7323c93503ea7b8634fc313313726b83afa
         with:
-          idl-path: idl/subscriptions.json
+          program: ${{ env.PROGRAM }}
+          program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
           keypair: ${{ env.DEPLOYER_KEYPAIR }}
-          buffer-authority: ${{ env.SQUADS_VAULT }}
-          priority-fees: ${{ inputs.priority-fee }}
+          squads-vault: ${{ env.SQUADS_VAULT }}
+          metadata-path: idl/subscriptions.json
+          priority-fee: ${{ inputs.priority-fee }}
+          export-verify-pda: 'true'
+          repo-url: ${{ env.REPO_URL }}
+          commit-hash: ${{ github.sha }}
 
       - if: inputs.network == 'mainnet'
         name: Confirm mainnet buffer handoff
@@ -140,10 +146,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- Program: \`${{ env.PROGRAM_ID }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Buffer: \`${{ steps.write-buffer.outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.network }}" = "mainnet" ]; then
-            echo "- IDL buffer: \`${{ steps.metadata-buffer.outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Buffer: \`${{ steps['prepare-squads-release'].outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- IDL buffer: \`${{ steps['prepare-squads-release'].outputs['metadata-buffer'] }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Verify PDA transaction: \`${{ steps['prepare-squads-release'].outputs['pda-tx'] }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- Buffer authority: \`${{ env.SQUADS_VAULT }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- **Action required**: create the Squads upgrade proposal using the listed buffers" >> $GITHUB_STEP_SUMMARY
             echo "- CI keypair role: fee payer and buffer writer only; it does not need Squads membership" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Buffer: \`${{ steps.write-buffer.outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@5211ef3784cf89d8bfa9bf2bbcd9c704220278cf
+        uses: dev-jodee/github-actions/prepare-squads-release@5119dacc0f2af4880ceb8fd2406158d979b38d0c
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -125,9 +125,10 @@ jobs:
           squads-vault: ${{ env.SQUADS_VAULT }}
           metadata-path: idl/subscriptions.json
           priority-fee: ${{ inputs.priority-fee }}
-          program-buffer-max-sign-attempts: '20'
-          program-buffer-write-timeout-minutes: '15'
-          program-buffer-retry-attempts: '4'
+          program-buffer-max-sign-attempts: '100'
+          program-buffer-write-timeout-minutes: '55'
+          program-buffer-retry-attempts: '1'
+          program-buffer-use-rpc: 'false'
           export-verify-pda: 'true'
           repo-url: ${{ env.REPO_URL }}
           commit-hash: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: dev-jodee/github-actions/prepare-squads-release@46df7c5ea1b1da3af494ab2d0a4ace694831c73a
+        uses: solana-developers/github-actions/prepare-squads-release@b480a01c45f5670da8e9d76fa03d30d9deb7153d
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           echo "pubkey=$PUBKEY" >> "$GITHUB_OUTPUT"
 
       - name: Configure Solana CLI
-        run: solana config set --url "$RPC_URL" --keypair "$HOME/.config/solana/id.json"
+        run: solana config set --url "$RPC_URL" --keypair "$HOME/.config/solana/id.json" > /dev/null
 
       - name: Generate IDL
         run: just generate-idl
@@ -125,10 +125,6 @@ jobs:
           squads-vault: ${{ env.SQUADS_VAULT }}
           metadata-path: idl/subscriptions.json
           priority-fee: ${{ inputs.priority-fee }}
-          program-buffer-max-sign-attempts: '100'
-          program-buffer-write-timeout-minutes: '55'
-          program-buffer-retry-attempts: '1'
-          program-buffer-use-rpc: 'false'
           export-verify-pda: 'true'
           repo-url: ${{ env.REPO_URL }}
           commit-hash: ${{ github.sha }}
@@ -153,7 +149,7 @@ jobs:
           if [ "${{ inputs.network }}" = "mainnet" ]; then
             echo "- Buffer: \`${{ steps['prepare-squads-release'].outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- IDL buffer: \`${{ steps['prepare-squads-release'].outputs['metadata-buffer'] }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- Verify PDA transaction: \`${{ steps['prepare-squads-release'].outputs['pda-tx'] }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Verify PDA transaction exported: \`true\`" >> $GITHUB_STEP_SUMMARY
             echo "- Buffer authority: \`${{ env.SQUADS_VAULT }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- **Action required**: create the Squads upgrade proposal using the listed buffers" >> $GITHUB_STEP_SUMMARY
             echo "- CI keypair role: fee payer and buffer writer only; it does not need Squads membership" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Wire mainnet release to the unmerged `prepare-squads-release` action from solana-developers/github-actions#14, pinned to the PR head SHA.
- Keep devnet on the existing direct buffer/write/upgrade path.
- Surface the Squads-owned program buffer, metadata buffer, and verify PDA transaction in the release summary.

## Test Plan
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"`\n- `pnpm exec prettier --check .github/workflows/release.yml`\n- pre-push `just fmt-check`\n- pre-push `just lint-check`\n\n## Mainnet Test Command\n```sh\ngh workflow run release.yml \\\n  --ref ci/test-squads-release-action \\\n  -f network=mainnet \\\n  -f priority-fee=100000\n```\n\nDraft only: this is for testing solana-developers/github-actions#14 before merging that action upstream.