### PR TITLE
chore: point repo URLs to solana-foundation org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 env:
   PROGRAM: subscriptions_program
   PROGRAM_ID: De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44
-  REPO_URL: https://github.com/solana-program/subscriptions
+  REPO_URL: https://github.com/solana-foundation/subscriptions
 
 jobs:
   release:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/solana-program/subscriptions"
+repository = "https://github.com/solana-foundation/subscriptions"
 
 [workspace.metadata.cli]
 solana = "3.1.10"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ subscriptions/
 ## Quick Start
 
 ```bash
-git clone git@github.com:solana-program/subscriptions.git
+git clone git@github.com:solana-foundation/subscriptions.git
 cd subscriptions
 just setup
 just build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **DO NOT CREATE A GITHUB ISSUE** to report a security problem.
 
-Instead please use this [Report a Vulnerability](https://github.com/solana-program/subscriptions/security/advisories/new) link.
+Instead please use this [Report a Vulnerability](https://github.com/solana-foundation/subscriptions/security/advisories/new) link.
 Provide a helpful title and detailed description of the problem.
 Expect a response as fast as possible in the advisory, typically within 72 hours.
 

--- a/audits/AUDIT_STATUS.md
+++ b/audits/AUDIT_STATUS.md
@@ -9,9 +9,9 @@ Last updated: 2026-04-08
 - Auditor: Cantina
 - Report: `audits/report-cli-cantina-db2ffeea-c85c-4f35-b188-e861cdcd785d-solana-multi-delegator.pdf`
 - Audited-through commit: `18a50bc21c4b91ed62e612109c371f41200385e8`
-- Compare audited baseline delta: https://github.com/solana-program/subscriptions/compare/18a50bc21c4b91ed62e612109c371f41200385e8...main
+- Compare audited baseline delta: https://github.com/solana-foundation/subscriptions/compare/18a50bc21c4b91ed62e612109c371f41200385e8...main
 - Audit fixes implemented/verified through commit: `b4b0345f9fd616e1355b7b6628362283fd6b1691`
-- Compare post-fix delta: https://github.com/solana-program/subscriptions/compare/b4b0345f9fd616e1355b7b6628362283fd6b1691...main
+- Compare post-fix delta: https://github.com/solana-foundation/subscriptions/compare/b4b0345f9fd616e1355b7b6628362283fd6b1691...main
 
 Audit scope is commit-based. The external audit baseline is `18a50bc...`. Audit remediation was implemented and verified through `b4b0345...`.
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,8 +1,8 @@
 # @solana/subscriptions
 
-TypeScript SDK for the [Subscriptions Solana program](https://github.com/solana-program/subscriptions): token delegation, recurring payments, and subscriptions. Ships as a [`@solana/kit`](https://github.com/anza-xyz/kit) plugin.
+TypeScript SDK for the [Subscriptions Solana program](https://github.com/solana-foundation/subscriptions): token delegation, recurring payments, and subscriptions. Ships as a [`@solana/kit`](https://github.com/anza-xyz/kit) plugin.
 
-**Source & issues:** https://github.com/solana-program/subscriptions
+**Source & issues:** https://github.com/solana-foundation/subscriptions
 
 ## Installation
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -4,14 +4,14 @@
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",
-    "homepage": "https://github.com/solana-program/subscriptions#readme",
+    "homepage": "https://github.com/solana-foundation/subscriptions#readme",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/solana-program/subscriptions.git",
+        "url": "git+https://github.com/solana-foundation/subscriptions.git",
         "directory": "clients/typescript"
     },
     "bugs": {
-        "url": "https://github.com/solana-program/subscriptions/issues"
+        "url": "https://github.com/solana-foundation/subscriptions/issues"
     },
     "keywords": [
         "solana",

--- a/docs/004-program-upgrade-mechanism.md
+++ b/docs/004-program-upgrade-mechanism.md
@@ -75,7 +75,7 @@ After an upgrade, anyone can verify the on-chain program matches the public sour
 ```bash
 solana-verify verify-from-repo \
     --program-id <PROGRAM_ID> \
-    --url https://github.com/solana-program/subscriptions
+    --url https://github.com/solana-foundation/subscriptions
 ```
 
 ## References

--- a/justfile
+++ b/justfile
@@ -348,7 +348,7 @@ verify-mainnet: check-solana-verify
     set -euo pipefail
     PROG_ID=$(sed -n 's/.*declare_id!("\([^"]*\)").*/\1/p' "{{program_dir}}/src/lib.rs")
     solana-verify verify-from-repo \
-        https://github.com/solana-program/subscriptions \
+        https://github.com/solana-foundation/subscriptions \
         --program-id "$PROG_ID" \
         --library-name subscriptions_program \
         --remote \

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -54,9 +54,9 @@ use solana_security_txt::security_txt;
 #[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Subscriptions Program",
-    project_url: "https://github.com/solana-program/subscriptions",
-    contacts: "link:https://github.com/solana-program/subscriptions/security/advisories/new",
-    policy: "https://github.com/solana-program/subscriptions/security/policy",
-    source_code: "https://github.com/solana-program/subscriptions",
+    project_url: "https://github.com/solana-foundation/subscriptions",
+    contacts: "link:https://github.com/solana-foundation/subscriptions/security/advisories/new",
+    policy: "https://github.com/solana-foundation/subscriptions/security/policy",
+    source_code: "https://github.com/solana-foundation/subscriptions",
     auditors: "Cantina"
 }


### PR DESCRIPTION
## Summary
- Repo moved from `solana-program` to `solana-foundation` GitHub org; swap `solana-program/subscriptions` → `solana-foundation/subscriptions` across 10 files
- Updated: `Cargo.toml` repository, `clients/typescript/package.json` (homepage/repo/bugs), docs, README, SECURITY.md, audit compare links, `release.yml` REPO_URL, and on-chain `security_txt!` URLs in `program/src/lib.rs`
- Left untouched: ecosystem `@solana-program/*` npm deps, the `solana-program/program-metadata` reference (different repo), and dynamic `${{ github.repository }}` workflow refs (self-correct)

## Test Plan
- `grep -rn 'solana-program/subscriptions' .` → 0 matches (excluding vendored/generated)
- `just build && just integration-test` — string-only change, must still pass
- on-chain `security_txt` URL only takes effect on next program deploy/upgrade

## Follow-up ops (out of this PR, human)
- npm trusted publisher (`@solana/subscriptions`, published) → re-point to new org
- crates.io trusted publisher (`subscriptions`) → verify/re-point
- Doppler service-identity OIDC trust subject → update to new repo path
- Vercel GitHub App → re-authorize on `solana-foundation` org (site stays live, git auto-deploy disconnects until reconnected)
- re-run `just verify-mainnet` if program is mainnet-verified