### PR TITLE
audit remediation: MULT-54/53/56 fixes + MULT-57/51 docs & CI

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Guard allowed source branch for release publish
         run: |
           case "${{ github.ref }}" in
-            refs/heads/main|refs/heads/hotfix/*) ;;
+            refs/heads/main) ;;
             *)
-              echo "::error::Publish Rust Client must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              echo "::error::Publish Rust Client must be run from main. Current ref: ${{ github.ref }}"
               exit 1
               ;;
           esac

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Guard allowed source branch for release publish
         run: |
           case "${{ github.ref }}" in
-            refs/heads/main|refs/heads/hotfix/*) ;;
+            refs/heads/main) ;;
             *)
-              echo "::error::Publish TypeScript Client must be run from main or hotfix/*. Current ref: ${{ github.ref }}"
+              echo "::error::Publish TypeScript Client must be run from main. Current ref: ${{ github.ref }}"
               exit 1
               ;;
           esac

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported delegation models:
 
 The program emits on-chain events via self-CPI for indexer integration (subscription created/cancelled, fixed/recurring/subscription transfers).
 
-Token-2022 mints are supported. The only extension rejected is a configured `TransferHook` (where the hook `authority` or `program_id` is set). An inert `TransferHook` (both unset, therefore permanently immutable) is allowed.
+Token-2022 mints are supported, including mints with a configured `TransferHook`. On delegated transfers the program forwards the mint's runtime hook accounts into the Token-2022 `TransferChecked` CPI, which executes the configured hook program. The hook's `ExtraAccountMetaList` validation PDA is required among those accounts, so an active hook's configured policy context is always enforced.
 
 Delegation accounts include a version field and the program implements a three-tier migration framework (lazy in-place update, explicit migrate instruction, revoke/recreate) for future upgrades. See [ADR-003](docs/003-versioning-migration-architecture.md) for details.
 

--- a/clients/typescript/test/subscription-security.test.ts
+++ b/clients/typescript/test/subscription-security.test.ts
@@ -1584,7 +1584,7 @@ describe('Subscription Security', () => {
             .sendTransaction();
 
         const subData = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda)).data;
-        expect(subData.expiresAtTs).toBeLessThanOrEqual(endTs);
+        expect(subData.expiresAtTs).toBe(endTs + 1n);
 
         const signature = await t.client.subscriptions.instructions
             .revokeSubscription({

--- a/docs/001-program-architecture.md
+++ b/docs/001-program-architecture.md
@@ -505,7 +505,10 @@ Executes a transfer for a recurring delegation.
 
 ## Token-2022 Extension Policy
 
-`Mint2022Account::check` rejects only mints with a configured `TransferHook`
-(`authority` or `program_id` set). An inert `TransferHook` (both fields unset) is
-allowed: with no hook authority, `update_transfer_hook` cannot be invoked, so the hook
-stays permanently dormant.
+`Mint2022Account::check` validates that the account is a Token-2022 mint but does not
+reject any extension. Mints with a configured `TransferHook` are supported: delegated
+transfers (`transfer_fixed` / `transfer_recurring` / `transfer_subscription`) forward the
+caller-supplied hook accounts into the Token-2022 `TransferChecked` CPI, which invokes the
+hook program. `invoke_transfer_checked_with_hook` requires the hook's `ExtraAccountMetaList`
+validation PDA among the supplied accounts, so an active hook's configured policy context is
+always enforced.

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -2656,6 +2656,62 @@
         ],
         "kind": "instructionNode",
         "name": "revokeSubscriptionAuthority"
+      },
+      {
+        "accounts": [
+          {
+            "docs": [
+              "The recorded payer reclaiming rent"
+            ],
+            "isSigner": true,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "payer"
+          },
+          {
+            "docs": [
+              "The fixed or recurring delegation PDA to close"
+            ],
+            "isSigner": false,
+            "isWritable": true,
+            "kind": "instructionAccountNode",
+            "name": "delegationAccount"
+          },
+          {
+            "docs": [
+              "The delegation's recorded SubscriptionAuthority PDA (may be closed)"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "subscriptionAuthority"
+          }
+        ],
+        "arguments": [
+          {
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 15
+            },
+            "defaultValueStrategy": "omitted",
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "endian": "le",
+              "format": "u8",
+              "kind": "numberTypeNode"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "kind": "instructionNode",
+        "name": "revokeAbandonedDelegation"
       }
     ],
     "kind": "programNode",

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -1063,6 +1063,12 @@
         "name": "transferHookTooManyAccounts"
       },
       {
+        "code": 138,
+        "kind": "errorNode",
+        "message": "Transfer hook validation account missing from provided accounts",
+        "name": "transferHookValidationAccountMissing"
+      },
+      {
         "code": 300,
         "kind": "errorNode",
         "message": "Transfer amount exceeds delegation limit",

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -3,8 +3,9 @@ use pinocchio::{account::AccountView, entrypoint, Address, ProgramResult};
 use crate::instructions::{
     cancel_subscription, close_subscription_authority, create_fixed_delegation, create_plan,
     create_recurring_delegation, delete_plan, emit_event, initialize_subscription_authority, resume_subscription,
-    revoke_delegation, revoke_subscription_authority, subscribe, transfer_fixed_delegation,
-    transfer_recurring_delegation, transfer_subscription, update_plan, SubscriptionsInstruction,
+    revoke_abandoned_delegation, revoke_delegation, revoke_subscription_authority, subscribe,
+    transfer_fixed_delegation, transfer_recurring_delegation, transfer_subscription, update_plan,
+    SubscriptionsInstruction,
 };
 
 entrypoint!(process_instruction);
@@ -34,6 +35,7 @@ pub fn process_instruction(
         SubscriptionsInstruction::CancelSubscription => cancel_subscription::process(accounts),
         SubscriptionsInstruction::ResumeSubscription => resume_subscription::process(accounts),
         SubscriptionsInstruction::RevokeSubscriptionAuthority => revoke_subscription_authority::process(accounts),
+        SubscriptionsInstruction::RevokeAbandonedDelegation => revoke_abandoned_delegation::process(accounts),
         SubscriptionsInstruction::EmitEvent => emit_event::process(program_id, accounts),
     }
 }

--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -53,6 +53,7 @@ impl TryFrom<u32> for SubscriptionsError {
             135 => Ok(Self::DelegationAlreadyExists),
             136 => Ok(Self::StaleSubscriptionAuthority),
             137 => Ok(Self::TransferHookTooManyAccounts),
+            138 => Ok(Self::TransferHookValidationAccountMissing),
             // Fixed delegation errors (300-399)
             300 => Ok(Self::AmountExceedsLimit),
             301 => Ok(Self::FixedDelegationExpiryInPast),
@@ -185,6 +186,8 @@ pub enum SubscriptionsError {
     StaleSubscriptionAuthority,
     #[error("Too many transfer hook accounts provided")]
     TransferHookTooManyAccounts,
+    #[error("Transfer hook validation account missing from provided accounts")]
+    TransferHookValidationAccountMissing,
 
     // --- Fixed delegation errors (300--399) ---
     #[error("Transfer amount exceeds delegation limit")]

--- a/program/src/instructions/cancel_subscription.rs
+++ b/program/src/instructions/cancel_subscription.rs
@@ -62,8 +62,10 @@ pub fn process(accounts: &mut [AccountView]) -> ProgramResult {
                     .checked_add(1)
                     .and_then(|p| p.checked_mul(period_length_s))
                     .and_then(|offset| period_start.checked_add(offset))
-                    // Cap at plan end so the subscriber can revoke as soon as the plan expires.
-                    .map(|ts| if plan.data.end_ts != 0 { ts.min(plan.data.end_ts) } else { ts })
+                    // end_ts is inclusive (the merchant may pull through end_ts), so cap one
+                    // second past it: revoke unlocks only once current_ts > end_ts, matching the
+                    // plan-expiry boundary used everywhere else.
+                    .map(|ts| if plan.data.end_ts != 0 { ts.min(plan.data.end_ts.saturating_add(1)) } else { ts })
                     .ok_or::<ProgramError>(SubscriptionsError::ArithmeticOverflow.into())?;
             }
         } else {

--- a/program/src/instructions/helpers/transfer_hook_util.rs
+++ b/program/src/instructions/helpers/transfer_hook_util.rs
@@ -16,6 +16,7 @@ const ACCOUNT_TYPE_INDEX: usize = 165;
 const TLV_START_INDEX: usize = ACCOUNT_TYPE_INDEX + 1;
 const TLV_HEADER_LEN: usize = 4;
 const EXTENSION_TYPE_TRANSFER_HOOK: u16 = 14;
+const EXTRA_ACCOUNT_METAS_SEED: &[u8] = b"extra-account-metas";
 const TRANSFER_HOOK_EXTENSION_LEN: usize = 64; // authority(32) || program_id(32)
 const TRANSFER_HOOK_PROGRAM_ID_OFFSET: usize = 32;
 const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
@@ -81,9 +82,14 @@ pub fn mint_transfer_hook_program_id(mint_data: &[u8]) -> Result<Option<Address>
 
 /// `TransferChecked` CPI forwarding the caller-supplied `remaining` hook accounts
 /// (each with its runtime writable/signer flags); Token-2022 validates them.
+///
+/// Requires the hook's `ExtraAccountMetaList` validation PDA among `remaining`.
+/// Token-2022 only resolves the hook's configured policy context when that PDA
+/// is passed, so without this check an active-hook transfer would fail open.
 #[allow(clippy::too_many_arguments)]
 pub fn invoke_transfer_checked_with_hook(
     token_program: &Address,
+    hook_program: &Address,
     from: &AccountView,
     mint: &AccountView,
     to: &AccountView,
@@ -95,6 +101,12 @@ pub fn invoke_transfer_checked_with_hook(
 ) -> ProgramResult {
     if remaining.len() > MAX_TRANSFER_HOOK_REMAINING_ACCOUNTS {
         return Err(SubscriptionsError::TransferHookTooManyAccounts.into());
+    }
+
+    let (validation_pda, _) =
+        Address::find_program_address(&[EXTRA_ACCOUNT_METAS_SEED, mint.address().as_ref()], hook_program);
+    if !remaining.iter().any(|account| account.address().eq(&validation_pda)) {
+        return Err(SubscriptionsError::TransferHookValidationAccountMissing.into());
     }
 
     let mut data = [0u8; 10];

--- a/program/src/instructions/helpers/transfer_utils.rs
+++ b/program/src/instructions/helpers/transfer_utils.rs
@@ -183,9 +183,10 @@ pub fn transfer_with_delegate(
     ];
     let signer = [Signer::from(&seeds)];
 
-    if hook_program_id.is_some() {
+    if let Some(hook_program_id) = hook_program_id {
         return invoke_transfer_checked_with_hook(
             accounts.token_program.address(),
+            &hook_program_id,
             accounts.delegator_ata,
             accounts.token_mint,
             accounts.to_ata,

--- a/program/src/instructions/mod.rs
+++ b/program/src/instructions/mod.rs
@@ -18,6 +18,7 @@ pub mod emit_event;
 pub mod helpers;
 pub mod initialize_subscription_authority;
 pub mod resume_subscription;
+pub mod revoke_abandoned_delegation;
 pub mod revoke_delegation;
 pub mod revoke_subscription_authority;
 pub mod transfer_fixed_delegation;
@@ -268,6 +269,14 @@ pub enum SubscriptionsInstruction {
     #[codama(account(name = "token_program", docs = "Token program"))]
     RevokeSubscriptionAuthority = 14,
 
+    #[codama(account(name = "payer", signer, writable, docs = "The recorded payer reclaiming rent"))]
+    #[codama(account(name = "delegation_account", writable, docs = "The fixed or recurring delegation PDA to close"))]
+    #[codama(account(
+        name = "subscription_authority",
+        docs = "The delegation's recorded SubscriptionAuthority PDA (may be closed)"
+    ))]
+    RevokeAbandonedDelegation = 15,
+
     #[codama(skip)]
     #[codama(account(
         name = "event_authority",
@@ -324,6 +333,7 @@ impl SubscriptionsInstruction {
             cancel_subscription::DISCRIMINATOR => Ok(Self::CancelSubscription),
             resume_subscription::DISCRIMINATOR => Ok(Self::ResumeSubscription),
             revoke_subscription_authority::DISCRIMINATOR => Ok(Self::RevokeSubscriptionAuthority),
+            revoke_abandoned_delegation::DISCRIMINATOR => Ok(Self::RevokeAbandonedDelegation),
             &EMIT_EVENT_IX_DISC => Ok(Self::EmitEvent),
             _ => Err(SubscriptionsError::InvalidInstruction.into()),
         }
@@ -348,6 +358,7 @@ impl fmt::Display for SubscriptionsInstruction {
             Self::CancelSubscription => write!(f, "cancel_subscription"),
             Self::ResumeSubscription => write!(f, "resume_subscription"),
             Self::RevokeSubscriptionAuthority => write!(f, "revoke_subscription_authority"),
+            Self::RevokeAbandonedDelegation => write!(f, "revoke_abandoned_delegation"),
             Self::EmitEvent => write!(f, "emit_event"),
         }
     }

--- a/program/src/instructions/revoke_abandoned_delegation.rs
+++ b/program/src/instructions/revoke_abandoned_delegation.rs
@@ -80,7 +80,10 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
             true
         } else {
             let authority_data = accounts.subscription_authority.try_borrow()?;
-            SubscriptionAuthority::load(&authority_data)?.init_id != recorded_init_id
+            match SubscriptionAuthority::load(&authority_data) {
+                Ok(authority) => authority.init_id != recorded_init_id,
+                Err(_) => true,
+            }
         };
 
         if !authority_is_dead {

--- a/program/src/instructions/revoke_abandoned_delegation.rs
+++ b/program/src/instructions/revoke_abandoned_delegation.rs
@@ -1,0 +1,92 @@
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+
+use crate::{
+    state::{
+        common::AccountDiscriminator, fixed_delegation::FixedDelegation, recurring_delegation::RecurringDelegation,
+    },
+    AccountCheck, AccountClose, Header, ProgramAccount, SignerAccount, SubscriptionAuthority, SubscriptionsError,
+    WritableAccount, DISCRIMINATOR_OFFSET,
+};
+
+/// Validated accounts for the [`RevokeAbandonedDelegation`](crate::SubscriptionsInstruction::RevokeAbandonedDelegation) instruction.
+pub struct RevokeAbandonedDelegationAccounts<'a> {
+    /// The recorded payer reclaiming rent (signer + writable).
+    pub payer: &'a AccountView,
+    /// The fixed or recurring delegation PDA to close.
+    pub delegation_account: &'a AccountView,
+    /// The SubscriptionAuthority PDA recorded on the delegation; may be closed.
+    pub subscription_authority: &'a AccountView,
+}
+
+impl<'a> TryFrom<&'a [AccountView]> for RevokeAbandonedDelegationAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(accounts: &'a [AccountView]) -> Result<Self, Self::Error> {
+        let [payer, delegation_account, subscription_authority, ..] = accounts else {
+            return Err(SubscriptionsError::NotEnoughAccountKeys.into());
+        };
+
+        SignerAccount::check(payer)?;
+        WritableAccount::check(payer)?;
+        WritableAccount::check(delegation_account)?;
+        ProgramAccount::check(delegation_account)?;
+
+        Ok(Self { payer, delegation_account, subscription_authority })
+    }
+}
+
+/// Instruction discriminator byte for `RevokeAbandonedDelegation`.
+pub const DISCRIMINATOR: &u8 = &15;
+
+/// Closes a fixed or recurring delegation back to its payer once the delegator
+/// has rendered it permanently unusable — its SubscriptionAuthority PDA is
+/// closed, or that PDA's `init_id` no longer matches the delegation header.
+///
+/// This is the payer's only recovery path for `expiry_ts == 0` delegations,
+/// which [`RevokeDelegation`](crate::SubscriptionsInstruction::RevokeDelegation)
+/// can never close. Both dead states are irreversible, so a live delegation can
+/// never be closed here.
+pub fn process(accounts: &[AccountView]) -> ProgramResult {
+    let accounts = RevokeAbandonedDelegationAccounts::try_from(accounts)?;
+
+    {
+        let data = accounts.delegation_account.try_borrow()?;
+        if data.len() < Header::LEN {
+            return Err(SubscriptionsError::InvalidHeaderData.into());
+        }
+
+        let (recorded_authority, recorded_init_id, payer) =
+            match AccountDiscriminator::try_from(data[DISCRIMINATOR_OFFSET])? {
+                AccountDiscriminator::FixedDelegation => {
+                    let delegation = FixedDelegation::load_with_min_size(&data)?;
+                    (delegation.subscription_authority, delegation.header.init_id, delegation.header.payer)
+                }
+                AccountDiscriminator::RecurringDelegation => {
+                    let delegation = RecurringDelegation::load_with_min_size(&data)?;
+                    (delegation.subscription_authority, delegation.header.init_id, delegation.header.payer)
+                }
+                _ => return Err(SubscriptionsError::InvalidAccountDiscriminator.into()),
+            };
+
+        if payer != *accounts.payer.address() {
+            return Err(SubscriptionsError::Unauthorized.into());
+        }
+
+        if recorded_authority != *accounts.subscription_authority.address() {
+            return Err(SubscriptionsError::Unauthorized.into());
+        }
+
+        let authority_is_dead = if !accounts.subscription_authority.owned_by(&crate::ID) {
+            true
+        } else {
+            let authority_data = accounts.subscription_authority.try_borrow()?;
+            SubscriptionAuthority::load(&authority_data)?.init_id != recorded_init_id
+        };
+
+        if !authority_is_dead {
+            return Err(SubscriptionsError::Unauthorized.into());
+        }
+    }
+
+    ProgramAccount::close(accounts.delegation_account, accounts.payer)
+}

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -27,6 +27,8 @@ mod test_initialize_subscription_authority;
 #[cfg(test)]
 mod test_resume_subscription;
 #[cfg(test)]
+mod test_revoke_abandoned_delegation;
+#[cfg(test)]
 mod test_revoke_delegation;
 #[cfg(test)]
 mod test_revoke_subscription_authority;

--- a/tests/integration-tests/src/test_cancel_subscription.rs
+++ b/tests/integration-tests/src/test_cancel_subscription.rs
@@ -1,14 +1,20 @@
 use crate::{
-    state::subscription_delegation::SubscriptionDelegation,
+    state::{plan::Plan, subscription_delegation::SubscriptionDelegation},
     tests::{
         asserts::TransactionResultExt,
+        constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         utils::{
-            current_ts, days, hours, init_wallet, minutes, move_clock_forward, setup_with_subscription,
-            CancelSubscription, CreatePlan, DeletePlan, UpdatePlan,
+            current_ts, days, get_ata_balance, hours, init_ata, init_mint, init_wallet,
+            initialize_subscription_authority_action, minutes, move_clock_forward, setup, setup_with_subscription,
+            CancelSubscription, CreatePlan, CreateSubscription, DeletePlan, RevokeSubscription, TransferSubscription,
+            UpdatePlan,
         },
     },
     SubscriptionsError,
 };
+use solana_clock::Clock;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
 #[test]
 fn cancel_subscription_happy_path() {
     let (mut litesvm, alice, _merchant, _mint, plan_pda, _plan_bump, subscription_pda) = setup_with_subscription();
@@ -19,6 +25,56 @@ fn cancel_subscription_happy_path() {
     let sub_account = litesvm.get_account(&subscription_pda).unwrap();
     let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
     assert_ne!({ sub.expires_at_ts }, 0);
+}
+
+#[test]
+fn cancel_at_exact_end_ts_keeps_final_period_billable() {
+    let (mut litesvm, subscriber) = setup();
+    let merchant = Keypair::new();
+    litesvm.airdrop(&merchant.pubkey(), 10_000_000_000).unwrap();
+
+    let mint = init_mint(&mut litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(subscriber.pubkey()), &[]);
+    init_ata(&mut litesvm, mint, subscriber.pubkey(), 100_000_000);
+    let merchant_ata = init_ata(&mut litesvm, mint, merchant.pubkey(), 0);
+
+    initialize_subscription_authority_action(&mut litesvm, &subscriber, mint).0.assert_ok();
+
+    let start_ts = litesvm.get_sysvar::<Clock>().unix_timestamp;
+    let end_ts = start_ts + hours(2) as i64;
+
+    let (res, plan_pda) = CreatePlan::new(&mut litesvm, &merchant, mint)
+        .plan_id(1)
+        .amount(50_000_000)
+        .period_hours(1)
+        .end_ts(end_ts)
+        .execute();
+    res.assert_ok();
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let terms = Plan::load(&plan_account.data).unwrap().data.terms;
+    let subscription_pda =
+        CreateSubscription::new(&mut litesvm, plan_pda, subscriber.pubkey(), mint, start_ts).terms(terms).execute();
+
+    let now = litesvm.get_sysvar::<Clock>().unix_timestamp;
+    move_clock_forward(&mut litesvm, u64::try_from(end_ts - now).unwrap());
+    assert_eq!(litesvm.get_sysvar::<Clock>().unix_timestamp, end_ts);
+
+    CancelSubscription::new(&mut litesvm, &subscriber, plan_pda, subscription_pda).execute().assert_ok();
+
+    let sub_account = litesvm.get_account(&subscription_pda).unwrap();
+    let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
+    assert_eq!({ sub.expires_at_ts }, end_ts + 1);
+
+    RevokeSubscription::new(&mut litesvm, &subscriber, subscription_pda, plan_pda)
+        .execute()
+        .assert_err(SubscriptionsError::SubscriptionNotCancelled);
+
+    TransferSubscription::new(&mut litesvm, &merchant, subscriber.pubkey(), mint, subscription_pda, plan_pda)
+        .amount(20_000_000)
+        .to(merchant_ata)
+        .execute()
+        .assert_ok();
+    assert_eq!(get_ata_balance(&litesvm, &merchant_ata), 20_000_000);
 }
 
 #[test]
@@ -139,7 +195,11 @@ fn cancel_subscription_caps_at_plan_end_ts() {
 
     let sub_account = litesvm.get_account(&subscription_pda).unwrap();
     let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
-    assert_eq!({ sub.expires_at_ts }, end_ts, "expires_at_ts should be capped at plan end_ts, not period end");
+    assert_eq!(
+        { sub.expires_at_ts },
+        end_ts + 1,
+        "expires_at_ts should be capped just past the inclusive plan end_ts, not period end"
+    );
 }
 
 #[test]

--- a/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
+++ b/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
@@ -8,8 +8,8 @@ use crate::{
         asserts::TransactionResultExt,
         constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         utils::{
-            init_ata, init_mint, initialize_subscription_authority_action, setup, CloseSubscriptionAuthority,
-            CreateDelegation, RevokeAbandonedDelegation,
+            current_ts, hours, init_ata, init_mint, initialize_subscription_authority_action, move_clock_forward,
+            setup, CloseSubscriptionAuthority, CreateDelegation, RevokeAbandonedDelegation,
         },
     },
     SubscriptionsError,
@@ -50,6 +50,64 @@ fn sponsor_recovers_no_expiry_fixed_delegation_after_authority_closed() {
 
     let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
     assert!(sponsor_after >= sponsor_before + delegation_rent - 10_000);
+}
+
+#[test]
+fn payer_recovers_no_expiry_recurring_delegation_after_authority_closed() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, delegation_pda) = CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).recurring(
+        100,
+        hours(1),
+        current_ts(),
+        NO_EXPIRY,
+    );
+    res.assert_ok();
+
+    let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
+
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee).execute().assert_ok();
+
+    let delegation_after = litesvm.get_account(&delegation_pda);
+    assert!(delegation_after.is_none() || delegation_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0);
+
+    let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+    assert!(sponsor_after >= sponsor_before + delegation_rent - 10_000);
+}
+
+#[test]
+fn payer_recovers_delegation_after_authority_reinit_bumps_init_id() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    move_clock_forward(litesvm, 10);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee).execute().assert_ok();
+
+    let delegation_after = litesvm.get_account(&delegation_pda);
+    assert!(delegation_after.is_none() || delegation_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0);
 }
 
 #[test]

--- a/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
+++ b/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
@@ -1,0 +1,116 @@
+use solana_keypair::Keypair;
+use solana_native_token::LAMPORTS_PER_SOL;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+
+use crate::{
+    tests::{
+        asserts::TransactionResultExt,
+        constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
+        utils::{
+            init_ata, init_mint, initialize_subscription_authority_action, setup, CloseSubscriptionAuthority,
+            CreateDelegation, RevokeAbandonedDelegation,
+        },
+    },
+    SubscriptionsError,
+};
+
+const NO_EXPIRY: i64 = 0;
+
+fn fund(litesvm: &mut litesvm::LiteSVM) -> Keypair {
+    let sponsor = Keypair::new();
+    litesvm.airdrop(&sponsor.pubkey(), LAMPORTS_PER_SOL * 10).unwrap();
+    sponsor
+}
+
+#[test]
+fn sponsor_recovers_no_expiry_fixed_delegation_after_authority_closed() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
+
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee).execute().assert_ok();
+
+    let delegation_after = litesvm.get_account(&delegation_pda);
+    assert!(delegation_after.is_none() || delegation_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0);
+
+    let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+    assert!(sponsor_after >= sponsor_before + delegation_rent - 10_000);
+}
+
+#[test]
+fn revoke_abandoned_rejects_live_delegation() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, _delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee)
+        .execute()
+        .assert_err(SubscriptionsError::Unauthorized);
+}
+
+#[test]
+fn revoke_abandoned_rejects_non_sponsor_caller() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let stranger = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, _delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    RevokeAbandonedDelegation::new(litesvm, &stranger, user.pubkey(), mint, delegatee)
+        .execute()
+        .assert_err(SubscriptionsError::Unauthorized);
+}
+
+#[test]
+fn revoke_abandoned_rejects_unbound_authority_account() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, _delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee)
+        .authority(Pubkey::new_unique())
+        .execute()
+        .assert_err(SubscriptionsError::Unauthorized);
+}

--- a/tests/integration-tests/src/test_transfer_fixed_delegation.rs
+++ b/tests/integration-tests/src/test_transfer_fixed_delegation.rs
@@ -224,6 +224,39 @@ fn test_fixed_transfer_token_2022_active_transfer_hook() {
 }
 
 #[test]
+fn active_hook_transfer_without_validation_pda_fails() {
+    let (mut litesvm, alice) = setup();
+    load_transfer_hook_example(&mut litesvm);
+    let bob = Keypair::new();
+    litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
+
+    let mint = init_mint(
+        &mut litesvm,
+        TOKEN_2022_PROGRAM_ID,
+        MINT_DECIMALS,
+        1_000_000_000,
+        Some(alice.pubkey()),
+        &[ExtensionType::TransferHook],
+    );
+    set_transfer_hook_config(&mut litesvm, mint, Some(alice.pubkey()), Some(TRANSFER_HOOK_EXAMPLE_PROGRAM_ID));
+    install_transfer_hook_extra_metas(&mut litesvm, mint);
+
+    let _alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+    let _bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
+
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey())
+        .fixed(50_000_000, current_ts() + days(1) as i64);
+    res.assert_ok();
+
+    TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+        .amount(10_000_000)
+        .remaining(vec![AccountMeta::new_readonly(TRANSFER_HOOK_EXAMPLE_PROGRAM_ID, false)])
+        .fixed()
+        .assert_err(SubscriptionsError::TransferHookValidationAccountMissing);
+}
+
+#[test]
 fn test_fixed_transfer_multiple_times() {
     let amount: u64 = 50_000_000;
     let expiry_s: i64 = current_ts() + days(1) as i64;

--- a/tests/integration-tests/src/test_transfer_recurring_delegation.rs
+++ b/tests/integration-tests/src/test_transfer_recurring_delegation.rs
@@ -16,6 +16,7 @@ use crate::{
     SubscriptionsError,
 };
 use litesvm::LiteSVM;
+use solana_clock::Clock;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
@@ -857,11 +858,12 @@ fn test_recurring_transfer_token_2022_confidential_transfer_public_balance() {
 
     initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
 
+    let start_ts = litesvm.get_sysvar::<Clock>().unix_timestamp;
     let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
         50_000_000,
         hours(1),
-        current_ts(),
-        current_ts() + days(1) as i64,
+        start_ts,
+        start_ts + days(1) as i64,
     );
     res.assert_ok();
 
@@ -893,11 +895,12 @@ fn test_recurring_transfer_token_2022_unconfigured_transfer_hook() {
 
     initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
 
+    let start_ts = litesvm.get_sysvar::<Clock>().unix_timestamp;
     let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
         50_000_000,
         hours(1),
-        current_ts(),
-        current_ts() + days(1) as i64,
+        start_ts,
+        start_ts + days(1) as i64,
     );
     res.assert_ok();
 

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -42,8 +42,8 @@ use crate::{
     instructions::{
         cancel_subscription, close_subscription_authority, create_fixed_delegation, create_plan,
         create_recurring_delegation, delete_plan, initialize_subscription_authority, resume_subscription,
-        revoke_delegation, revoke_subscription_authority, subscribe, transfer_fixed_delegation,
-        transfer_recurring_delegation, transfer_subscription, update_plan,
+        revoke_abandoned_delegation, revoke_delegation, revoke_subscription_authority, subscribe,
+        transfer_fixed_delegation, transfer_recurring_delegation, transfer_subscription, update_plan,
     },
     state::common::PlanStatus,
     tests::{
@@ -769,6 +769,63 @@ impl<'a> RevokeSubscriptionAuthority<'a> {
             Instruction { program_id: PROGRAM_ID, accounts, data: vec![*revoke_subscription_authority::DISCRIMINATOR] };
 
         build_and_send_transaction(self.litesvm, &[self.user], &self.user.pubkey(), &ix)
+    }
+}
+
+pub struct RevokeAbandonedDelegation<'a> {
+    litesvm: &'a mut LiteSVM,
+    payer: &'a Keypair,
+    delegator: Pubkey,
+    mint: Pubkey,
+    delegatee: Pubkey,
+    nonce: u64,
+    custom_pda: Option<Pubkey>,
+    custom_authority: Option<Pubkey>,
+}
+
+impl<'a> RevokeAbandonedDelegation<'a> {
+    pub fn new(
+        litesvm: &'a mut LiteSVM,
+        payer: &'a Keypair,
+        delegator: Pubkey,
+        mint: Pubkey,
+        delegatee: Pubkey,
+    ) -> Self {
+        Self { litesvm, payer, delegator, mint, delegatee, nonce: 0, custom_pda: None, custom_authority: None }
+    }
+
+    pub fn nonce(mut self, nonce: u64) -> Self {
+        self.nonce = nonce;
+        self
+    }
+
+    pub fn pda(mut self, pda: Pubkey) -> Self {
+        self.custom_pda = Some(pda);
+        self
+    }
+
+    pub fn authority(mut self, authority: Pubkey) -> Self {
+        self.custom_authority = Some(authority);
+        self
+    }
+
+    #[allow(clippy::result_large_err)]
+    pub fn execute(self) -> TransactionResult {
+        let (derived_authority, _) = get_subscription_authority_pda(&self.delegator, &self.mint);
+        let subscription_authority_pda = self.custom_authority.unwrap_or(derived_authority);
+        let (derived_pda, _) = get_delegation_pda(&derived_authority, &self.delegator, &self.delegatee, self.nonce);
+        let delegation_pda = self.custom_pda.unwrap_or(derived_pda);
+
+        let accounts = vec![
+            AccountMeta::new(self.payer.pubkey(), true),
+            AccountMeta::new(delegation_pda, false),
+            AccountMeta::new_readonly(subscription_authority_pda, false),
+        ];
+
+        let ix =
+            Instruction { program_id: PROGRAM_ID, accounts, data: vec![*revoke_abandoned_delegation::DISCRIMINATOR] };
+
+        build_and_send_transaction(self.litesvm, &[self.payer], &self.payer.pubkey(), &ix)
     }
 }
 


### PR DESCRIPTION
Cantina/APEX audit remediation. Independent findings, each its own commit.

## MULT-54 — sponsor-funded delegation rent permanently trapped (`RevokeAbandonedDelegation`)
- A delegator can unilaterally make a sponsor-funded delegation permanently unusable (close its `SubscriptionAuthority`, or bump `init_id` via re-init). `RevokeDelegation` only lets the sponsor close on expiry, so `expiry_ts == 0` delegations trapped the payer's rent forever.
- Adds `RevokeAbandonedDelegation` (discriminator 15): the recorded payer reclaims rent once the delegation is provably dead — authority PDA closed, `init_id` mismatch, or unreadable program-owned authority. All irreversible, so no live delegation can be swept.
- Non-breaking (additive instruction); recovers rent already locked on mainnet.

## MULT-53 — transfer-hook fail-open on delegated transfers
- Delegated transfers forwarded caller-supplied trailing accounts verbatim; Token-2022 only enforces the hook's `ExtraAccountMetaList` policy when the validation PDA is present, so a caller could omit it and bypass an active-hook mint's policy.
- `invoke_transfer_checked_with_hook` now derives the expected validation PDA and rejects with `TransferHookValidationAccountMissing` when absent → fail-closed. Non-breaking (SDK already includes it).

## MULT-56 — exact `end_ts` boundary split-brain on cancel/revoke
- `cancel_subscription` capped `expires_at_ts` to `plan.end_ts`, but `end_ts` is inclusive everywhere else, so a subscriber could `cancel + revoke` at exactly `current_ts == end_ts` and skip the final billable period.
- Cap to `end_ts + 1` so a cancelled subscription becomes revocable only once `current_ts > end_ts`.

## MULT-57 — stale Token-2022 transfer-hook docs (docs only)
- README + ADR-001 still claimed configured `TransferHook` mints are rejected. Updated both to describe actual behavior (hooks supported; validation PDA enforced).

## MULT-51 — `hotfix/*` could publish official SDK releases (CI)
- Publish workflows allowed dispatch from unprotected `refs/heads/hotfix/*`. Restricted both publish guards to `main` only.

## Test Plan
- 218 integration + 48 unit (Rust), fmt + clippy clean. TS integration assertion updated for the MULT-56 cap. New tests cover all program fixes.