### PR TITLE
fix(webapp): gate RevokeSubscriptionAuthority behind feature flag

### DIFF
--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -47,16 +47,19 @@ export const STATIC_NETWORKS: Record<Network, NetworkConfig> = {
 
 export interface Features {
     revokeAbandonedDelegation: boolean;
+    revokeSubscriptionAuthority: boolean;
     startNowRecurringDelegation: boolean;
 }
 
 const SOAK_FEATURES: Features = {
     revokeAbandonedDelegation: true,
+    revokeSubscriptionAuthority: true,
     startNowRecurringDelegation: true,
 };
 
 const STABLE_FEATURES: Features = {
     revokeAbandonedDelegation: false,
+    revokeSubscriptionAuthority: false,
     startNowRecurringDelegation: false,
 };
 

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -29,6 +29,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast as sonnerToast } from 'sonner';
 
 import { useClusterConfig } from '@/hooks/use-cluster-config';
+import { useFeatures } from '@/hooks/use-features';
 import { getBlockTimestamp } from '@/hooks/use-time-travel';
 import { useProgramAddress } from '@/hooks/use-token-config';
 import { type ConfirmedPlanTransfer, createAllPlanPaymentCollectionResult } from '@/lib/collect-all-results';
@@ -52,6 +53,7 @@ export function useSubscriptionsMutations() {
     const queryClient = useQueryClient();
     const toast = useTransactionToast();
     const { url: rpcUrl } = useClusterConfig();
+    const features = useFeatures();
     const programAddress = useProgramAddress();
 
     const progId = programAddress ? address(programAddress) : undefined;
@@ -167,17 +169,18 @@ export function useSubscriptionsMutations() {
             });
             const ataInfo = await rpc.getAccountInfo(userAta, { encoding: 'base64' }).send();
 
-            const instructions = ataInfo.value
-                ? [
-                      await getRevokeSubscriptionAuthorityOverlayInstructionAsync({
-                          programAddress: progId,
-                          tokenMint: address(tokenMint),
-                          tokenProgram,
-                          user: signer,
-                      }),
-                      closeInstruction,
-                  ]
-                : [closeInstruction];
+            const instructions =
+                ataInfo.value && features.revokeSubscriptionAuthority
+                    ? [
+                          await getRevokeSubscriptionAuthorityOverlayInstructionAsync({
+                              programAddress: progId,
+                              tokenMint: address(tokenMint),
+                              tokenProgram,
+                              user: signer,
+                          }),
+                          closeInstruction,
+                      ]
+                    : [closeInstruction];
 
             const signature = await signAndSend(instructions, signer);
             return { signature };


### PR DESCRIPTION
## Summary
- The Disable flow (`closeSubscriptionAuthority`) unconditionally prepended a `RevokeSubscriptionAuthority` instruction (discriminator 14) whenever the user ATA exists. The mainnet program does not yet support that instruction (added in #162, not deployed), so the tx failed on the prepended instruction with custom error 114 → surfaced as **"Invalid instruction"**.
- Added a `revokeSubscriptionAuthority` feature flag to `Features` (on for soak/devnet/localnet, off for mainnet/testnet), mirroring the existing `revokeAbandonedDelegation` (disc 15) gate.
- Gated the disc-14 prepend on that flag. On mainnet, Disable now closes the authority (disc 6, supported) without the revoke until the program upgrade ships; on soak/devnet it still sends `[revoke, close]`.

## Root cause
Confirmed via mainnet `simulateTransaction`: disc 14 → `InstructionError:[0, Custom(114)]`; disc 6 (Close) and disc 0 (Init) succeed. Only disc 14 and disc 15 are absent from the mainnet program; disc 15 was already gated, disc 14 was not.

## Test Plan
- Mainnet, initialized SubscriptionAuthority → click **Disable** → tx succeeds (Close only), no "Invalid instruction".
- Devnet/localnet → **Disable** still sends `RevokeSubscriptionAuthority` + Close.
- Flip `revokeSubscriptionAuthority` to `true` for mainnet once #162 is deployed there.