### PR TITLE
build(verify): add verify-local recipe for program-only build

### DIFF
--- a/justfile
+++ b/justfile
@@ -353,3 +353,6 @@ verify-mainnet: check-solana-verify
         --library-name subscriptions_program \
         --remote \
         -um
+
+verify-local: check-solana-verify
+    solana-verify build --library-name subscriptions_program


### PR DESCRIPTION
## Summary
- Add `just verify-local` for a local verifiable build of the program library only.
- Scopes `solana-verify build` to `--library-name subscriptions_program`. A bare `solana-verify build` mounts the workspace root and SBF-compiles every member; `tests/integration-tests` and `clients/rust` pull `getrandom 0.2.17`, which has no `target_os = "solana"` backend and fails `cargo build-sbf` with "target is not supported". CI passes because `just build` runs `cd program && cargo build-sbf` (program crate only).

## Test Plan
- `DOCKER_DEFAULT_PLATFORM=linux/amd64 just verify-local` → builds the program lib, no getrandom error (verified locally; produced program hash).