### PR TITLE
feat(webapp): add devnet-gated delegation UI for soak period

### DIFF
--- a/webapp/src/components/delegation/active-delegations.tsx
+++ b/webapp/src/components/delegation/active-delegations.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dialog';
 import { useDelegations, useIncomingDelegations, type DelegationItem } from '@/hooks/use-delegations';
 import { useSubscriptionsMutations } from '@/hooks/use-subscriptions-mutations';
+import { useFeatures } from '@/hooks/use-features';
 import { useGetTokenAccountsQuery } from '@/components/account/account-data-access';
 import { useWallet } from '@solana/connector/react';
 import { address } from '@solana/kit';
@@ -855,6 +856,8 @@ export function ActiveDelegations({
     const [outgoingSubTab, setOutgoingSubTab] = useState<OutgoingSubTab>('active');
     const [closeDialogOpen, setCloseDialogOpen] = useState(false);
     const queryClient = useQueryClient();
+    const { account } = useWallet();
+    const features = useFeatures();
     const { url: rpcUrl } = useClusterConfig();
     const { data: blockTime } = useQuery({
         queryKey: ['blockTime', rpcUrl],
@@ -892,7 +895,12 @@ export function ActiveDelegations({
         return outgoingForMint.all.filter(d => d.data.header.initId !== subscriptionAuthorityInitId);
     }, [outgoingForMint.all, subscriptionAuthorityInitId]);
 
-    const { revokeMultipleDelegations } = useSubscriptionsMutations();
+    const abandonedDelegations = useMemo(() => {
+        if (isInitialized || !account) return [];
+        return outgoingForMint.all.filter(d => d.data.header.payer === account);
+    }, [isInitialized, account, outgoingForMint.all]);
+
+    const { revokeMultipleDelegations, revokeAbandonedDelegations } = useSubscriptionsMutations();
     const approvalState = getDelegationApprovalState({
         isInitialized,
         isApproved,
@@ -903,6 +911,15 @@ export function ActiveDelegations({
         if (staleDelegations.length === 0) return;
         await revokeMultipleDelegations.mutateAsync({
             delegations: staleDelegations.map(d => ({ address: d.address, payer: d.data.header.payer })),
+        });
+        onInitSuccess?.();
+    };
+
+    const handleReclaimAbandoned = async () => {
+        if (abandonedDelegations.length === 0) return;
+        await revokeAbandonedDelegations.mutateAsync({
+            tokenMint,
+            delegationAccounts: abandonedDelegations.map(d => d.address),
         });
         onInitSuccess?.();
     };
@@ -1000,6 +1017,20 @@ export function ActiveDelegations({
                         {revokeMultipleDelegations.isPending
                             ? 'Revoking...'
                             : `Revoke ${staleDelegations.length} Stale`}
+                    </Button>
+                )}
+                {features.revokeAbandonedDelegation && abandonedDelegations.length > 0 && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleReclaimAbandoned}
+                        disabled={revokeAbandonedDelegations.isPending}
+                        className="text-amber-600 border-amber-300 hover:bg-amber-100 hover:text-amber-700"
+                    >
+                        <Trash2 className="h-4 w-4 mr-1.5" />
+                        {revokeAbandonedDelegations.isPending
+                            ? 'Reclaiming...'
+                            : `Reclaim ${abandonedDelegations.length} Abandoned`}
                     </Button>
                 )}
                 {approvalState.canCloseSubscriptionAuthority && (

--- a/webapp/src/components/delegation/create-delegation-dialog.tsx
+++ b/webapp/src/components/delegation/create-delegation-dialog.tsx
@@ -12,6 +12,7 @@ import { cn, SECONDS_PER_DAY } from '@/lib/utils';
 import { parseTokenAmount, resolvePlanTokenDisplay } from '@/lib/token-display';
 import { getBlockTimestamp } from '@/hooks/use-time-travel';
 import { useClusterConfig } from '@/hooks/use-cluster-config';
+import { useFeatures } from '@/hooks/use-features';
 
 interface CreateDelegationDialogProps {
     tokenMint: string;
@@ -58,11 +59,13 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
     const [expiryDate, setExpiryDate] = useState('');
     const [expiryHour, setExpiryHour] = useState('12');
     const [periodDays, setPeriodDays] = useState('');
+    const [startNow, setStartNow] = useState(false);
 
     const { createFixedDelegation, createRecurringDelegation } = useSubscriptionsMutations();
     const { data: authorityStatus } = useSubscriptionAuthorityStatus(tokenMint);
     const authorityInitId = authorityStatus?.data?.initId;
     const { url: rpcUrl } = useClusterConfig();
+    const features = useFeatures();
     const { data: tokens } = useTokenConfig();
     const token = useMemo(() => resolvePlanTokenDisplay(tokenMint, tokens), [tokenMint, tokens]);
     const [blockTime, setBlockTime] = useState<number | undefined>();
@@ -84,6 +87,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
         setExpiryDate('');
         setExpiryHour('12');
         setPeriodDays('');
+        setStartNow(false);
         setStep('kind');
         setSelectedKind('fixed');
     };
@@ -156,6 +160,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
                     amountPerPeriod: amountInSmallestUnits,
                     periodLengthS: periodSeconds,
                     expiryTs: expiryTimestamp,
+                    startTs: startNow ? 0n : undefined,
                     expectedSubscriptionAuthorityInitId: authorityInitId,
                 },
                 {
@@ -192,7 +197,8 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
         authorityInitId != null &&
         (noExpiry || expiryDate.length > 0) &&
         isExpiryValid() &&
-        (selectedKind === 'fixed' || (periodDays.length > 0 && Number(periodDays) > 0));
+        (selectedKind === 'fixed' || (periodDays.length > 0 && Number(periodDays) > 0)) &&
+        !(selectedKind === 'recurring' && startNow && noExpiry);
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange} modal={false}>
@@ -294,6 +300,31 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
                                     <p className="text-xs text-muted-foreground">
                                         How often the delegatee can withdraw the specified amount
                                     </p>
+                                </div>
+                            )}
+
+                            {selectedKind === 'recurring' && features.startNowRecurringDelegation && (
+                                <div className="grid gap-2">
+                                    <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                            type="checkbox"
+                                            checked={startNow}
+                                            onChange={e => setStartNow(e.target.checked)}
+                                            className="h-4 w-4 rounded border-sand-400 bg-card text-foreground focus:ring-foreground"
+                                        />
+                                        <span className="text-sm text-foreground">
+                                            Start when transaction lands (start_ts = 0)
+                                        </span>
+                                    </label>
+                                    {startNow && noExpiry ? (
+                                        <p className="text-xs text-destructive">
+                                            Start-on-landing requires an expiry. Turn off &ldquo;No expiry&rdquo;.
+                                        </p>
+                                    ) : (
+                                        <p className="text-xs text-muted-foreground">
+                                            First period begins at the on-chain block time instead of a fixed date.
+                                        </p>
+                                    )}
                                 </div>
                             )}
 

--- a/webapp/src/components/delegation/create-delegation-dialog.tsx
+++ b/webapp/src/components/delegation/create-delegation-dialog.tsx
@@ -100,6 +100,7 @@ export function CreateDelegationDialog({ tokenMint, disabled }: CreateDelegation
     };
 
     const handleKindSelect = (kind: DelegationKindId) => {
+        if (kind !== 'recurring') setStartNow(false);
         setSelectedKind(kind);
     };
 

--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -44,3 +44,25 @@ export const STATIC_NETWORKS: Record<Network, NetworkConfig> = {
         tokens: [],
     },
 };
+
+export interface Features {
+    revokeAbandonedDelegation: boolean;
+    startNowRecurringDelegation: boolean;
+}
+
+const SOAK_FEATURES: Features = {
+    revokeAbandonedDelegation: true,
+    startNowRecurringDelegation: true,
+};
+
+const STABLE_FEATURES: Features = {
+    revokeAbandonedDelegation: false,
+    startNowRecurringDelegation: false,
+};
+
+export const FEATURES: Record<Network, Features> = {
+    devnet: SOAK_FEATURES,
+    localnet: SOAK_FEATURES,
+    mainnet: STABLE_FEATURES,
+    testnet: STABLE_FEATURES,
+};

--- a/webapp/src/hooks/use-features.ts
+++ b/webapp/src/hooks/use-features.ts
@@ -1,0 +1,8 @@
+import { FEATURES, type Features } from '@/config/networks';
+import { useClusterConfig } from '@/hooks/use-cluster-config';
+import { clusterIdToNetwork } from '@/lib/cluster';
+
+export function useFeatures(): Features {
+    const { id } = useClusterConfig();
+    return FEATURES[clusterIdToNetwork(id)];
+}

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -915,10 +915,10 @@ export function useSubscriptionsMutations() {
                 { programAddress: progId },
             );
 
-            const revokeIxs = delegationAccounts.map(account =>
+            const revokeIxs = delegationAccounts.map(delegationAccount =>
                 getRevokeAbandonedDelegationInstruction(
                     {
-                        delegationAccount: address(account),
+                        delegationAccount: address(delegationAccount),
                         payer: signer,
                         subscriptionAuthority,
                     },

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -11,6 +11,7 @@ import {
     getDeletePlanOverlayInstruction,
     getInitSubscriptionAuthorityOverlayInstructionAsync,
     getResumeSubscriptionOverlayInstructionAsync,
+    getRevokeAbandonedDelegationInstruction,
     getRevokeDelegationOverlayInstruction,
     getRevokeSubscriptionAuthorityOverlayInstructionAsync,
     getRevokeSubscriptionOverlayInstruction,
@@ -904,6 +905,47 @@ export function useSubscriptionsMutations() {
         },
     });
 
+    const revokeAbandonedDelegations = useMutation({
+        mutationFn: async ({ tokenMint, delegationAccounts }: { delegationAccounts: string[]; tokenMint: string }) => {
+            if (!signer) throw new Error('Wallet not connected');
+            if (!progId) throw new Error('Program address not configured');
+
+            const [subscriptionAuthority] = await findSubscriptionAuthorityPda(
+                { tokenMint: address(tokenMint), user: signer.address },
+                { programAddress: progId },
+            );
+
+            const revokeIxs = delegationAccounts.map(account =>
+                getRevokeAbandonedDelegationInstruction(
+                    {
+                        delegationAccount: address(account),
+                        payer: signer,
+                        subscriptionAuthority,
+                    },
+                    { programAddress: progId },
+                ),
+            );
+
+            const batches = packInstructionBatches(revokeIxs, signer);
+            const signatures: string[] = [];
+
+            for (const batch of batches) {
+                signatures.push(await signAndSend(batch, signer));
+            }
+
+            return { revoked: delegationAccounts.length, signatures };
+        },
+        onError: error => toast.onError(error),
+        onSuccess: res => {
+            toast.onSuccess(res.signatures[0]);
+            invalidateWithDelay(queryClient, [
+                ['delegations'],
+                ['subscriptionAuthorityStatus'],
+                ['get-token-accounts'],
+            ]);
+        },
+    });
+
     return {
         cancelAndRevokeSubscription,
         cancelSubscription,
@@ -916,6 +958,7 @@ export function useSubscriptionsMutations() {
         deletePlan,
         initSubscriptionAuthority,
         resumeSubscription,
+        revokeAbandonedDelegations,
         revokeDelegation,
         revokeMultipleDelegations,
         revokeSubscription,

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -21,6 +21,7 @@ import {
     getTransferSubscriptionOverlayInstructionAsync,
     getUpdatePlanOverlayInstruction,
     PlanStatus,
+    resolveTransferHookAccounts,
     ZERO_ADDRESS,
 } from '@solana/subscriptions';
 import { findAssociatedTokenPda, getCreateAssociatedTokenIdempotentInstruction } from '@solana-program/token';
@@ -320,6 +321,19 @@ export function useSubscriptionsMutations() {
             tokenProgram,
         });
 
+        const [subscriptionAuthority] = await findSubscriptionAuthorityPda(
+            { tokenMint: mint, user: delegatorAddr },
+            { programAddress: progId },
+        );
+        const transferHookAccounts = await resolveTransferHookAccounts(createSolanaRpc(rpcUrl), {
+            amount: params.amount,
+            authority: subscriptionAuthority,
+            destination: receiver,
+            mint,
+            source: delegatorAta,
+            tokenProgram,
+        });
+
         const buildFn =
             kind === 'fixed' ? getTransferFixedOverlayInstructionAsync : getTransferRecurringOverlayInstructionAsync;
         const transferIx = await buildFn({
@@ -332,6 +346,7 @@ export function useSubscriptionsMutations() {
             receiverAta: receiver,
             tokenMint: mint,
             tokenProgram,
+            transferHookAccounts,
         });
 
         return { instructions: [createAtaIx, transferIx], signer };


### PR DESCRIPTION
## Summary
- Adds two delegation UI features that are live on the **devnet** program but not yet on mainnet, gated by cluster so mainnet/testnet users never hit unsupported program paths.
- **RevokeAbandonedDelegation** — a "Reclaim N Abandoned" toolbar action reclaims rent from delegation PDAs whose `SubscriptionAuthority` has been closed (no UI existed for this instruction before).
- **CreateRecurringDelegation `start_ts=0`** — a "Start when transaction lands" toggle on recurring delegations; blocks the no-expiry combo the program rejects (`RecurringDelegationStartOnLandingRequiresExpiry`, 408).
- New cluster-keyed `FEATURES` map + `useFeatures()` hook: both features on for `devnet`/`localnet`, off for `mainnet`/`testnet`. One-line flip per flag when the mainnet program upgrade lands.

## Soak / rollout
Same program ID across clusters, but mainnet isn't upgraded yet, so capability is gated on the **cluster** (not the deploy env) — a mainnet user on the prod deploy can't reach the new paths. Flip `MAINNET`/`testnet` flags in `webapp/src/config/networks.ts` post-upgrade.

## Test Plan
- Devnet: recurring delegation → "Start when transaction lands" → submit → `current_period_start_ts` ≈ block time. Toggle off expiry → submit blocked.
- Devnet: create delegation → "Disable" (closes authority, orphans PDAs) → "Reclaim N Abandoned" appears → click → PDAs close, rent returned.
- Mainnet/testnet: neither control renders.
- `tsc -b`, eslint, prettier all clean.

## Notes
- Token-2022 transfer-hook (the third devnet-only capability) is **not** gated here — its UI (add-token / auto token-program detection) predates this PR and is generic. If we want to block hook/token-2022 mints on mainnet during soak, that's a follow-up touching the add-token flow.
