### PR TITLE
fix: Token-2022 transfer-hook gaps (collect paths + hook fixture)

### DIFF
--- a/tests/transfer-hook-example/Cargo.lock
+++ b/tests/transfer-hook-example/Cargo.lock
@@ -47,6 +47,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "five8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_const"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +97,16 @@ dependencies = [
  "solana-define-syscall 5.1.0",
  "solana-instruction-view",
  "solana-program-error",
+]
+
+[[package]]
+name = "pinocchio-system"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ae2ee67b42e2ac797dd88312da473c895660e270d8093e0ba2749b885b5778"
+dependencies = [
+ "pinocchio",
+ "solana-address",
 ]
 
 [[package]]
@@ -108,6 +142,8 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
+ "five8",
+ "five8_const",
  "sha2-const-stable",
  "solana-define-syscall 5.1.0",
  "solana-program-error",
@@ -166,6 +202,7 @@ name = "transfer-hook-example"
 version = "0.1.0"
 dependencies = [
  "pinocchio",
+ "pinocchio-system",
 ]
 
 [[package]]

--- a/tests/transfer-hook-example/Cargo.toml
+++ b/tests/transfer-hook-example/Cargo.toml
@@ -13,7 +13,8 @@ license = "MIT"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-pinocchio = "0.11.1"
+pinocchio = { version = "0.11.1", features = ["cpi"] }
+pinocchio-system = "0.6.1"
 
 [profile.release]
 opt-level = 3

--- a/tests/transfer-hook-example/src/lib.rs
+++ b/tests/transfer-hook-example/src/lib.rs
@@ -1,35 +1,117 @@
-//! Minimal Token-2022 transfer-hook program (Execute only) used as a CPI target in tests.
+//! Minimal Token-2022 transfer-hook program for tests and devnet fixtures.
+//! - `Execute`: increments a per-mint counter account (CPI target proof).
+//! - `InitializeExtraAccountMetaList`: creates the validation PDA (one
+//!   seed-derived counter meta) and the counter PDA so a hooked
+//!   `TransferChecked` resolves and runs on-chain.
 #![no_std]
 
 use pinocchio::{
-    account::AccountView, default_allocator, error::ProgramError, nostd_panic_handler, program_entrypoint, Address,
-    ProgramResult,
+    account::AccountView,
+    cpi::{Seed, Signer},
+    default_allocator,
+    error::ProgramError,
+    nostd_panic_handler, program_entrypoint,
+    sysvars::{rent::Rent, Sysvar},
+    Address, ProgramResult,
 };
+use pinocchio_system::instructions::CreateAccount;
 
-const EXECUTE_DISCRIMINATOR: [u8; 8] = [0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a]; // sha256("spl-transfer-hook-interface:execute")[..8]
+// sha256("spl-transfer-hook-interface:execute")[..8]
+const EXECUTE_DISCRIMINATOR: [u8; 8] = [0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a];
+// sha256("spl-transfer-hook-interface:initialize-extra-account-metas")[..8]
+const INIT_DISCRIMINATOR: [u8; 8] = [43, 34, 13, 49, 167, 88, 235, 235];
 
 // Execute accounts: [source, mint, destination, authority, validation, counter]
 const COUNTER_ACCOUNT_INDEX: usize = 5;
+
+const EXTRA_ACCOUNT_METAS_SEED: &[u8] = b"extra-account-metas";
+const COUNTER_SEED: &[u8] = b"counter";
+// ExtraAccountMetaList with one seed-derived counter meta: 8-byte execute
+// discriminator, u32 value length (4 + 35), u32 entry count (1), one 35-byte meta.
+const VALIDATION_LEN: usize = 51;
+const COUNTER_LEN: usize = 1;
 
 program_entrypoint!(process_instruction);
 default_allocator!();
 nostd_panic_handler!();
 
 pub fn process_instruction(
-    _program_id: &Address,
+    program_id: &Address,
     accounts: &mut [AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    if instruction_data.len() < EXECUTE_DISCRIMINATOR.len()
-        || instruction_data[..EXECUTE_DISCRIMINATOR.len()] != EXECUTE_DISCRIMINATOR
-    {
+    if instruction_data.len() < 8 {
         return Err(ProgramError::InvalidInstructionData);
     }
+    if instruction_data[..8] == INIT_DISCRIMINATOR {
+        return initialize_extra_account_metas(program_id, accounts);
+    }
+    if instruction_data[..8] == EXECUTE_DISCRIMINATOR {
+        return execute(accounts);
+    }
+    Err(ProgramError::InvalidInstructionData)
+}
 
+fn execute(accounts: &mut [AccountView]) -> ProgramResult {
     let counter = accounts.get_mut(COUNTER_ACCOUNT_INDEX).ok_or(ProgramError::NotEnoughAccountKeys)?;
     let mut data = counter.try_borrow_mut()?;
     let byte = data.first_mut().ok_or(ProgramError::AccountDataTooSmall)?;
     *byte = byte.wrapping_add(1);
+    Ok(())
+}
 
+// Accounts: [payer, validation PDA, counter PDA, mint, system program]
+fn initialize_extra_account_metas(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    if accounts.len() < 4 {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    let mut mint_key = [0u8; 32];
+    mint_key.copy_from_slice(accounts[3].address().as_ref());
+
+    create_pda(accounts, 1, EXTRA_ACCOUNT_METAS_SEED, &mint_key, program_id, VALIDATION_LEN)?;
+    write_validation_list(accounts)?;
+    create_pda(accounts, 2, COUNTER_SEED, &mint_key, program_id, COUNTER_LEN)?;
+
+    Ok(())
+}
+
+fn create_pda(
+    accounts: &mut [AccountView],
+    account_index: usize,
+    prefix: &[u8],
+    mint_key: &[u8; 32],
+    program_id: &Address,
+    space: usize,
+) -> ProgramResult {
+    let (expected_pda, bump) = Address::find_program_address(&[prefix, mint_key.as_ref()], program_id);
+    if expected_pda != *accounts[account_index].address() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let lamports = Rent::get()?.try_minimum_balance(space)?;
+    let bump_binding = [bump];
+    let seeds = [Seed::from(prefix), Seed::from(mint_key.as_ref()), Seed::from(&bump_binding)];
+    let signer = [Signer::from(&seeds)];
+
+    CreateAccount { from: &accounts[0], to: &accounts[account_index], lamports, space: space as u64, owner: program_id }
+        .invoke_signed(&signer)
+}
+
+// Writes an ExtraAccountMetaList with one PDA meta: counter = PDA of the hook
+// program from seeds [Literal("counter"), AccountKey(mint)], writable.
+fn write_validation_list(accounts: &mut [AccountView]) -> ProgramResult {
+    let mut data = accounts[1].try_borrow_mut()?;
+    data[..8].copy_from_slice(&EXECUTE_DISCRIMINATOR);
+    data[8..12].copy_from_slice(&((4 + 35) as u32).to_le_bytes());
+    data[12..16].copy_from_slice(&1u32.to_le_bytes());
+    data[16] = 1; // ExtraAccountMeta discriminator: PDA of the hook program
+    data[17] = 1; // seed 0: Literal
+    data[18] = COUNTER_SEED.len() as u8;
+    data[19..19 + COUNTER_SEED.len()].copy_from_slice(COUNTER_SEED);
+    data[26] = 3; // seed 1: AccountKey
+    data[27] = 1; // account index 1 = mint
+    data[49] = 0; // is_signer
+    data[50] = 1; // is_writable
     Ok(())
 }

--- a/tests/transfer-hook-example/src/lib.rs
+++ b/tests/transfer-hook-example/src/lib.rs
@@ -62,7 +62,7 @@ fn execute(accounts: &mut [AccountView]) -> ProgramResult {
 
 // Accounts: [payer, validation PDA, counter PDA, mint, system program]
 fn initialize_extra_account_metas(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
-    if accounts.len() < 4 {
+    if accounts.len() < 5 {
         return Err(ProgramError::NotEnoughAccountKeys);
     }
 

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -75,6 +75,29 @@ export function useSubscriptionsMutations() {
         return subscriptionAuthority.data.initId;
     };
 
+    const resolveSubscriptionHookAccounts = async (
+        mint: Address,
+        delegator: Address,
+        receiverAta: Address,
+        amount: bigint,
+        tokenProgram: Address,
+    ) => {
+        if (!progId) throw new Error('Program address not configured');
+        const [subscriptionAuthority] = await findSubscriptionAuthorityPda(
+            { tokenMint: mint, user: delegator },
+            { programAddress: progId },
+        );
+        const [delegatorAta] = await findAssociatedTokenPda({ mint, owner: delegator, tokenProgram });
+        return await resolveTransferHookAccounts(createSolanaRpc(rpcUrl), {
+            amount,
+            authority: subscriptionAuthority,
+            destination: receiverAta,
+            mint,
+            source: delegatorAta,
+            tokenProgram,
+        });
+    };
+
     const initSubscriptionAuthority = useMutation({
         mutationFn: async ({
             tokenMint,
@@ -700,6 +723,13 @@ export function useSubscriptionsMutations() {
                         subscriptionPda: address(sub.subscriptionAddress),
                         tokenMint: mintAddr,
                         tokenProgram,
+                        transferHookAccounts: await resolveSubscriptionHookAccounts(
+                            mintAddr,
+                            address(sub.delegator),
+                            receiverAta,
+                            sub.amount,
+                            tokenProgram,
+                        ),
                     });
                     return { instruction, subscriber: sub };
                 }),
@@ -828,6 +858,13 @@ export function useSubscriptionsMutations() {
                         subscriptionPda: address(sub.subscriptionAddress),
                         tokenMint: mintAddr,
                         tokenProgram,
+                        transferHookAccounts: await resolveSubscriptionHookAccounts(
+                            mintAddr,
+                            address(sub.delegator),
+                            receiverAta,
+                            sub.amount,
+                            tokenProgram,
+                        ),
                     });
                     transferEntries.push({ instruction, subscriber: sub });
                 }

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -847,7 +847,19 @@ export function useSubscriptionsMutations() {
                     );
                 }
 
-                for (const sub of payable) {
+                const planHookAccounts = await Promise.all(
+                    payable.map(sub =>
+                        resolveSubscriptionHookAccounts(
+                            mintAddr,
+                            address(sub.delegator),
+                            receiverAta,
+                            sub.amount,
+                            tokenProgram,
+                        ),
+                    ),
+                );
+
+                for (const [i, sub] of payable.entries()) {
                     const instruction = await getTransferSubscriptionOverlayInstructionAsync({
                         amount: sub.amount,
                         caller: signer,
@@ -858,13 +870,7 @@ export function useSubscriptionsMutations() {
                         subscriptionPda: address(sub.subscriptionAddress),
                         tokenMint: mintAddr,
                         tokenProgram,
-                        transferHookAccounts: await resolveSubscriptionHookAccounts(
-                            mintAddr,
-                            address(sub.delegator),
-                            receiverAta,
-                            sub.amount,
-                            tokenProgram,
-                        ),
+                        transferHookAccounts: planHookAccounts[i],
                     });
                     transferEntries.push({ instruction, subscriber: sub });
                 }


### PR DESCRIPTION
## Summary
- **fix(webapp):** `collectSubscriptionPayments` and `collectAllPlanPayments` built the transfer overlay directly without resolving Token-2022 transfer-hook accounts, so hooked-mint plan payments failed with `TransferHookValidationAccountMissing` (138). Now resolve them per subscriber from the delegator's subscription authority and forward them. Mirrors the delegation-transfer fix from #171 and the plugin client's `resolveDelegationHookAccounts`. No-op for non-hooked / non-2022 mints (`resolveTransferHookAccounts` returns `[]`).
- **test(hook):** the `transfer-hook-example` program was Execute-only — its validation PDA + counter were fabricated in-VM under LiteSVM, so it couldn't be set up on a real cluster. Added an on-chain `InitializeExtraAccountMetaList` that creates the `extra-account-metas` PDA (one seed-derived counter meta) and the counter PDA, so the hook can be exercised on devnet.

## Background
Found while manually testing Token-2022 transfer-hook support on devnet (PYUSD-style mints). The delegation-transfer path was fixed in #171; this PR closes the same gap in the two plan-payment collection paths and makes the hook fixture deployable.

## Test Plan
- Devnet, end-to-end: deployed the extended hook, minted a Token-2022 mint with an active transfer hook, ran a fixed-delegation transfer through the webapp → hook fired (`Program <hook> invoke [3]`), counter PDA incremented `0 → 1`.
- `tsc -b`, eslint, prettier clean (webapp).
- `cargo fmt --check` + `cargo build-sbf` clean (hook example). Existing LiteSVM integration/lifecycle tests unaffected — `Execute` behavior is unchanged.
