### PR TITLE
chore(release): bump SDK clients to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,7 +5351,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "borsh",
  "num-derive",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/subscriptions",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `subscriptions` (Rust, crates.io) from 0.2.0 → 0.3.0
- Bump `@solana/subscriptions` (TypeScript, npm) from 0.2.0 → 0.3.0
- Regenerate Cargo.lock crate entry (pnpm-lock unchanged — workspace pkg referenced via `link:`)

0.2.0 is already published on npm + crates.io and tagged (`ts-client-v0.2.0`, `rust-client-v0.2.0`). This bump cuts the next release. Notable changes since 0.2.0: token-2022 support (transfer fees, confidential transfers, inert transfer-hook mints, additional extensions) and authority-generation binding fixes for delegations/subscriptions.

## Release Plan
After merge, publish from `main` via workflow_dispatch (dry-run first, then real):
- `publish-typescript.yml` (dry-run=true → false)
- `publish-rust.yml` (publish-to-crates=false → true)

These workflows read the version from the manifests and create tags `ts-client-v0.3.0` / `rust-client-v0.3.0` + GitHub releases.