### PR TITLE
fix(webapp): map custom program errors per failing program

### DIFF
--- a/webapp/src/lib/parse-program-error.ts
+++ b/webapp/src/lib/parse-program-error.ts
@@ -1,24 +1,43 @@
 import idl from '@idl';
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022';
 
 type IdlError = { code: number; name: string; message: string };
 
 const errors = (idl.program?.errors ?? []) as IdlError[];
 const PROGRAM_ERRORS: Record<number, string> = Object.fromEntries(errors.map(e => [e.code, e.message]));
+const PROGRAM_ADDRESS = idl.program?.publicKey ?? '';
 
 const SPL_TOKEN_ERRORS: Record<number, string> = {
     0: 'Account not rent exempt',
     1: 'Insufficient funds',
     2: 'Invalid mint',
-    3: 'Mint mismatch',
+    3: 'Account not associated with this mint',
     4: 'Owner mismatch',
+    5: 'Mint has a fixed supply',
+    6: 'Account already in use',
+    7: 'Invalid number of provided signers',
+    8: 'Invalid number of required signers',
+    9: 'Token account is not initialized',
+    10: 'Instruction does not support native tokens',
+    11: 'Non-native account can only be closed if its balance is zero',
+    12: 'Invalid instruction',
+    13: 'Account is in an invalid state for this operation',
+    14: 'Operation overflowed',
+    15: 'Account does not support the specified authority type',
+    16: 'This mint cannot freeze accounts',
+    17: 'Token account is frozen',
+    18: 'Decimals do not match the mint',
+    19: 'Instruction does not support non-native tokens',
 };
 
-export function parseProgramError(error: unknown, programAddress?: string): string {
+const TOKEN_PROGRAM_IDS = new Set<string>([TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]);
+
+export function parseProgramError(error: unknown): string {
     if (!(error instanceof Error)) return 'Unknown error';
 
     const hexMatch = error.message.match(/custom program error: 0x([0-9a-fA-F]+)/i);
     const decMatch = error.message.match(/Custom\((\d+)\)/);
-
     const code = hexMatch ? parseInt(hexMatch[1], 16) : decMatch ? parseInt(decMatch[1], 10) : null;
 
     if (code === null) return error.message;
@@ -26,10 +45,17 @@ export function parseProgramError(error: unknown, programAddress?: string): stri
     const failLineMatch = error.message.match(/Program (\w+) failed: custom program error:/);
     const failedProgram = failLineMatch?.[1] ?? '';
 
-    if (!programAddress || failedProgram === programAddress) {
-        const msg = PROGRAM_ERRORS[code];
-        if (msg) return msg;
+    if (failedProgram === PROGRAM_ADDRESS) {
+        return PROGRAM_ERRORS[code] ?? `Subscriptions program error ${code}`;
     }
 
-    return SPL_TOKEN_ERRORS[code] ?? `Program error ${code}`;
+    if (TOKEN_PROGRAM_IDS.has(failedProgram)) {
+        return SPL_TOKEN_ERRORS[code] ?? `Token program error ${code}`;
+    }
+
+    if (failedProgram) {
+        return `Program ${failedProgram} error ${code}`;
+    }
+
+    return PROGRAM_ERRORS[code] ?? `Program error ${code}`;
 }


### PR DESCRIPTION
## Summary
- `parseProgramError` applied the SPL Token error table to **any** unmapped custom error code, regardless of which program threw it. An error 17 from a non-token program would be mislabeled as "Token account is frozen".
- Now attributes the custom error code to the **failing program** before mapping: our subscriptions program (from the IDL `publicKey`) vs SPL Token / Token-2022 (`TOKEN_PROGRAM_ADDRESS` / `TOKEN_2022_PROGRAM_ADDRESS`). Unattributable codes fall back to naming the program + code instead of a bare number.
- Completed the standard SPL Token error table (codes 0–19). Error 17 = `AccountFrozen` → "Token account is frozen" (verified against spl-token-interface source).

## Context
Reported: a recurring-delegation pull on devnet failed with "Program error 17". Confirmed the destination token account was **frozen** (Token-2022 mint). The old message surfaced the raw code; this makes it readable and correctly scoped to the emitting program.

## Test Plan
- `prettier --check` clean.
- `pnpm --filter webapp exec tsc -b` passes (webapp typechecks clean with the change).
- Change is isolated to `webapp/src/lib/parse-program-error.ts`.