### PR TITLE
fix(verify): drop --mount-path, note Apple Silicon build

### DIFF
--- a/justfile
+++ b/justfile
@@ -340,6 +340,9 @@ check-solana-verify:
 
 # Verify mainnet deployment against repo (remote build via OtterSec).
 # Note: Remote verification (--remote) only works on mainnet.
+# Apple Silicon (local builds without --remote): enable Docker/Colima Rosetta and
+# `export DOCKER_DEFAULT_PLATFORM=linux/amd64`. The pinned verify image is amd64-only,
+# so the SBF build fails on getrandom under arm64 emulation without it.
 verify-mainnet: check-solana-verify
     #!/usr/bin/env bash
     set -euo pipefail
@@ -348,6 +351,5 @@ verify-mainnet: check-solana-verify
         https://github.com/solana-program/subscriptions \
         --program-id "$PROG_ID" \
         --library-name subscriptions_program \
-        --mount-path program \
         --remote \
         -um


### PR DESCRIPTION
## Summary
- Remove `--mount-path program` from the `verify-mainnet` justfile recipe. `Cargo.lock` lives at the workspace root, not in `program/`, so solana-verify failed pre-flight with `Missing Cargo.lock file`. Mount the repo root (as CI's `build-verified` action does) and select the program via `--library-name`.
- Add a recipe note that local verification on Apple Silicon requires Docker/Colima Rosetta + `DOCKER_DEFAULT_PLATFORM=linux/amd64`. solana-verify pins Solana `3.1.10` to an amd64-only image and runs `docker run` with no `--platform`, so the SBF build fails compiling `getrandom` under arm64 emulation otherwise.

## Test Plan
- On Apple Silicon: `colima start --vz-rosetta` (or enable Rosetta in Docker Desktop), `export DOCKER_DEFAULT_PLATFORM=linux/amd64`, then `solana-verify verify-from-repo https://github.com/solana-program/subscriptions --program-id De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44 --library-name subscriptions_program -um` — builds clean, getrandom compiles, produces deterministic `.so`.