### PR TITLE
ci: add stale PR workflow with 30-day window

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10.3.0
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 5
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-message: >
+            This PR has been inactive for 30 days and has been marked as stale.
+            It will be closed in 5 days if there is no further activity.
+          close-pr-message: 'Closed due to inactivity.'
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,work-in-progress'
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- Add a stale PR workflow matching the escrow/rewards repos
- Marks PRs stale after 30 days of inactivity, closes 5 days later
- Issues are exempt (`days-before-issue-stale: -1`)