### PR TITLE
test: add TransferFee test for transfer_recurring_delegation

### DIFF
--- a/tests/integration-tests/src/test_transfer_recurring_delegation.rs
+++ b/tests/integration-tests/src/test_transfer_recurring_delegation.rs
@@ -798,6 +798,47 @@ fn test_recurring_transfer_past_drift_window() {
 }
 
 #[test]
+fn test_recurring_transfer_token_2022_transfer_fee() {
+    let (mut litesvm, alice) = setup();
+    let bob = Keypair::new();
+    litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
+
+    let mint = init_mint(
+        &mut litesvm,
+        TOKEN_2022_PROGRAM_ID,
+        MINT_DECIMALS,
+        1_000_000_000,
+        Some(alice.pubkey()),
+        &[ExtensionType::TransferFeeConfig],
+    );
+    let alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+    let bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
+
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+
+    let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
+        50_000_000,
+        hours(1),
+        current_ts(),
+        current_ts() + days(1) as i64,
+    );
+    res.assert_ok();
+
+    TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+        .amount(10_000_000)
+        .recurring()
+        .assert_ok();
+
+    assert_eq!(get_ata_balance(&litesvm, &alice_ata), 90_000_000);
+    assert_eq!(get_ata_balance(&litesvm, &bob_ata), 9_900_000);
+
+    let delegation_account = litesvm.get_account(&delegation_pda).unwrap();
+    let delegation = RecurringDelegation::load(&delegation_account.data).unwrap();
+    let amount_pulled = delegation.amount_pulled_in_period;
+    assert_eq!(amount_pulled, 10_000_000);
+}
+
+#[test]
 fn test_recurring_transfer_token_2022_confidential_transfer_public_balance() {
     let (mut litesvm, alice) = setup();
     let bob = Keypair::new();


### PR DESCRIPTION
## Summary

Closes #153 

Adds `test_recurring_transfer_token_2022_transfer_fee` to
`tests/integration-tests/src/test_transfer_recurring_delegation.rs`,
closing a parity gap with the fixed-delegation test suite.

**What the test verifies:**
- Transfer succeeds against a Token-2022 mint with `TransferFeeConfig` (1% fee)
- Alice's ATA loses the gross amount (10,000,000)
- Bob's ATA receives the net amount (9,900,000) — fee withheld from receiver
- `amount_pulled_in_period` records the gross amount (10,000,000), not the net

The third assertion is the important one: it documents that the per-period
cap enforces limits on what is **pulled from the delegator**, independent
of what the delegatee actually receives after fees.

## Test plan
- [x] `cargo test -p tests-subscriptions test_transfer_recurring_delegation` — all 22 tests pass
