### PR TITLE
docs: add changelogs for program and SDK clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,24 +11,25 @@ _Targets `program-v1.1.0` (target deploy 2026-06-26). Additive and non-breaking;
 
 ### Added
 
-- `RevokeSubscriptionAuthority` — revoke the SPL Token / Token-2022 delegate left on a user's ATA when tearing down a `SubscriptionAuthority` (revoke + close). Fixes advisory GHSA-278q-6j9j-9c3r. ([#162])
+- `RevokeSubscriptionAuthority` — revoke the SPL Token / Token-2022 delegate left on a user's ATA when tearing down a `SubscriptionAuthority` (revoke + close). ([#162])
 - `RevokeAbandonedDelegation` — let a sponsor reclaim rent from a delegation whose token account was closed (subscription authority dead). ([#163])
-- Token-2022 Transfer Hook support — hooked mints (e.g. PYUSD) work end-to-end for fixed, recurring, and subscription transfers. ([#160])
+- Token-2022 Transfer Hook support — hooked mints work end-to-end for fixed, recurring, and subscription transfers. ([#160])
 
 ### Changed
 
 - `CreateRecurringDelegation` accepts `start_ts = 0` as a sentinel: the first period starts at the on-chain clock time when the transaction lands. Requires a non-zero `expiry_ts`. ([#164])
-- Tightened account and state validation (audit remediation MULT-54/53/56). ⚠️ Integrators relying on previously-lax behavior may now see validation errors. ([#163])
+- Tightened account and state validation. ([#163])
 
 ### Security
 
-- Cantina delta audit remediations (MULT-54/53/56); advisory GHSA-278q-6j9j-9c3r resolved. See [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md).
+- See [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md).
 
 ## [1.0.0] — 2026-06-01
 
 Initial audited mainnet release (`program-v1.0.0`, commit `0221a37`).
 
 [Unreleased]: https://github.com/solana-foundation/subscriptions/compare/0221a37...main
+[1.0.0]: https://github.com/solana-foundation/subscriptions/commit/0221a37
 [#160]: https://github.com/solana-foundation/subscriptions/pull/160
 [#162]: https://github.com/solana-foundation/subscriptions/pull/162
 [#163]: https://github.com/solana-foundation/subscriptions/pull/163

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `program-vX.Y.Z` git tags.
 SDK client changelogs are tracked separately: [`clients/typescript`](clients/typescript/CHANGELOG.md) and [`clients/rust`](clients/rust/CHANGELOG.md).
 
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — Subscriptions program
+
+On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `program-vX.Y.Z` git tags.
+SDK client changelogs are tracked separately: [`clients/typescript`](clients/typescript/CHANGELOG.md) and [`clients/rust`](clients/rust/CHANGELOG.md).
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+_Targets `program-v1.1.0` (target deploy 2026-06-26). Additive and non-breaking; reproducible via `solana-verify`. Audit status: [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md)._
+
+### Added
+
+- `RevokeSubscriptionAuthority` — revoke the SPL Token / Token-2022 delegate left on a user's ATA when tearing down a `SubscriptionAuthority` (revoke + close). Fixes advisory GHSA-278q-6j9j-9c3r. ([#162])
+- `RevokeAbandonedDelegation` — let a sponsor reclaim rent from a delegation whose token account was closed (subscription authority dead). ([#163])
+- Token-2022 Transfer Hook support — hooked mints (e.g. PYUSD) work end-to-end for fixed, recurring, and subscription transfers. ([#160])
+
+### Changed
+
+- `CreateRecurringDelegation` accepts `start_ts = 0` as a sentinel: the first period starts at the on-chain clock time when the transaction lands. Requires a non-zero `expiry_ts`. ([#164])
+- Tightened account and state validation (audit remediation MULT-54/53/56). ⚠️ Integrators relying on previously-lax behavior may now see validation errors. ([#163])
+
+### Security
+
+- Cantina delta audit remediations (MULT-54/53/56); advisory GHSA-278q-6j9j-9c3r resolved. See [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md).
+
+## [1.0.0] — 2026-06-01
+
+Initial audited mainnet release (`program-v1.0.0`, commit `0221a37`).
+
+[Unreleased]: https://github.com/solana-foundation/subscriptions/compare/0221a37...main
+[#160]: https://github.com/solana-foundation/subscriptions/pull/160
+[#162]: https://github.com/solana-foundation/subscriptions/pull/162
+[#163]: https://github.com/solana-foundation/subscriptions/pull/163
+[#164]: https://github.com/solana-foundation/subscriptions/pull/164

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Rust SDK for the Subscriptions program. Published to crates.io; tagged `rust-client-vX.Y.Z`.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — `subscriptions` (Rust client)
+
+Rust SDK for the Subscriptions program. Published to crates.io; tagged `rust-client-vX.Y.Z`.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+_Targets `0.4.0` (release candidate `0.4.0-rc.1` published to crates.io)._
+
+### Added
+
+- Instruction builders for `RevokeSubscriptionAuthority` and `RevokeAbandonedDelegation`. ([#162], [#163])
+- Token-2022 transfer-hook account resolution for fixed, recurring, and subscription transfers. ([#160])
+
+### Changed
+
+- `create_recurring_delegation` accepts `start_ts = 0` (start on landing; requires a non-zero `expiry_ts`). ([#164])
+
+_Releases before `0.4.0` predate this changelog; see the `rust-client-v*` tags and GitHub Releases._
+
+[#160]: https://github.com/solana-foundation/subscriptions/pull/160
+[#162]: https://github.com/solana-foundation/subscriptions/pull/162
+[#163]: https://github.com/solana-foundation/subscriptions/pull/163
+[#164]: https://github.com/solana-foundation/subscriptions/pull/164

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 TypeScript SDK for the Subscriptions program. Published to npm; tagged `ts-client-vX.Y.Z`.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — `@solana/subscriptions`
+
+TypeScript SDK for the Subscriptions program. Published to npm; tagged `ts-client-vX.Y.Z`.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+_Targets `0.4.0` (release candidate `0.4.0-rc.1` published to npm)._
+
+### Added
+
+- `revokeSubscriptionAuthority` and `revokeAbandonedDelegation` instruction builders. ([#162], [#163])
+- `resolveTransferHookAccounts`, plus automatic Token-2022 transfer-hook account resolution in `transferFixed`, `transferRecurring`, and `transferSubscription` on the plugin client. ([#160])
+
+### Changed
+
+- `createRecurringDelegation` accepts `startTs: 0` (start on landing; requires a non-zero `expiryTs`). ([#164])
+
+_Releases before `0.4.0` predate this changelog; see the `ts-client-v*` tags and GitHub Releases._
+
+[#160]: https://github.com/solana-foundation/subscriptions/pull/160
+[#162]: https://github.com/solana-foundation/subscriptions/pull/162
+[#163]: https://github.com/solana-foundation/subscriptions/pull/163
+[#164]: https://github.com/solana-foundation/subscriptions/pull/164


### PR DESCRIPTION
## Summary
- Adds [Keep a Changelog](https://keepachangelog.com/) files following the SF SDLC release-notes standard (headers for Added/Changed/Fixed/Security; SemVer):
  - **`CHANGELOG.md`** — the on-chain program, versioned by `program-vX.Y.Z` tags (program ID + verified-build + audit refs).
  - **`clients/typescript/CHANGELOG.md`** and **`clients/rust/CHANGELOG.md`** — the independently-published SDKs (SemVer `0.4.0`).
- Entries are curated from the merged PR history (#160, #162, #163, #164) and seeded into `[Unreleased]` for the pending June-2026 release: `RevokeSubscriptionAuthority`, `RevokeAbandonedDelegation`, Token-2022 transfer-hook support, and the `start_ts = 0` sentinel. Includes the `[1.0.0]` mainnet baseline (`0221a37`).

## Why this shape
- Program and SDKs version independently (program tags vs npm/crates `0.4.0`), so they get separate changelogs.
- `[Unreleased]` accrues as PRs merge; at Phase 5 it's renamed to `[1.1.0] — <date>` and mirrored into the GitHub Release notes (where SDLC §3.5.1 puts release notes).
- `⚠️` flags the #163 validation tightening (non-breaking but may surface new errors for lax integrators), matching the Known Limitations in the release plan.

## Notes
- Part of release **TOO-476**. Does not change behavior or build — docs only.
- Compare link uses the mainnet commit `0221a37`; once Phase 0 retro-tags `program-v1.0.0`, it can switch to the tag.

## Test Plan
- `prettier --check` passes on all three files.
