### PR TITLE
chore(release): bump clients to v0.4.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,7 +5432,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 dependencies = [
  "borsh",
  "num-derive",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.4.0-rc.1"
+version = "0.4.0-rc.2"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/subscriptions",
-    "version": "0.4.0-rc.1",
+    "version": "0.4.0-rc.2",
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `subscriptions` (Rust client) and `@solana/subscriptions` (TS client) from `0.4.0-rc.1` → `0.4.0-rc.2` in `clients/rust/Cargo.toml`, `clients/typescript/package.json`, and `Cargo.lock`.
- Prepares the rc.2 release candidate; no code/API changes.

## Release steps (after merge)
- Dispatch **Publish Rust Client** and **Publish TypeScript Client** workflows from `main` — they read the bumped versions, publish to crates.io/npm, and create the `rust-client-v0.4.0-rc.2` / `ts-client-v0.4.0-rc.2` tags + GitHub Releases.

## Notes
- CHANGELOGs left unchanged: their `[Unreleased]` "rc.1 published" note remains accurate until rc.2 actually publishes.