### PR TITLE
ci: add webapp build job to validate frontend on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,26 @@ jobs:
 
       - name: Build program and clients
         run: just build
+
+  webapp-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup
+        with:
+          install-rust: 'false'
+          install-solana: 'false'
+          install-just: 'false'
+          enable-rust-cache: 'false'
+
+      - name: Generate and build TypeScript client
+        run: |
+          pnpm run generate-clients
+          pnpm --filter @solana/subscriptions build
+
+      - name: Build webapp
+        run: pnpm --filter webapp build


### PR DESCRIPTION
## Summary
- Add a `webapp-build` job to `.github/workflows/build.yml` that compiles the `webapp/` workspace on every PR.
- Closes a CI coverage gap: `webapp/` was never built, typechecked, or tested. Frontend-only dependency bumps (e.g. the current `lucide-react` dependabot PR) went green without anything compiling the code that uses them.
- Node-only job (no Rust/Solana toolchain): generates + builds the TS client, then runs `tsc -b && vite build` for webapp. `generate-clients` reads the committed IDL, so no `cargo build-sbf` needed.

## Test Plan
Verified the full chain locally on current main:
```
pnpm install --frozen-lockfile
pnpm run generate-clients
pnpm --filter @solana/subscriptions build
pnpm --filter webapp build   # tsc -b && vite build -> green
```
After merge, the new `webapp-build` check should appear and pass on open PRs (including the lucide-react bump).