### PR TITLE
fix(webapp): correct api/scripts typecheck errors under nodenext

### DIFF
--- a/webapp/api/lib/bpf-loader.ts
+++ b/webapp/api/lib/bpf-loader.ts
@@ -1,7 +1,7 @@
 import {
     type Address,
-    type IInstruction,
-    type IAccountMeta,
+    type Instruction,
+    type AccountMeta,
     address,
     getAddressEncoder,
     getProgramDerivedAddress,
@@ -29,23 +29,23 @@ function u64LE(value: number | bigint): Uint8Array {
 
 const AccountRole = { READONLY: 0, WRITABLE: 1, SIGNER: 2, WRITABLE_SIGNER: 3 } as const;
 
-function writable(addr: Address): IAccountMeta {
+function writable(addr: Address): AccountMeta {
     return { address: addr, role: AccountRole.WRITABLE };
 }
 
-function writableSigner(addr: Address): IAccountMeta {
+function writableSigner(addr: Address): AccountMeta {
     return { address: addr, role: AccountRole.WRITABLE_SIGNER };
 }
 
-function signer(addr: Address): IAccountMeta {
+function signer(addr: Address): AccountMeta {
     return { address: addr, role: AccountRole.SIGNER };
 }
 
-function readonly(addr: Address): IAccountMeta {
+function readonly(addr: Address): AccountMeta {
     return { address: addr, role: AccountRole.READONLY };
 }
 
-export function buildInitializeBufferIx(buffer: Address, authority: Address): IInstruction {
+export function buildInitializeBufferIx(buffer: Address, authority: Address): Instruction {
     return {
         programAddress: BPF_LOADER_UPGRADEABLE,
         accounts: [writable(buffer), readonly(authority)],
@@ -53,7 +53,7 @@ export function buildInitializeBufferIx(buffer: Address, authority: Address): II
     };
 }
 
-export function buildWriteIx(buffer: Address, authority: Address, offset: number, chunk: Uint8Array): IInstruction {
+export function buildWriteIx(buffer: Address, authority: Address, offset: number, chunk: Uint8Array): Instruction {
     const data = new Uint8Array(4 + 4 + 8 + chunk.length);
     data.set(u32LE(1), 0);
     data.set(u32LE(offset), 4);
@@ -73,7 +73,7 @@ export function buildDeployIx(
     buffer: Address,
     authority: Address,
     maxDataLen: number | bigint,
-): IInstruction {
+): Instruction {
     const data = new Uint8Array(4 + 8);
     data.set(u32LE(2), 0);
     data.set(u64LE(maxDataLen), 4);
@@ -99,7 +99,7 @@ export function buildUpgradeIx(
     buffer: Address,
     spill: Address,
     authority: Address,
-): IInstruction {
+): Instruction {
     return {
         programAddress: BPF_LOADER_UPGRADEABLE,
         accounts: [
@@ -115,7 +115,7 @@ export function buildUpgradeIx(
     };
 }
 
-export function buildSetAuthorityIx(account: Address, currentAuth: Address, newAuth: Address | null): IInstruction {
+export function buildSetAuthorityIx(account: Address, currentAuth: Address, newAuth: Address | null): Instruction {
     const accounts = [writable(account), signer(currentAuth)];
     if (newAuth) accounts.push(readonly(newAuth));
     return {
@@ -125,7 +125,7 @@ export function buildSetAuthorityIx(account: Address, currentAuth: Address, newA
     };
 }
 
-export function buildCloseBufferIx(buffer: Address, recipient: Address, authority: Address): IInstruction {
+export function buildCloseBufferIx(buffer: Address, recipient: Address, authority: Address): Instruction {
     return {
         programAddress: BPF_LOADER_UPGRADEABLE,
         accounts: [writable(buffer), writable(recipient), signer(authority)],

--- a/webapp/scripts/init-test-environment.ts
+++ b/webapp/scripts/init-test-environment.ts
@@ -4,8 +4,8 @@
  */
 
 import { createSolanaRpc, address } from '@solana/kit';
-import { readConfig, addToken, clearConfig, setProgramAddress } from './config-manager';
-import { createMockUsdc } from './helpers';
+import { readConfig, addToken, clearConfig, setProgramAddress } from './config-manager.js';
+import { createMockUsdc } from './helpers.js';
 
 const PROGRAM_ID = 'De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44';
 

--- a/webapp/scripts/mint-usdc.ts
+++ b/webapp/scripts/mint-usdc.ts
@@ -4,8 +4,8 @@
  */
 
 import { address } from '@solana/kit';
-import { getUsdcMint } from './config-manager';
-import { mintMockUsdc } from './helpers';
+import { getUsdcMint } from './config-manager.js';
+import { mintMockUsdc } from './helpers.js';
 
 async function main() {
     const args = process.argv.slice(2);


### PR DESCRIPTION
## Summary
The webapp `api/` (Vercel serverless functions) and `scripts/` compile under node16/nodenext, but the webapp's `tsc -b` only includes `src` + `vite.config.ts` — so these type errors never surfaced locally/CI, only in the Vercel function build logs:

- **`api/lib/bpf-loader.ts`** imported `IInstruction` / `IAccountMeta`; `@solana/kit` dropped the `I` prefix → use `Instruction` / `AccountMeta`.
- **`scripts/init-test-environment.ts`, `scripts/mint-usdc.ts`** relative imports lacked the `.js` extension required under nodenext. Adding it also fixes a downstream implicit-`any` (the param was `any` only because the unresolved `./config-manager` import erased its type).

## Verification
Reproduced + verified clean with a nodenext typecheck over `api/**` + `scripts/**` (kit 6.9.0):
```
tsc --module nodenext --moduleResolution nodenext --strict --noEmit  →  0 errors
```

## Note / follow-up
The Vercel logs also showed `@solana/kit` "no exported member" errors for names that **do** exist in 6.9.0 (`Address`, `address`, `createSolanaRpc`, …) and a `server.ts` discriminated-union error on code that is actually correctly narrowed. These do **not** reproduce locally with kit 6.9.0 — they appear to be a Vercel-side dependency-resolution artifact (the lockfile carries kit 2.3.0 / 5.5.1 / 6.9.0). This PR fixes the genuine, reproducible source errors; if the resolution residue persists on the Vercel build after merge, a kit dedupe/version-pin is the next step.