### PR TITLE
fix(program): require transfer-hook validation PDA on delegated transfers

### DIFF
--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -1063,6 +1063,12 @@
         "name": "transferHookTooManyAccounts"
       },
       {
+        "code": 138,
+        "kind": "errorNode",
+        "message": "Transfer hook validation account missing from provided accounts",
+        "name": "transferHookValidationAccountMissing"
+      },
+      {
         "code": 300,
         "kind": "errorNode",
         "message": "Transfer amount exceeds delegation limit",

--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -53,6 +53,7 @@ impl TryFrom<u32> for SubscriptionsError {
             135 => Ok(Self::DelegationAlreadyExists),
             136 => Ok(Self::StaleSubscriptionAuthority),
             137 => Ok(Self::TransferHookTooManyAccounts),
+            138 => Ok(Self::TransferHookValidationAccountMissing),
             // Fixed delegation errors (300-399)
             300 => Ok(Self::AmountExceedsLimit),
             301 => Ok(Self::FixedDelegationExpiryInPast),
@@ -185,6 +186,8 @@ pub enum SubscriptionsError {
     StaleSubscriptionAuthority,
     #[error("Too many transfer hook accounts provided")]
     TransferHookTooManyAccounts,
+    #[error("Transfer hook validation account missing from provided accounts")]
+    TransferHookValidationAccountMissing,
 
     // --- Fixed delegation errors (300--399) ---
     #[error("Transfer amount exceeds delegation limit")]

--- a/program/src/instructions/helpers/transfer_hook_util.rs
+++ b/program/src/instructions/helpers/transfer_hook_util.rs
@@ -16,6 +16,7 @@ const ACCOUNT_TYPE_INDEX: usize = 165;
 const TLV_START_INDEX: usize = ACCOUNT_TYPE_INDEX + 1;
 const TLV_HEADER_LEN: usize = 4;
 const EXTENSION_TYPE_TRANSFER_HOOK: u16 = 14;
+const EXTRA_ACCOUNT_METAS_SEED: &[u8] = b"extra-account-metas";
 const TRANSFER_HOOK_EXTENSION_LEN: usize = 64; // authority(32) || program_id(32)
 const TRANSFER_HOOK_PROGRAM_ID_OFFSET: usize = 32;
 const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
@@ -81,9 +82,14 @@ pub fn mint_transfer_hook_program_id(mint_data: &[u8]) -> Result<Option<Address>
 
 /// `TransferChecked` CPI forwarding the caller-supplied `remaining` hook accounts
 /// (each with its runtime writable/signer flags); Token-2022 validates them.
+///
+/// Requires the hook's `ExtraAccountMetaList` validation PDA among `remaining`.
+/// Token-2022 only resolves the hook's configured policy context when that PDA
+/// is passed, so without this check an active-hook transfer would fail open.
 #[allow(clippy::too_many_arguments)]
 pub fn invoke_transfer_checked_with_hook(
     token_program: &Address,
+    hook_program: &Address,
     from: &AccountView,
     mint: &AccountView,
     to: &AccountView,
@@ -95,6 +101,12 @@ pub fn invoke_transfer_checked_with_hook(
 ) -> ProgramResult {
     if remaining.len() > MAX_TRANSFER_HOOK_REMAINING_ACCOUNTS {
         return Err(SubscriptionsError::TransferHookTooManyAccounts.into());
+    }
+
+    let (validation_pda, _) =
+        Address::find_program_address(&[EXTRA_ACCOUNT_METAS_SEED, mint.address().as_ref()], hook_program);
+    if !remaining.iter().any(|account| account.address().eq(&validation_pda)) {
+        return Err(SubscriptionsError::TransferHookValidationAccountMissing.into());
     }
 
     let mut data = [0u8; 10];

--- a/program/src/instructions/helpers/transfer_utils.rs
+++ b/program/src/instructions/helpers/transfer_utils.rs
@@ -183,9 +183,10 @@ pub fn transfer_with_delegate(
     ];
     let signer = [Signer::from(&seeds)];
 
-    if hook_program_id.is_some() {
+    if let Some(hook_program_id) = hook_program_id {
         return invoke_transfer_checked_with_hook(
             accounts.token_program.address(),
+            &hook_program_id,
             accounts.delegator_ata,
             accounts.token_mint,
             accounts.to_ata,

--- a/tests/integration-tests/src/test_transfer_fixed_delegation.rs
+++ b/tests/integration-tests/src/test_transfer_fixed_delegation.rs
@@ -224,6 +224,39 @@ fn test_fixed_transfer_token_2022_active_transfer_hook() {
 }
 
 #[test]
+fn active_hook_transfer_without_validation_pda_fails() {
+    let (mut litesvm, alice) = setup();
+    load_transfer_hook_example(&mut litesvm);
+    let bob = Keypair::new();
+    litesvm.airdrop(&bob.pubkey(), 10_000_000).unwrap();
+
+    let mint = init_mint(
+        &mut litesvm,
+        TOKEN_2022_PROGRAM_ID,
+        MINT_DECIMALS,
+        1_000_000_000,
+        Some(alice.pubkey()),
+        &[ExtensionType::TransferHook],
+    );
+    set_transfer_hook_config(&mut litesvm, mint, Some(alice.pubkey()), Some(TRANSFER_HOOK_EXAMPLE_PROGRAM_ID));
+    install_transfer_hook_extra_metas(&mut litesvm, mint);
+
+    let _alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+    let _bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
+
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey())
+        .fixed(50_000_000, current_ts() + days(1) as i64);
+    res.assert_ok();
+
+    TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
+        .amount(10_000_000)
+        .remaining(vec![AccountMeta::new_readonly(TRANSFER_HOOK_EXAMPLE_PROGRAM_ID, false)])
+        .fixed()
+        .assert_err(SubscriptionsError::TransferHookValidationAccountMissing);
+}
+
+#[test]
 fn test_fixed_transfer_multiple_times() {
     let amount: u64 = 50_000_000;
     let expiry_s: i64 = current_ts() + days(1) as i64;


### PR DESCRIPTION
## Summary
- Fixes audit finding **MULT-53**: delegated transfers on active-hook Token-2022 mints could **fail open**, skipping the mint's configured `ExtraAccountMetaList` policy.
- Root cause: `invoke_transfer_checked_with_hook` forwarded caller-supplied trailing accounts verbatim. Token-2022 only injects the hook's policy context when the validation PDA is among the passed accounts, so a caller (delegatee / whitelisted puller) could omit it and have a permissive hook run with no policy context.
- Fix: derive the expected validation PDA (`["extra-account-metas", mint]` under the hook program) and reject with new error `TransferHookValidationAccountMissing` when it is absent. Forces fail-closed — either the hook gets its full context (Token-2022 then resolves/validates the extra-account set), or the transfer is rejected.

## Why non-breaking
- The SDK's `resolveTransferHookAccounts` already returns `[hookProgram, validationPda, ...extras]` for every active, non-inert hook — so correct callers (incl. the webapp) already pass the validation PDA. Only the omission path is now rejected.
- No instruction account-list / IDL interface change (hook accounts are variadic trailing accounts). New error code is additive (`138`).

## Test Plan
- New `active_hook_transfer_without_validation_pda_fails`: active-hook transfer passing only the hook program (omitting the validation PDA) now fails with `TransferHookValidationAccountMissing`.
- Existing `test_fixed_transfer_token_2022_active_transfer_hook` (validation PDA + extras supplied) still passes.
- Full suite green: 211 integration + 48 program unit, fmt + clippy clean.

## Scope
Applies to all delegated transfer paths (fixed / recurring / subscription) via the shared `transfer_with_delegate` helper.