### PR TITLE
feat(program): support gasless create_plan via optional payer

### DIFF
--- a/clients/typescript/src/plugin.ts
+++ b/clients/typescript/src/plugin.ts
@@ -237,6 +237,7 @@ export type CreatePlanInput = WithProgramAddress & {
     metadataUri: string;
     mint: Address;
     owner: TransactionSigner;
+    payer?: TransactionSigner;
     periodHours: bigint | number;
     planId: bigint | number;
     pullers: Address[];
@@ -566,27 +567,30 @@ export async function getCreatePlanOverlayInstructionAsync(input: CreatePlanInpu
         pdaConfig(input.programAddress),
     );
 
-    return getCreatePlanInstruction(
-        {
-            merchant: input.owner,
-            planData: {
-                destinations,
-                endTs: input.endTs,
-                metadataUri: input.metadataUri,
-                mint: input.mint,
-                planId: input.planId,
-                pullers,
-                terms: {
-                    amount: input.amount,
-                    createdAt: 0n,
-                    periodHours: input.periodHours,
+    return appendPayer(
+        getCreatePlanInstruction(
+            {
+                merchant: input.owner,
+                planData: {
+                    destinations,
+                    endTs: input.endTs,
+                    metadataUri: input.metadataUri,
+                    mint: input.mint,
+                    planId: input.planId,
+                    pullers,
+                    terms: {
+                        amount: input.amount,
+                        createdAt: 0n,
+                        periodHours: input.periodHours,
+                    },
                 },
+                planPda,
+                tokenMint: input.mint,
+                tokenProgram: input.tokenProgram,
             },
-            planPda,
-            tokenMint: input.mint,
-            tokenProgram: input.tokenProgram,
-        },
-        pdaConfig(input.programAddress),
+            pdaConfig(input.programAddress),
+        ),
+        input.payer,
     );
 }
 
@@ -862,6 +866,7 @@ export function subscriptionsProgram() {
                         getCreatePlanOverlayInstructionAsync({
                             ...input,
                             owner: input.owner ?? client.identity,
+                            payer: input.payer ?? (client.payer === client.identity ? undefined : client.payer),
                         }),
                     ),
                 createRecurringDelegation: input =>

--- a/docs/002-subscriptions-architecture.md
+++ b/docs/002-subscriptions-architecture.md
@@ -289,13 +289,20 @@ Per-subscriber billing state linked to a Plan:
 
 Merchant publishes a Plan with subscription terms.
 
-| Account | Type             | Description           |
-| ------- | ---------------- | --------------------- |
-| 0       | signer, writable | Merchant (Plan owner) |
-| 1       | writable         | Plan PDA to create    |
-| 2       |                  | Token mint            |
-| 3       |                  | System program        |
-| 4       |                  | Token program         |
+| Account | Type             | Description                     |
+| ------- | ---------------- | ------------------------------- |
+| 0       | signer, writable | Merchant (Plan owner)           |
+| 1       | writable         | Plan PDA to create              |
+| 2       |                  | Token mint                      |
+| 3       |                  | System program                  |
+| 4       |                  | Token program                   |
+| 5       | signer, writable | Optional payer/sponsor for rent |
+
+When account 5 is supplied it funds plan rent (gasless create); the merchant
+still owns the plan. **Security:** sponsored rent is not recoverable by the
+payer — `delete_plan` refunds the owner, not the payer. Sponsor only merchants
+you trust and gate sponsorship off-chain; never expose it through an open
+relayer, which would let merchants siphon rent by creating and deleting plans.
 
 **Parameters (PlanData):**
 
@@ -372,6 +379,8 @@ Plan owner deletes an expired plan, closing the account and reclaiming rent. Doe
 1. Verify caller is Plan owner (else `NotPlanOwner`)
 2. Verify plan is expired: `end_ts != 0 && current_ts > end_ts` (else `PlanNotExpired`)
 3. Close account: zero all data, transfer lamports to owner
+
+Rent always returns to the owner, even when a sponsor funded creation via `create_plan`'s optional payer. The payer does not recover sponsored rent.
 
 **Lifecycle paths to deletion:**
 

--- a/program/src/instructions/create_plan.rs
+++ b/program/src/instructions/create_plan.rs
@@ -105,6 +105,11 @@ pub const DISCRIMINATOR: &u8 = &7;
 ///
 /// Validates the plan data, creates the plan account via CPI, and initializes
 /// its fields including owner, status, and the embedded [`PlanData`].
+///
+/// A trailing `payer` account, if supplied, funds plan rent while the merchant
+/// still owns the plan. Sponsored rent is NOT recoverable by the payer:
+/// `delete_plan` refunds the owner, not the payer. Only sponsor merchants you
+/// trust; never expose plan-creation sponsorship through an open relayer.
 pub fn process(accounts: &mut [AccountView], data: &PlanData) -> ProgramResult {
     let current_ts = Clock::get()?.unix_timestamp;
     data.validate(current_ts)?;

--- a/program/src/instructions/helpers/plan.rs
+++ b/program/src/instructions/helpers/plan.rs
@@ -1,8 +1,9 @@
 use pinocchio::{cpi::Seed, error::ProgramError, AccountView};
 
 use crate::{
-    find_plan_pda, state::plan::Plan, AccountCheck, MintInterface, ProgramAccount, ProgramAccountInit, SignerAccount,
-    SubscriptionsError, SystemAccount, TokenProgramInterface, WritableAccount,
+    find_plan_pda, helpers::system::resolve_optional_payer, state::plan::Plan, AccountCheck, MintInterface,
+    ProgramAccount, ProgramAccountInit, SignerAccount, SubscriptionsError, SystemAccount, TokenProgramInterface,
+    WritableAccount,
 };
 
 /// Validated accounts for the [`CreatePlan`](crate::SubscriptionsInstruction::CreatePlan) instruction.
@@ -12,13 +13,15 @@ pub struct CreatePlanAccounts<'a> {
     pub token_mint: &'a AccountView,
     pub system_program: &'a AccountView,
     pub token_program: &'a AccountView,
+    /// The account funding rent. Defaults to `merchant` if no extra account is provided.
+    pub payer: &'a AccountView,
 }
 
 impl<'a> TryFrom<&'a mut [AccountView]> for CreatePlanAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a mut [AccountView]) -> Result<Self, Self::Error> {
-        let [merchant, plan_pda, token_mint, system_program, token_program] = accounts else {
+        let [merchant, plan_pda, token_mint, system_program, token_program, rem @ ..] = accounts else {
             return Err(SubscriptionsError::NotEnoughAccountKeys.into());
         };
 
@@ -29,7 +32,9 @@ impl<'a> TryFrom<&'a mut [AccountView]> for CreatePlanAccounts<'a> {
         TokenProgramInterface::check(token_program)?;
         SystemAccount::check(system_program)?;
 
-        Ok(Self { merchant, plan_pda, token_mint, system_program, token_program })
+        let payer = resolve_optional_payer(merchant, rem)?;
+
+        Ok(Self { merchant, plan_pda, token_mint, system_program, token_program, payer })
     }
 }
 
@@ -57,7 +62,7 @@ pub fn create_plan_account(accounts: &CreatePlanAccounts, plan_id: u64) -> Resul
         Seed::from(&bump_bytes[..]),
     ];
 
-    ProgramAccount::init::<()>(accounts.merchant, accounts.plan_pda, &seeds, Plan::LEN)?;
+    ProgramAccount::init::<()>(accounts.payer, accounts.plan_pda, &seeds, Plan::LEN)?;
 
     Ok(bump)
 }

--- a/tests/integration-tests/src/test_create_plan.rs
+++ b/tests/integration-tests/src/test_create_plan.rs
@@ -9,7 +9,7 @@ use crate::{
         asserts::TransactionResultExt,
         constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         pda::get_plan_pda,
-        utils::{current_ts, days, init_mint, setup, CreatePlan},
+        utils::{current_ts, days, init_mint, init_wallet, setup, CreatePlan},
     },
 };
 
@@ -57,6 +57,36 @@ fn create_plan_happy_path() {
     assert_eq!(dests[0].to_bytes(), dest.to_bytes());
     assert_eq!(pulls[0].to_bytes(), puller.to_bytes());
     assert_ne!(bump, 0);
+}
+
+#[test]
+fn create_plan_gasless_sponsor_funds_rent() {
+    let (litesvm, merchant) = &mut setup();
+    let sponsor = init_wallet(litesvm, 10_000_000_000);
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, None, &[]);
+    let dest = Pubkey::new_unique();
+
+    let merchant_before = litesvm.get_account(&merchant.pubkey()).unwrap().lamports;
+    let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    let (res, plan_pda) = CreatePlan::new(litesvm, merchant, mint)
+        .plan_id(1)
+        .amount(1_000_000)
+        .period_hours(720)
+        .destinations(vec![dest])
+        .sponsor(&sponsor)
+        .execute();
+    res.assert_ok();
+
+    let account = litesvm.get_account(&plan_pda).unwrap();
+    let rent = account.lamports;
+    let owner = Plan::load(&account.data).unwrap().owner;
+    let merchant_after = litesvm.get_account(&merchant.pubkey()).unwrap().lamports;
+    let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    assert_eq!(merchant_after, merchant_before, "merchant must pay nothing for a sponsored create");
+    assert!(sponsor_before - sponsor_after >= rent, "sponsor must fund the plan rent");
+    assert_eq!(owner.to_bytes(), merchant.pubkey().to_bytes(), "merchant still owns the sponsored plan");
 }
 
 #[test]

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -907,6 +907,7 @@ pub struct CreatePlan<'a> {
     destinations_vec: Vec<Pubkey>,
     pullers_vec: Vec<Pubkey>,
     custom_pda: Option<Pubkey>,
+    sponsor: Option<&'a Keypair>,
 }
 
 impl<'a> CreatePlan<'a> {
@@ -927,7 +928,13 @@ impl<'a> CreatePlan<'a> {
             destinations_vec: vec![],
             pullers_vec: vec![],
             custom_pda: None,
+            sponsor: None,
         }
+    }
+
+    pub fn sponsor(mut self, sponsor: &'a Keypair) -> Self {
+        self.sponsor = Some(sponsor);
+        self
     }
 
     pub fn plan_id(mut self, plan_id: u64) -> Self {
@@ -1004,7 +1011,7 @@ impl<'a> CreatePlan<'a> {
             .map(|a| a.owner)
             .unwrap_or(crate::tests::constants::TOKEN_PROGRAM_ID);
 
-        let accounts = vec![
+        let mut accounts = vec![
             AccountMeta::new(self.owner.pubkey(), true),
             AccountMeta::new(plan_pda, false),
             AccountMeta::new_readonly(mint_pubkey, false),
@@ -1012,9 +1019,17 @@ impl<'a> CreatePlan<'a> {
             AccountMeta::new_readonly(token_program, false),
         ];
 
+        let mut signers = vec![self.owner];
+        let mut fee_payer = self.owner.pubkey();
+        if let Some(sponsor) = self.sponsor {
+            accounts.push(AccountMeta::new(sponsor.pubkey(), true));
+            signers.push(sponsor);
+            fee_payer = sponsor.pubkey();
+        }
+
         let ix = Instruction { program_id: PROGRAM_ID, accounts, data };
 
-        (build_and_send_transaction(self.litesvm, &[self.owner], &self.owner.pubkey(), &ix), plan_pda)
+        (build_and_send_transaction(self.litesvm, &signers, &fee_payer, &ix), plan_pda)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add an optional trailing `payer` account to `create_plan`; when present it funds plan rent (gasless create) while the merchant remains the plan owner. Mirrors the existing sponsor pattern (`resolve_optional_payer`) used by `init_subscription_authority`, `subscribe`, and the delegation creators.
- Wire the optional `payer` through the TS SDK (`CreatePlanInput`, `appendPayer`, plugin passthrough).
- Document the security invariant: sponsored rent is **not** recoverable by the payer (`delete_plan` refunds the owner), so sponsorship must be gated off-chain to avoid a rent-siphon via create/delete cycles.

## Test Plan
- `just unit-test` → 48 passed
- `just integration-test` → 222 passed, incl. new `create_plan_gasless_sponsor_funds_rent` (asserts merchant pays nothing, sponsor funds rent, merchant still owns the plan)
- `tsc --noEmit` on the TS client → clean
- IDL + Rust client regenerate with no drift (optional payer is a hand-SDK trailing account, not in the IDL — matches `init_subscription_authority`)

## Breaking Changes
- None. No `Plan` account-layout change; existing plans and existing callers (no trailing account → merchant funds rent) are unaffected.