### PR TITLE
ci: migrate github actions from solana-developers to solana-foundation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,4 +32,4 @@ jobs:
 
       - name: Report compute units
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: solana-developers/github-actions/cu-benchmark@e846103a578b3170a9a14824bcdf38d5dcf59ac0
+        uses: solana-foundation/github-actions/cu-benchmark@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish Rust client crate
         id: cargo_publish
-        uses: solana-developers/github-actions/cargo-publish@e2cd34eb09f996b48be7f6daeb8f455094dd6d53
+        uses: solana-foundation/github-actions/cargo-publish@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           package: subscriptions
           working-directory: clients/rust

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Publish TypeScript client
         id: npm_publish
-        uses: solana-developers/github-actions/npm-publish@279ffba919ebb53b40c1f7e3b98783888942f666
+        uses: solana-foundation/github-actions/npm-publish@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           package: '@solana/subscriptions'
           package-directory: clients/typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,14 +71,14 @@ jobs:
         run: just generate-idl
 
       - name: Build verified program
-        uses: solana-developers/github-actions/build-verified@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/build-verified@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           program: ${{ env.PROGRAM }}
 
       - id: write-buffer
         if: inputs.network == 'devnet'
         name: Write program buffer
-        uses: solana-developers/github-actions/write-program-buffer@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/write-program-buffer@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -92,7 +92,7 @@ jobs:
       # ============================================
       - if: inputs.network == 'devnet'
         name: Upgrade program (devnet)
-        uses: solana-developers/github-actions/program-upgrade@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/program-upgrade@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}
@@ -102,7 +102,7 @@ jobs:
 
       - if: inputs.network == 'devnet'
         name: Upload IDL via program-metadata (devnet)
-        uses: solana-developers/github-actions/metadata-upload@eb606791e11d06eb92593dfd3404bf0d4c809121
+        uses: solana-foundation/github-actions/metadata-upload@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           program-id: ${{ env.PROGRAM_ID }}
           rpc-url: ${{ env.RPC_URL }}
@@ -116,7 +116,7 @@ jobs:
       - if: inputs.network == 'mainnet'
         id: prepare-squads-release
         name: Prepare Squads release buffers (mainnet)
-        uses: solana-developers/github-actions/prepare-squads-release@b480a01c45f5670da8e9d76fa03d30d9deb7153d
+        uses: solana-foundation/github-actions/prepare-squads-release@f0ddc2234ac4ac19c5c17f520b60bc2d7308744f
         with:
           program: ${{ env.PROGRAM }}
           program-id: ${{ env.PROGRAM_ID }}


### PR DESCRIPTION
## Summary
- Point all `uses:` steps at `solana-foundation/github-actions` (was `solana-developers/github-actions`) across `release.yml`, `publish-rust.yml`, `publish-typescript.yml`, and `benchmark.yml`.
- Repin all 8 references to the latest release **v0.2.11** → `f0ddc2234ac4ac19c5c17f520b60bc2d7308744f`.
- No `solana-developers/github-workflows` references existed; nothing to migrate there. Latest `solana-foundation/github-workflows` release is v0.4.1 (`1a62a52041b4a9beed9e96843062be1859447f1d`), unused by this repo.
- No docs referenced these actions in prose; no doc changes needed.

## Test Plan
- `git grep solana-developers` returns nothing.
- All 8 references resolve to `solana-foundation/github-actions/<action>@f0ddc22`.
- Verified all 8 action paths (build-verified, write-program-buffer, program-upgrade, metadata-upload, prepare-squads-release, cargo-publish, npm-publish, cu-benchmark) exist at the v0.2.11 commit via `gh api`.