### PR TITLE
feat(program): add start-on-landing sentinel for recurring delegations

### DIFF
--- a/clients/typescript/src/plugin.ts
+++ b/clients/typescript/src/plugin.ts
@@ -171,6 +171,8 @@ export type CreateRecurringDelegationInput = WithProgramAddress & {
     nonce: bigint | number;
     payer?: TransactionSigner;
     periodLengthS: bigint | number;
+    /** Unix timestamp when the first period begins. Pass 0 to start when the
+     * transaction lands on chain (requires a non-zero `expiryTs`). */
     startTs: bigint | number;
     tokenMint: Address;
 };

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -1129,6 +1129,12 @@
         "name": "delegationNotStarted"
       },
       {
+        "code": 408,
+        "kind": "errorNode",
+        "message": "start_ts of 0 (start on landing) requires a non-zero expiry",
+        "name": "recurringDelegationStartOnLandingRequiresExpiry"
+      },
+      {
         "code": 500,
         "kind": "errorNode",
         "message": "Plan is in sunset status",

--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -66,6 +66,7 @@ impl TryFrom<u32> for SubscriptionsError {
             405 => Ok(Self::RecurringDelegationStartTimeGreaterThanExpiry),
             406 => Ok(Self::RecurringDelegationAmountZero),
             407 => Ok(Self::DelegationNotStarted),
+            408 => Ok(Self::RecurringDelegationStartOnLandingRequiresExpiry),
             // Plan and subscription errors (500-599)
             500 => Ok(Self::PlanSunset),
             501 => Ok(Self::PlanExpired),
@@ -211,6 +212,8 @@ pub enum SubscriptionsError {
     RecurringDelegationAmountZero,
     #[error("Delegation period has not started yet")]
     DelegationNotStarted,
+    #[error("start_ts of 0 (start on landing) requires a non-zero expiry")]
+    RecurringDelegationStartOnLandingRequiresExpiry,
 
     // --- Plan and subscription errors (500--599) ---
     #[error("Plan is in sunset status")]

--- a/program/src/instructions/create_recurring_delegation.rs
+++ b/program/src/instructions/create_recurring_delegation.rs
@@ -24,9 +24,10 @@ pub struct CreateRecurringDelegationData {
     pub amount_per_period: u64,
     /// Length of each period in seconds (must be > 0 and <= [`MAX_DELEGATION_PERIOD_SECS`]).
     pub period_length_s: u64,
-    /// Unix timestamp when the first period begins.
+    /// Unix timestamp when the first period begins, or 0 to start when the
+    /// transaction lands (requires a non-zero `expiry_ts`).
     pub start_ts: i64,
-    /// Unix timestamp after which the delegation expires.
+    /// Unix timestamp after which the delegation expires (0 = never).
     pub expiry_ts: i64,
     /// SubscriptionAuthority generation the delegator approved.
     pub expected_subscription_authority_init_id: i64,
@@ -45,17 +46,29 @@ impl CreateRecurringDelegationData {
     }
 
     /// Validates the instruction data against the current clock time.
+    ///
+    /// A `start_ts` of 0 means the delegation starts at `current_time`; that
+    /// form requires a non-zero `expiry_ts` so a held transaction (e.g. signed
+    /// with a durable nonce) cannot activate the delegation unboundedly late.
     pub fn validate(&self, current_time: i64) -> Result<(), SubscriptionsError> {
-        if self.start_ts < current_time.saturating_sub(TIME_DRIFT_ALLOWED_SECS) {
-            return Err(SubscriptionsError::RecurringDelegationStartTimeInPast);
+        if self.start_ts == 0 {
+            if self.expiry_ts == 0 {
+                return Err(SubscriptionsError::RecurringDelegationStartOnLandingRequiresExpiry);
+            }
+            if current_time >= self.expiry_ts {
+                return Err(SubscriptionsError::RecurringDelegationStartTimeGreaterThanExpiry);
+            }
+        } else {
+            if self.start_ts < current_time.saturating_sub(TIME_DRIFT_ALLOWED_SECS) {
+                return Err(SubscriptionsError::RecurringDelegationStartTimeInPast);
+            }
+            if self.expiry_ts != 0 && self.start_ts >= self.expiry_ts {
+                return Err(SubscriptionsError::RecurringDelegationStartTimeGreaterThanExpiry);
+            }
         }
 
         if self.period_length_s == 0 || self.period_length_s > MAX_DELEGATION_PERIOD_SECS {
             return Err(SubscriptionsError::InvalidPeriodLength);
-        }
-
-        if self.expiry_ts != 0 && self.start_ts >= self.expiry_ts {
-            return Err(SubscriptionsError::RecurringDelegationStartTimeGreaterThanExpiry);
         }
 
         if self.amount_per_period == 0 {
@@ -74,7 +87,8 @@ pub const DISCRIMINATOR: &u8 = &2;
 /// Validates the instruction data, creates the delegation account via CPI,
 /// and initializes its header and period-tracking fields.
 pub fn process(accounts: &mut [AccountView], call_data: &CreateRecurringDelegationData) -> ProgramResult {
-    call_data.validate(Clock::get()?.unix_timestamp)?;
+    let current_time = Clock::get()?.unix_timestamp;
+    call_data.validate(current_time)?;
 
     let accounts = CreateDelegationAccounts::try_from(accounts)?;
 
@@ -100,7 +114,7 @@ pub fn process(accounts: &mut [AccountView], call_data: &CreateRecurringDelegati
     );
     delegation.subscription_authority = *accounts.subscription_authority.address();
     delegation.mint = mint;
-    delegation.current_period_start_ts = call_data.start_ts;
+    delegation.current_period_start_ts = if call_data.start_ts == 0 { current_time } else { call_data.start_ts };
     delegation.period_length_s = call_data.period_length_s;
     delegation.expiry_ts = call_data.expiry_ts;
     delegation.amount_per_period = call_data.amount_per_period;

--- a/tests/integration-tests/src/test_create_recurring_delegation.rs
+++ b/tests/integration-tests/src/test_create_recurring_delegation.rs
@@ -204,6 +204,103 @@ fn create_recurring_delegation_with_period_exceeding_max() {
 }
 
 #[test]
+fn create_recurring_delegation_with_sentinel_start_starts_at_landing() {
+    let (litesvm, user) = &mut setup();
+    let payer = user;
+    let amount_per_period: u64 = 50_000_000;
+    let period_length_s: u64 = 86400;
+    let start_ts: i64 = 0;
+    let expiry_ts = current_ts() + days(7) as i64;
+    let nonce: u64 = 0;
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(payer.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, payer.pubkey(), 100_000_000);
+
+    initialize_subscription_authority_action(litesvm, payer, mint).0.assert_ok();
+
+    let delegatee = solana_keypair::Keypair::new();
+    litesvm.airdrop(&delegatee.pubkey(), 10_000_000).unwrap();
+    let delegatee_ata = init_ata(litesvm, mint, delegatee.pubkey(), 0);
+
+    let (res, delegation_pda) = CreateDelegation::new(litesvm, payer, mint, delegatee.pubkey()).nonce(nonce).recurring(
+        amount_per_period,
+        period_length_s,
+        start_ts,
+        expiry_ts,
+    );
+    res.assert_ok();
+
+    let clock_ts = litesvm.get_sysvar::<solana_clock::Clock>().unix_timestamp;
+    let account = litesvm.get_account(&delegation_pda).unwrap();
+    let delegation = RecurringDelegation::load(&account.data).unwrap();
+    let del_current_period_start_ts = delegation.current_period_start_ts;
+    assert_eq!(del_current_period_start_ts, clock_ts);
+    assert_ne!(del_current_period_start_ts, 0);
+
+    let transfer_amount: u64 = 10_000_000;
+    TransferDelegation::new(litesvm, &delegatee, payer.pubkey(), mint, delegation_pda)
+        .amount(transfer_amount)
+        .recurring()
+        .assert_ok();
+
+    assert_eq!(get_ata_balance(litesvm, &delegatee_ata), transfer_amount);
+}
+
+#[test]
+fn create_recurring_delegation_sentinel_start_requires_expiry() {
+    let (litesvm, user) = &mut setup();
+    let payer = user;
+    let amount_per_period: u64 = 50_000_000;
+    let period_length_s: u64 = 86400;
+    let start_ts: i64 = 0;
+    let expiry_ts: i64 = 0;
+    let nonce: u64 = 0;
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(payer.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, payer.pubkey(), 1_000_000);
+
+    initialize_subscription_authority_action(litesvm, payer, mint).0.assert_ok();
+
+    let delegatee = Pubkey::new_unique();
+
+    let (res, _delegation_pda) = CreateDelegation::new(litesvm, payer, mint, delegatee).nonce(nonce).recurring(
+        amount_per_period,
+        period_length_s,
+        start_ts,
+        expiry_ts,
+    );
+    res.assert_err(SubscriptionsError::RecurringDelegationStartOnLandingRequiresExpiry);
+}
+
+#[test]
+fn create_recurring_delegation_sentinel_start_rejects_elapsed_expiry() {
+    let (litesvm, user) = &mut setup();
+    let payer = user;
+    let amount_per_period: u64 = 50_000_000;
+    let period_length_s: u64 = 86400;
+    let start_ts: i64 = 0;
+    let expiry_ts = current_ts() + days(7) as i64;
+    let nonce: u64 = 0;
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(payer.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, payer.pubkey(), 1_000_000);
+
+    initialize_subscription_authority_action(litesvm, payer, mint).0.assert_ok();
+
+    move_clock_forward(litesvm, days(8));
+
+    let delegatee = Pubkey::new_unique();
+
+    let (res, _delegation_pda) = CreateDelegation::new(litesvm, payer, mint, delegatee).nonce(nonce).recurring(
+        amount_per_period,
+        period_length_s,
+        start_ts,
+        expiry_ts,
+    );
+    res.assert_err(SubscriptionsError::RecurringDelegationStartTimeGreaterThanExpiry);
+}
+
+#[test]
 fn create_recurring_delegation_with_zero_expiry() {
     let (litesvm, user) = &mut setup();
     let payer = user;


### PR DESCRIPTION
## Summary
- `start_ts == 0` in `CreateRecurringDelegation` now means "start when the transaction lands": the first period is anchored at the on-chain clock at execution time. Previously 0 was rejected as a past start time, so the sentinel slot was unused.
- Guards against deferred activation via held transactions (durable nonces): the sentinel form requires a non-zero `expiry_ts` (new error 408 `RecurringDelegationStartOnLandingRequiresExpiry`) and rejects creation at or past `expiry_ts` with no drift grace.
- Explicit `start_ts` behavior is unchanged, including the `TIME_DRIFT_ALLOWED_SECS` staleness check.
- Adds three LiteSVM integration tests: sentinel anchors to the clock and allows an immediate first charge; sentinel without expiry is rejected; sentinel landing after expiry (held-transaction scenario) is rejected.

## Motivation
Integrators build `create_recurring_delegation` transactions with `start_ts = now + X`, but user signing can take minutes, so the transaction lands with `start_ts` already past the 120s drift window (error 404). Padding `start_ts` further into the future delays activation and confirmation. The sentinel removes the guess entirely while keeping a signed deadline (`expiry_ts`) as the staleness bound, mirroring how `Subscribe` already anchors `current_period_start_ts` at landing.

## Test Plan
- `cargo test -p tests-subscriptions` — 213/213 pass
- `just check` — clean

## Notes for indexers
There is no creation event; consumers deriving the start time from instruction data will see 0 for sentinel transactions and should read `current_period_start_ts` from the delegation account instead.