### PR TITLE
ci(cu): skip CU report comment on forked PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,4 +31,5 @@ jobs:
         run: just test-and-benchmark
 
       - name: Report compute units
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: solana-developers/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0


### PR DESCRIPTION
## Summary
- Forked PRs run the Benchmark workflow with a read-only `GITHUB_TOKEN`, so the cu-benchmark action's comment-upsert step fails with `403 Resource not accessible by integration` and marks the Compute Units check red.
- Guard the `Report compute units` step with `if: github.event.pull_request.head.repo.full_name == github.repository` so it only runs for same-repo PRs.
- Benchmark + tests still run on forks; only the CU comment is skipped. Matches the guard used across vault/rewards/escrow.

## Test Plan
- Same-repo PR: CU comment posts as before, check green.
- Forked PR: report step skipped (neutral), Benchmark check green instead of 403 failure.