### PR TITLE
feat: co-init transaction introspection for 1-step signup

### DIFF
--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -50,3 +50,11 @@ export const METADATA_URI_LEN = 128;
 
 /** On-chain delegation variant identifier (matches the `kind` tag in the `Delegation` union). */
 export type DelegationKindId = 'fixed' | 'recurring' | 'subscription';
+
+/**
+ * Sentinel `expectedSubscriptionAuthorityInitId` that opts a subscribe or
+ * delegation-creation instruction into same-transaction co-init detection.
+ * Pass this when the SubscriptionAuthority is initialized in the same transaction
+ * (1-step signup); the program then verifies co-init instead of matching `initId`.
+ */
+export const UNKNOWN_INIT_ID = -9223372036854775808n;

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -2108,6 +2108,19 @@
             "name": "systemProgram"
           },
           {
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111"
+            },
+            "docs": [
+              "Instructions sysvar for same-transaction co-init detection"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar"
+          },
+          {
             "docs": [
               "Optional sponsor that funds the account rent. Defaults to the delegator/signer when omitted."
             ],
@@ -2203,6 +2216,19 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "systemProgram"
+          },
+          {
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111"
+            },
+            "docs": [
+              "Instructions sysvar for same-transaction co-init detection"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar"
           },
           {
             "docs": [
@@ -3090,6 +3116,19 @@
             "isWritable": false,
             "kind": "instructionAccountNode",
             "name": "selfProgram"
+          },
+          {
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111"
+            },
+            "docs": [
+              "Instructions sysvar for same-transaction co-init detection"
+            ],
+            "isSigner": false,
+            "isWritable": false,
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar"
           },
           {
             "docs": [

--- a/program/src/constants.rs
+++ b/program/src/constants.rs
@@ -50,3 +50,8 @@ pub const MINT_IS_INITIALIZED_OFFSET: usize = 45;
 
 /// Number of seconds in one hour. Used to convert plan/subscription period (hours) to seconds.
 pub const SECS_PER_HOUR: u64 = 3600;
+
+/// Sentinel `expected_subscription_authority_init_id` that opts a `Subscribe` or
+/// delegation-creation instruction into same-transaction co-init detection.
+/// A real `init_id` is `Clock::slot` (always non-negative), so this never collides.
+pub const UNKNOWN_INIT_ID: i64 = i64::MIN;

--- a/program/src/instructions/helpers/delegation.rs
+++ b/program/src/instructions/helpers/delegation.rs
@@ -1,9 +1,10 @@
 use pinocchio::{cpi::Seed, error::ProgramError, AccountView, Address};
 
 use crate::{
-    helpers::system::resolve_optional_payer, state::common::find_delegation_pda, AccountCheck, Header, ProgramAccount,
-    ProgramAccountInit, SignerAccount, SubscriptionAuthority, SubscriptionAuthorityAccount, SubscriptionsError,
-    SystemAccount, WritableAccount, DELEGATE_BASE_SEED,
+    helpers::system::resolve_optional_payer, state::common::find_delegation_pda, subscription_authority_inited_in_tx,
+    AccountCheck, Header, ProgramAccount, ProgramAccountInit, SignerAccount, SubscriptionAuthority,
+    SubscriptionAuthorityAccount, SubscriptionsError, SystemAccount, WritableAccount, DELEGATE_BASE_SEED,
+    UNKNOWN_INIT_ID,
 };
 
 /// Validated accounts shared by `CreateFixedDelegation` and `CreateRecurringDelegation`.
@@ -18,6 +19,8 @@ pub struct CreateDelegationAccounts<'a> {
     pub delegatee: &'a AccountView,
     /// System program (for CPI account creation).
     pub system_program: &'a AccountView,
+    /// Instructions sysvar, used for same-transaction co-init detection.
+    pub instructions_sysvar: &'a AccountView,
     /// The account funding rent. Defaults to `delegator` if no extra account is provided.
     pub payer: &'a AccountView,
 }
@@ -26,7 +29,8 @@ impl<'a> TryFrom<&'a mut [AccountView]> for CreateDelegationAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a mut [AccountView]) -> Result<Self, Self::Error> {
-        let [delegator, subscription_authority, delegation_account, delegatee, system_program, rem @ ..] = accounts
+        let [delegator, subscription_authority, delegation_account, delegatee, system_program, instructions_sysvar, rem @ ..] =
+            accounts
         else {
             return Err(SubscriptionsError::NotEnoughAccountKeys.into());
         };
@@ -39,7 +43,15 @@ impl<'a> TryFrom<&'a mut [AccountView]> for CreateDelegationAccounts<'a> {
 
         let payer = resolve_optional_payer(delegator, rem)?;
 
-        Ok(Self { delegator, subscription_authority, delegation_account, delegatee, system_program, payer })
+        Ok(Self {
+            delegator,
+            subscription_authority,
+            delegation_account,
+            delegatee,
+            system_program,
+            instructions_sysvar,
+            payer,
+        })
     }
 }
 
@@ -63,9 +75,19 @@ pub fn create_delegation_account(
         let md_data = accounts.subscription_authority.try_borrow()?;
         let subscription_authority = SubscriptionAuthority::load(&md_data)?;
         subscription_authority.check_owner(accounts.delegator.address())?;
-        if subscription_authority.init_id != expected_subscription_authority_init_id {
+
+        if expected_subscription_authority_init_id == UNKNOWN_INIT_ID {
+            if !subscription_authority_inited_in_tx(
+                accounts.instructions_sysvar,
+                accounts.subscription_authority.address(),
+                accounts.delegator.address(),
+            )? {
+                return Err(SubscriptionsError::StaleSubscriptionAuthority.into());
+            }
+        } else if subscription_authority.init_id != expected_subscription_authority_init_id {
             return Err(SubscriptionsError::StaleSubscriptionAuthority.into());
         }
+
         init_id = subscription_authority.init_id;
         mint = subscription_authority.token_mint;
     }

--- a/program/src/instructions/helpers/introspection.rs
+++ b/program/src/instructions/helpers/introspection.rs
@@ -1,0 +1,39 @@
+use pinocchio::{error::ProgramError, sysvars::instructions::Instructions, AccountView, Address};
+
+const INIT_AUTHORITY_DISCRIMINATOR: u8 = 0;
+const INIT_OWNER_ACCOUNT_INDEX: usize = 0;
+const INIT_AUTHORITY_ACCOUNT_INDEX: usize = 1;
+
+/// Returns `true` when an `InitSubscriptionAuthority` instruction earlier in the
+/// current transaction creates `authority_pda` for `expected_owner`.
+///
+/// Reads only top-level instructions: a call reached via CPI sees no sibling
+/// init and the caller falls back to the stored-`init_id` check.
+pub fn subscription_authority_inited_in_tx(
+    instructions_sysvar: &AccountView,
+    authority_pda: &Address,
+    expected_owner: &Address,
+) -> Result<bool, ProgramError> {
+    let instructions = Instructions::try_from(instructions_sysvar)?;
+    let current_index = instructions.load_current_index();
+
+    for index in 0..current_index {
+        let instruction = instructions.load_instruction_at(index as usize)?;
+
+        if instruction.get_program_id() != &crate::ID {
+            continue;
+        }
+        if instruction.get_instruction_data().first() != Some(&INIT_AUTHORITY_DISCRIMINATOR) {
+            continue;
+        }
+
+        let authority = instruction.get_instruction_account_at(INIT_AUTHORITY_ACCOUNT_INDEX)?;
+        let owner = instruction.get_instruction_account_at(INIT_OWNER_ACCOUNT_INDEX)?;
+
+        if &authority.key == authority_pda && &owner.key == expected_owner {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/program/src/instructions/helpers/introspection.rs
+++ b/program/src/instructions/helpers/introspection.rs
@@ -1,6 +1,8 @@
 use pinocchio::{error::ProgramError, sysvars::instructions::Instructions, AccountView, Address};
 
-const INIT_AUTHORITY_DISCRIMINATOR: u8 = 0;
+use crate::instructions::initialize_subscription_authority;
+
+const INIT_AUTHORITY_DISCRIMINATOR: u8 = *initialize_subscription_authority::DISCRIMINATOR;
 const INIT_OWNER_ACCOUNT_INDEX: usize = 0;
 const INIT_AUTHORITY_ACCOUNT_INDEX: usize = 1;
 
@@ -14,6 +16,7 @@ pub fn subscription_authority_inited_in_tx(
     authority_pda: &Address,
     expected_owner: &Address,
 ) -> Result<bool, ProgramError> {
+    // `try_from` verifies the account is the instructions sysvar.
     let instructions = Instructions::try_from(instructions_sysvar)?;
     let current_index = instructions.load_current_index();
 

--- a/program/src/instructions/helpers/mod.rs
+++ b/program/src/instructions/helpers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod authority;
 pub mod delegation;
+pub mod introspection;
 mod plan;
 pub mod program;
 pub mod system;
@@ -14,6 +15,7 @@ pub mod transfer_validation;
 
 pub use authority::*;
 pub use delegation::*;
+pub use introspection::*;
 pub use plan::{create_plan_account, CreatePlanAccounts};
 pub use program::*;
 pub use system::*;

--- a/program/src/instructions/mod.rs
+++ b/program/src/instructions/mod.rs
@@ -86,6 +86,11 @@ pub enum SubscriptionsInstruction {
         default_value = program("system")
     ))]
     #[codama(account(
+        name = "instructions_sysvar",
+        docs = "Instructions sysvar for same-transaction co-init detection",
+        default_value = public_key("Sysvar1nstructions1111111111111111111111111")
+    ))]
+    #[codama(account(
         name = "payer",
         signer,
         writable,
@@ -103,6 +108,11 @@ pub enum SubscriptionsInstruction {
         name = "system_program",
         docs = "The system program",
         default_value = program("system")
+    ))]
+    #[codama(account(
+        name = "instructions_sysvar",
+        docs = "Instructions sysvar for same-transaction co-init detection",
+        default_value = public_key("Sysvar1nstructions1111111111111111111111111")
     ))]
     #[codama(account(
         name = "payer",
@@ -262,6 +272,11 @@ pub enum SubscriptionsInstruction {
         name = "self_program",
         docs = "This program (for self-CPI)",
         default_value = public_key("De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44")
+    ))]
+    #[codama(account(
+        name = "instructions_sysvar",
+        docs = "Instructions sysvar for same-transaction co-init detection",
+        default_value = public_key("Sysvar1nstructions1111111111111111111111111")
     ))]
     #[codama(account(
         name = "payer",

--- a/program/src/instructions/subscribe.rs
+++ b/program/src/instructions/subscribe.rs
@@ -20,8 +20,8 @@ use crate::{
         subscription_authority::SubscriptionAuthority,
         subscription_delegation::SubscriptionDelegation,
     },
-    verify_plan_pda, AccountCheck, ProgramAccount, ProgramAccountInit, SignerAccount, SubscriptionAuthorityAccount,
-    SubscriptionsError, SystemAccount, WritableAccount,
+    subscription_authority_inited_in_tx, verify_plan_pda, AccountCheck, ProgramAccount, ProgramAccountInit,
+    SignerAccount, SubscriptionAuthorityAccount, SubscriptionsError, SystemAccount, WritableAccount, UNKNOWN_INIT_ID,
 };
 
 /// Instruction discriminator byte for `Subscribe`.
@@ -116,7 +116,15 @@ pub fn process(accounts: &mut [AccountView], data: &SubscribeData) -> ProgramRes
         if subscription_authority.token_mint != plan_mint {
             return Err(SubscriptionsError::MintMismatch.into());
         }
-        if subscription_authority.init_id != data.expected_subscription_authority_init_id {
+        if data.expected_subscription_authority_init_id == UNKNOWN_INIT_ID {
+            if !subscription_authority_inited_in_tx(
+                accounts_struct.instructions_sysvar,
+                accounts_struct.subscription_authority_pda.address(),
+                accounts_struct.subscriber.address(),
+            )? {
+                return Err(SubscriptionsError::StaleSubscriptionAuthority.into());
+            }
+        } else if subscription_authority.init_id != data.expected_subscription_authority_init_id {
             return Err(SubscriptionsError::StaleSubscriptionAuthority.into());
         }
         init_id = subscription_authority.init_id;
@@ -198,6 +206,8 @@ pub struct SubscribeAccounts<'a> {
     pub system_program: &'a AccountView,
     pub event_authority: &'a AccountView,
     pub self_program: &'a AccountView,
+    /// Instructions sysvar, used for same-transaction co-init detection.
+    pub instructions_sysvar: &'a AccountView,
     /// The account funding rent. Defaults to `subscriber` if no extra account is provided.
     pub payer: &'a AccountView,
 }
@@ -206,7 +216,7 @@ impl<'a> TryFrom<&'a mut [AccountView]> for SubscribeAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a mut [AccountView]) -> Result<Self, Self::Error> {
-        let [subscriber, merchant, plan_pda, subscription_pda, subscription_authority_pda, system_program, event_authority, self_program, rem @ ..] =
+        let [subscriber, merchant, plan_pda, subscription_pda, subscription_authority_pda, system_program, event_authority, self_program, instructions_sysvar, rem @ ..] =
             accounts
         else {
             return Err(SubscriptionsError::NotEnoughAccountKeys.into());
@@ -230,6 +240,7 @@ impl<'a> TryFrom<&'a mut [AccountView]> for SubscribeAccounts<'a> {
             system_program,
             event_authority,
             self_program,
+            instructions_sysvar,
             payer,
         })
     }

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -15,6 +15,8 @@ mod test_cancel_subscription;
 #[cfg(test)]
 mod test_close_subscription_authority;
 #[cfg(test)]
+mod test_co_init_introspection;
+#[cfg(test)]
 mod test_create_fixed_delegation;
 #[cfg(test)]
 mod test_create_plan;

--- a/tests/integration-tests/src/test_co_init_introspection.rs
+++ b/tests/integration-tests/src/test_co_init_introspection.rs
@@ -1,14 +1,13 @@
 use crate::{
-    instructions::{
-        create_fixed_delegation, create_recurring_delegation, initialize_subscription_authority, subscribe,
-    },
+    event_engine::event_authority_pda,
+    instructions::{create_fixed_delegation, create_recurring_delegation, subscribe},
     state::{FixedDelegation, Plan, RecurringDelegation, SubscriptionAuthority, SubscriptionDelegation},
     tests::{
         asserts::TransactionResultExt,
         constants::{INSTRUCTIONS_SYSVAR_ID, MINT_DECIMALS, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID},
         pda::{get_delegation_pda, get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
         utils::{
-            build_and_send_transaction_multi, current_ts, days, init_ata, init_mint,
+            build_and_send_transaction_multi, current_ts, days, init_ata, init_authority_ix, init_mint, init_wallet,
             initialize_subscription_authority_action, setup, CreatePlan,
         },
     },
@@ -19,21 +18,6 @@ use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
-
-fn init_authority_ix(user: &Pubkey, mint: Pubkey, user_ata: Pubkey, authority_pda: Pubkey) -> Instruction {
-    Instruction {
-        program_id: PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new(*user, true),
-            AccountMeta::new(authority_pda, false),
-            AccountMeta::new_readonly(mint, false),
-            AccountMeta::new(user_ata, false),
-            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
-            AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
-        ],
-        data: vec![*initialize_subscription_authority::DISCRIMINATOR],
-    }
-}
 
 #[allow(clippy::too_many_arguments)]
 fn subscribe_ix(
@@ -47,7 +31,7 @@ fn subscribe_ix(
     plan: &Plan,
     init_id: i64,
 ) -> Instruction {
-    let event_authority = Pubkey::new_from_array(crate::event_engine::event_authority_pda::ID.to_bytes());
+    let event_authority = Pubkey::new_from_array(event_authority_pda::ID.to_bytes());
     let expected_mint = plan.data.mint;
     let expected_amount = plan.data.terms.amount;
     let expected_period_hours = plan.data.terms.period_hours;
@@ -286,4 +270,32 @@ fn co_init_for_different_mint_does_not_satisfy_subscribe() {
 
     build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, sub_ix])
         .assert_err_at(1, SubscriptionsError::StaleSubscriptionAuthority);
+}
+
+#[test]
+fn co_init_by_different_user_rejected() {
+    let (mut litesvm, alice, merchant, mint, alice_ata, plan_pda, plan_bump) = setup_plan();
+    let bob = init_wallet(&mut litesvm, 10_000_000_000);
+
+    let (alice_authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let (bob_subscription_pda, _) = get_subscription_pda(&plan_pda, &bob.pubkey());
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let plan = Plan::load(&plan_account.data).unwrap();
+
+    let init_ix = init_authority_ix(&alice.pubkey(), mint, alice_ata, alice_authority_pda);
+    let sub_ix = subscribe_ix(
+        &bob.pubkey(),
+        &merchant.pubkey(),
+        plan_pda,
+        bob_subscription_pda,
+        alice_authority_pda,
+        1,
+        plan_bump,
+        plan,
+        UNKNOWN_INIT_ID,
+    );
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice, &bob], &alice.pubkey(), &[init_ix, sub_ix])
+        .assert_err_at(1, SubscriptionsError::Unauthorized);
 }

--- a/tests/integration-tests/src/test_co_init_introspection.rs
+++ b/tests/integration-tests/src/test_co_init_introspection.rs
@@ -1,0 +1,289 @@
+use crate::{
+    instructions::{
+        create_fixed_delegation, create_recurring_delegation, initialize_subscription_authority, subscribe,
+    },
+    state::{FixedDelegation, Plan, RecurringDelegation, SubscriptionAuthority, SubscriptionDelegation},
+    tests::{
+        asserts::TransactionResultExt,
+        constants::{INSTRUCTIONS_SYSVAR_ID, MINT_DECIMALS, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID},
+        pda::{get_delegation_pda, get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
+        utils::{
+            build_and_send_transaction_multi, current_ts, days, init_ata, init_mint,
+            initialize_subscription_authority_action, setup, CreatePlan,
+        },
+    },
+    SubscriptionsError, UNKNOWN_INIT_ID,
+};
+use litesvm::LiteSVM;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+
+fn init_authority_ix(user: &Pubkey, mint: Pubkey, user_ata: Pubkey, authority_pda: Pubkey) -> Instruction {
+    Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*user, true),
+            AccountMeta::new(authority_pda, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(user_ata, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
+        ],
+        data: vec![*initialize_subscription_authority::DISCRIMINATOR],
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn subscribe_ix(
+    subscriber: &Pubkey,
+    merchant: &Pubkey,
+    plan_pda: Pubkey,
+    subscription_pda: Pubkey,
+    authority_pda: Pubkey,
+    plan_id: u64,
+    plan_bump: u8,
+    plan: &Plan,
+    init_id: i64,
+) -> Instruction {
+    let event_authority = Pubkey::new_from_array(crate::event_engine::event_authority_pda::ID.to_bytes());
+    let expected_mint = plan.data.mint;
+    let expected_amount = plan.data.terms.amount;
+    let expected_period_hours = plan.data.terms.period_hours;
+    let expected_created_at = plan.data.terms.created_at;
+
+    let accounts = vec![
+        AccountMeta::new(*subscriber, true),
+        AccountMeta::new_readonly(*merchant, false),
+        AccountMeta::new_readonly(plan_pda, false),
+        AccountMeta::new(subscription_pda, false),
+        AccountMeta::new_readonly(authority_pda, false),
+        AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        AccountMeta::new_readonly(event_authority, false),
+        AccountMeta::new_readonly(PROGRAM_ID, false),
+        AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
+    ];
+
+    let data = [
+        vec![*subscribe::DISCRIMINATOR],
+        plan_id.to_le_bytes().to_vec(),
+        vec![plan_bump],
+        expected_mint.as_ref().to_vec(),
+        expected_amount.to_le_bytes().to_vec(),
+        expected_period_hours.to_le_bytes().to_vec(),
+        expected_created_at.to_le_bytes().to_vec(),
+        init_id.to_le_bytes().to_vec(),
+    ]
+    .concat();
+
+    Instruction { program_id: PROGRAM_ID, accounts, data }
+}
+
+fn delegation_accounts(
+    delegator: &Pubkey,
+    authority_pda: Pubkey,
+    delegation_pda: Pubkey,
+    delegatee: Pubkey,
+) -> Vec<AccountMeta> {
+    vec![
+        AccountMeta::new(*delegator, true),
+        AccountMeta::new(authority_pda, false),
+        AccountMeta::new(delegation_pda, false),
+        AccountMeta::new_readonly(delegatee, false),
+        AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
+    ]
+}
+
+fn setup_plan() -> (LiteSVM, Keypair, Keypair, Pubkey, Pubkey, Pubkey, u8) {
+    let (mut litesvm, alice) = setup();
+    let merchant = Keypair::new();
+    litesvm.airdrop(&merchant.pubkey(), 10_000_000_000).unwrap();
+
+    let mint = init_mint(&mut litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(alice.pubkey()), &[]);
+    let alice_ata = init_ata(&mut litesvm, mint, alice.pubkey(), 100_000_000);
+
+    let end_ts = current_ts() + days(30) as i64;
+    let (res, plan_pda) = CreatePlan::new(&mut litesvm, &merchant, mint)
+        .plan_id(1)
+        .amount(50_000_000)
+        .period_hours(1)
+        .end_ts(end_ts)
+        .execute();
+    res.assert_ok();
+    let (_, plan_bump) = get_plan_pda(&merchant.pubkey(), 1);
+
+    (litesvm, alice, merchant, mint, alice_ata, plan_pda, plan_bump)
+}
+
+#[test]
+fn co_init_then_subscribe_succeeds() {
+    let (mut litesvm, alice, merchant, mint, alice_ata, plan_pda, plan_bump) = setup_plan();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+
+    assert!(litesvm.get_account(&authority_pda).map(|a| a.data.is_empty()).unwrap_or(true));
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let plan = Plan::load(&plan_account.data).unwrap();
+    let init_ix = init_authority_ix(&alice.pubkey(), mint, alice_ata, authority_pda);
+    let sub_ix = subscribe_ix(
+        &alice.pubkey(),
+        &merchant.pubkey(),
+        plan_pda,
+        subscription_pda,
+        authority_pda,
+        1,
+        plan_bump,
+        plan,
+        UNKNOWN_INIT_ID,
+    );
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, sub_ix]).assert_ok();
+
+    let authority_account = litesvm.get_account(&authority_pda).unwrap();
+    let live_init_id = SubscriptionAuthority::load(&authority_account.data).unwrap().init_id;
+    let sub_account = litesvm.get_account(&subscription_pda).unwrap();
+    let sub = SubscriptionDelegation::load(&sub_account.data).unwrap();
+    let stored_init_id = sub.header.init_id;
+    assert_eq!(stored_init_id, live_init_id);
+}
+
+#[test]
+fn co_init_then_fixed_delegation_succeeds() {
+    let (mut litesvm, alice, _merchant, mint, alice_ata, _plan_pda, _plan_bump) = setup_plan();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let delegatee = Pubkey::new_unique();
+    let (delegation_pda, _) = get_delegation_pda(&authority_pda, &alice.pubkey(), &delegatee, 0);
+
+    let init_ix = init_authority_ix(&alice.pubkey(), mint, alice_ata, authority_pda);
+    let data = [
+        vec![*create_fixed_delegation::DISCRIMINATOR],
+        0u64.to_le_bytes().to_vec(),
+        1_000u64.to_le_bytes().to_vec(),
+        (current_ts() + days(1) as i64).to_le_bytes().to_vec(),
+        UNKNOWN_INIT_ID.to_le_bytes().to_vec(),
+    ]
+    .concat();
+    let del_ix = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: delegation_accounts(&alice.pubkey(), authority_pda, delegation_pda, delegatee),
+        data,
+    };
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, del_ix]).assert_ok();
+
+    let account = litesvm.get_account(&delegation_pda).unwrap();
+    assert_eq!(account.data.len(), FixedDelegation::LEN);
+}
+
+#[test]
+fn co_init_then_recurring_delegation_succeeds() {
+    let (mut litesvm, alice, _merchant, mint, alice_ata, _plan_pda, _plan_bump) = setup_plan();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let delegatee = Pubkey::new_unique();
+    let (delegation_pda, _) = get_delegation_pda(&authority_pda, &alice.pubkey(), &delegatee, 0);
+
+    let init_ix = init_authority_ix(&alice.pubkey(), mint, alice_ata, authority_pda);
+    let data = [
+        vec![*create_recurring_delegation::DISCRIMINATOR],
+        0u64.to_le_bytes().to_vec(),
+        1_000u64.to_le_bytes().to_vec(),
+        3_600u64.to_le_bytes().to_vec(),
+        0i64.to_le_bytes().to_vec(),
+        (current_ts() + days(30) as i64).to_le_bytes().to_vec(),
+        UNKNOWN_INIT_ID.to_le_bytes().to_vec(),
+    ]
+    .concat();
+    let del_ix = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: delegation_accounts(&alice.pubkey(), authority_pda, delegation_pda, delegatee),
+        data,
+    };
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, del_ix]).assert_ok();
+
+    let account = litesvm.get_account(&delegation_pda).unwrap();
+    assert_eq!(account.data.len(), RecurringDelegation::LEN);
+}
+
+#[test]
+fn idempotent_co_init_then_subscribe_succeeds() {
+    let (mut litesvm, alice, merchant, mint, alice_ata, plan_pda, plan_bump) = setup_plan();
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let plan = Plan::load(&plan_account.data).unwrap();
+    let init_ix = init_authority_ix(&alice.pubkey(), mint, alice_ata, authority_pda);
+    let sub_ix = subscribe_ix(
+        &alice.pubkey(),
+        &merchant.pubkey(),
+        plan_pda,
+        subscription_pda,
+        authority_pda,
+        1,
+        plan_bump,
+        plan,
+        UNKNOWN_INIT_ID,
+    );
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, sub_ix]).assert_ok();
+}
+
+#[test]
+fn sentinel_without_co_init_rejected() {
+    let (mut litesvm, alice, merchant, mint, _alice_ata, plan_pda, plan_bump) = setup_plan();
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let plan = Plan::load(&plan_account.data).unwrap();
+    let sub_ix = subscribe_ix(
+        &alice.pubkey(),
+        &merchant.pubkey(),
+        plan_pda,
+        subscription_pda,
+        authority_pda,
+        1,
+        plan_bump,
+        plan,
+        UNKNOWN_INIT_ID,
+    );
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[sub_ix])
+        .assert_err(SubscriptionsError::StaleSubscriptionAuthority);
+}
+
+#[test]
+fn co_init_for_different_mint_does_not_satisfy_subscribe() {
+    let (mut litesvm, alice, merchant, mint, _alice_ata, plan_pda, plan_bump) = setup_plan();
+    initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let (authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &mint);
+    let (subscription_pda, _) = get_subscription_pda(&plan_pda, &alice.pubkey());
+
+    let other_mint = init_mint(&mut litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(alice.pubkey()), &[]);
+    let other_ata = init_ata(&mut litesvm, other_mint, alice.pubkey(), 100_000_000);
+    let (other_authority_pda, _) = get_subscription_authority_pda(&alice.pubkey(), &other_mint);
+
+    let plan_account = litesvm.get_account(&plan_pda).unwrap();
+    let plan = Plan::load(&plan_account.data).unwrap();
+    let init_ix = init_authority_ix(&alice.pubkey(), other_mint, other_ata, other_authority_pda);
+    let sub_ix = subscribe_ix(
+        &alice.pubkey(),
+        &merchant.pubkey(),
+        plan_pda,
+        subscription_pda,
+        authority_pda,
+        1,
+        plan_bump,
+        plan,
+        UNKNOWN_INIT_ID,
+    );
+
+    build_and_send_transaction_multi(&mut litesvm, &[&alice], &alice.pubkey(), &[init_ix, sub_ix])
+        .assert_err_at(1, SubscriptionsError::StaleSubscriptionAuthority);
+}

--- a/tests/integration-tests/src/test_create_fixed_delegation.rs
+++ b/tests/integration-tests/src/test_create_fixed_delegation.rs
@@ -322,6 +322,7 @@ fn writable_accounts_must_be_writable() {
             AccountMeta::new(delegation_pda, false),
             AccountMeta::new_readonly(delegatee, false),
             AccountMeta::new_readonly(crate::tests::constants::SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(crate::tests::constants::INSTRUCTIONS_SYSVAR_ID, false),
         ];
 
         // Flip writable account to readonly, preserving signer flag
@@ -385,6 +386,7 @@ fn signer_accounts_must_be_signers() {
             AccountMeta::new(delegation_pda, false),
             AccountMeta::new_readonly(delegatee, false),
             AccountMeta::new_readonly(crate::tests::constants::SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(crate::tests::constants::INSTRUCTIONS_SYSVAR_ID, false),
         ];
 
         // Flip signer to non-signer, preserving writable flag

--- a/tests/integration-tests/src/test_subscribe.rs
+++ b/tests/integration-tests/src/test_subscribe.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{Plan, PlanStatus, SubscriptionAuthority, SubscriptionDelegation},
     tests::{
         asserts::TransactionResultExt,
-        constants::{MINT_DECIMALS, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID},
+        constants::{INSTRUCTIONS_SYSVAR_ID, MINT_DECIMALS, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID},
         pda::{get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
         utils::{
             build_and_send_transaction, current_ts, days, init_ata, init_mint, init_wallet,
@@ -220,6 +220,7 @@ fn subscribe_rejects_stale_subscription_authority_generation() {
         AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
         AccountMeta::new_readonly(event_authority, false),
         AccountMeta::new_readonly(PROGRAM_ID, false),
+        AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
     ];
 
     let data = [
@@ -270,6 +271,7 @@ fn subscribe_rejects_stale_expected_terms() {
         AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
         AccountMeta::new_readonly(event_authority, false),
         AccountMeta::new_readonly(PROGRAM_ID, false),
+        AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
     ];
 
     let data = [

--- a/tests/integration-tests/src/utils/asserts.rs
+++ b/tests/integration-tests/src/utils/asserts.rs
@@ -12,6 +12,9 @@ pub trait TransactionResultExt {
 
     /// Assert transaction failed with the expected error
     fn assert_err(self, expected: SubscriptionsError);
+
+    /// Assert transaction failed with the expected error at the given instruction index.
+    fn assert_err_at(self, ix_index: u8, expected: SubscriptionsError);
 }
 
 impl TransactionResultExt for TransactionResult {
@@ -40,6 +43,27 @@ impl TransactionResultExt for TransactionResult {
                         "Expected: {:?}:{} \nGot: {}\n\nLogs:\n{}",
                         expected,
                         expected,
+                        actual_msg,
+                        failed_tx.meta.logs.join("\n")
+                    );
+                }
+            }
+        }
+    }
+
+    fn assert_err_at(self, ix_index: u8, expected: SubscriptionsError) {
+        match self {
+            Ok(_) => panic!("Expected transaction to fail with {:?} ({})", expected, expected),
+            Err(failed_tx) => {
+                let expected_err =
+                    TransactionError::InstructionError(ix_index, InstructionError::Custom(expected as u32));
+                if failed_tx.err != expected_err {
+                    let actual_msg = format_error(&failed_tx);
+                    panic!(
+                        "Expected: {:?}:{} at ix {} \nGot: {}\n\nLogs:\n{}",
+                        expected,
+                        expected,
+                        ix_index,
                         actual_msg,
                         failed_tx.meta.logs.join("\n")
                     );

--- a/tests/integration-tests/src/utils/constants.rs
+++ b/tests/integration-tests/src/utils/constants.rs
@@ -7,4 +7,6 @@ pub static ASSOCIATED_TOKEN_PROGRAM_ID: Pubkey =
     Pubkey::new_from_array(pinocchio_associated_token_account::ID.to_bytes());
 
 pub static PROGRAM_ID: Pubkey = Pubkey::new_from_array(crate::ID.to_bytes());
+pub static INSTRUCTIONS_SYSVAR_ID: Pubkey =
+    Pubkey::new_from_array(pinocchio::sysvars::instructions::INSTRUCTIONS_ID.to_bytes());
 pub const MINT_DECIMALS: u8 = 6;

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -46,8 +46,9 @@ use crate::{
         subscribe, transfer_fixed_delegation, transfer_recurring_delegation, transfer_subscription, update_plan,
     },
     state::common::PlanStatus,
+    state::{Plan, SubscriptionAuthority},
     tests::{
-        constants::{INSTRUCTIONS_SYSVAR_ID, PROGRAM_ID, SYSTEM_PROGRAM_ID},
+        constants::{INSTRUCTIONS_SYSVAR_ID, PROGRAM_ID, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID},
         cu_tracker::{is_tracking_enabled, record_cu},
         pda::{get_delegation_pda, get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
     },
@@ -387,6 +388,23 @@ fn init_token_account_at(
     token_account
 }
 
+/// Builds an `InitSubscriptionAuthority` instruction (without sending) for composing
+/// multi-instruction transactions such as co-init + subscribe.
+pub fn init_authority_ix(user: &Pubkey, mint: Pubkey, user_ata: Pubkey, authority_pda: Pubkey) -> Instruction {
+    Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*user, true),
+            AccountMeta::new(authority_pda, false),
+            AccountMeta::new_readonly(mint, false),
+            AccountMeta::new(user_ata, false),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(TOKEN_PROGRAM_ID, false),
+        ],
+        data: vec![*initialize_subscription_authority::DISCRIMINATOR],
+    }
+}
+
 pub fn initialize_subscription_authority_action(
     litesvm: &mut LiteSVM,
     payer: &Keypair,
@@ -479,9 +497,7 @@ impl<'a> CreateDelegation<'a> {
             let (subscription_authority_pda, _) = get_subscription_authority_pda(&self.delegator.pubkey(), &self.mint);
             self.litesvm
                 .get_account(&subscription_authority_pda)
-                .and_then(|account| {
-                    crate::state::SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id)
-                })
+                .and_then(|account| SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id))
                 .unwrap_or_default()
         })
     }
@@ -1387,7 +1403,7 @@ impl<'a> Subscribe<'a> {
 
         // Snapshot live plan terms to bind subscriber consent.
         let plan_account = self.litesvm.get_account(&self.plan_pda).unwrap();
-        let plan = crate::state::Plan::load(&plan_account.data).unwrap();
+        let plan = Plan::load(&plan_account.data).unwrap();
         let expected_amount = plan.data.terms.amount;
         let expected_period_hours = plan.data.terms.period_hours;
         let expected_created_at = plan.data.terms.created_at;
@@ -1395,9 +1411,7 @@ impl<'a> Subscribe<'a> {
         let expected_subscription_authority_init_id = self.expected_init_id.unwrap_or_else(|| {
             self.litesvm
                 .get_account(&subscription_authority_pda)
-                .and_then(|account| {
-                    crate::state::SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id)
-                })
+                .and_then(|account| SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id))
                 .unwrap_or_default()
         });
 

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -47,7 +47,7 @@ use crate::{
     },
     state::common::PlanStatus,
     tests::{
-        constants::{PROGRAM_ID, SYSTEM_PROGRAM_ID},
+        constants::{INSTRUCTIONS_SYSVAR_ID, PROGRAM_ID, SYSTEM_PROGRAM_ID},
         cu_tracker::{is_tracking_enabled, record_cu},
         pda::{get_delegation_pda, get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
     },
@@ -129,6 +129,19 @@ pub fn build_and_send_transaction(
         }
     }
 
+    result
+}
+
+#[allow(clippy::result_large_err)]
+pub fn build_and_send_transaction_multi(
+    litesvm: &mut LiteSVM,
+    signers: &[&Keypair],
+    payer: &Pubkey,
+    ixs: &[Instruction],
+) -> TransactionResult {
+    let tx = Transaction::new(signers, Message::new(ixs, Some(payer)), litesvm.latest_blockhash());
+    let result = litesvm.send_transaction(tx);
+    litesvm.expire_blockhash();
     result
 }
 
@@ -523,6 +536,7 @@ impl<'a> CreateDelegation<'a> {
             AccountMeta::new(delegation_pda, false),
             AccountMeta::new_readonly(self.delegatee, false),
             AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+            AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
         ];
 
         let mut signers = vec![self.delegator];
@@ -1317,6 +1331,7 @@ pub struct Subscribe<'a> {
     plan_bump: u8,
     mint: Pubkey,
     payer: Option<&'a Keypair>,
+    expected_init_id: Option<i64>,
 }
 
 impl<'a> Subscribe<'a> {
@@ -1329,11 +1344,16 @@ impl<'a> Subscribe<'a> {
         plan_bump: u8,
         mint: Pubkey,
     ) -> Self {
-        Self { litesvm, subscriber, merchant, plan_pda, plan_id, plan_bump, mint, payer: None }
+        Self { litesvm, subscriber, merchant, plan_pda, plan_id, plan_bump, mint, payer: None, expected_init_id: None }
     }
 
     pub fn payer(mut self, payer: &'a Keypair) -> Self {
         self.payer = Some(payer);
+        self
+    }
+
+    pub fn expected_init_id(mut self, init_id: i64) -> Self {
+        self.expected_init_id = Some(init_id);
         self
     }
 
@@ -1353,6 +1373,7 @@ impl<'a> Subscribe<'a> {
             AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
             AccountMeta::new_readonly(event_authority, false),
             AccountMeta::new_readonly(PROGRAM_ID, false),
+            AccountMeta::new_readonly(INSTRUCTIONS_SYSVAR_ID, false),
         ];
 
         let mut signers: Vec<&Keypair> = vec![self.subscriber];
@@ -1371,13 +1392,14 @@ impl<'a> Subscribe<'a> {
         let expected_period_hours = plan.data.terms.period_hours;
         let expected_created_at = plan.data.terms.created_at;
         let expected_mint = plan.data.mint;
-        let expected_subscription_authority_init_id = self
-            .litesvm
-            .get_account(&subscription_authority_pda)
-            .and_then(|account| {
-                crate::state::SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id)
-            })
-            .unwrap_or_default();
+        let expected_subscription_authority_init_id = self.expected_init_id.unwrap_or_else(|| {
+            self.litesvm
+                .get_account(&subscription_authority_pda)
+                .and_then(|account| {
+                    crate::state::SubscriptionAuthority::load(&account.data).ok().map(|authority| authority.init_id)
+                })
+                .unwrap_or_default()
+        });
 
         let data = [
             vec![*subscribe::DISCRIMINATOR],


### PR DESCRIPTION
## Summary
- Adds a sentinel `init_id` (`UNKNOWN_INIT_ID = i64::MIN`) to `Subscribe`, `CreateFixedDelegation`, and `CreateRecurringDelegation`. When set, the program bypasses the `SubscriptionAuthority` generation (`init_id`) equality check **only if** an `InitSubscriptionAuthority` for the same authority PDA + owner ran earlier in the same transaction (instructions-sysvar introspection).
- Enables 1-step signup: bundle `init + subscribe` (or `init + create-delegation`) in one transaction without knowing `Clock::slot` at signing time. Same-transaction atomicity replaces same-generation pinning; standalone calls that pass a real `init_id` keep the original guarantee unchanged.
- New required read-only `instructions_sysvar` account on the 3 instructions (auto-defaulted by the generated client). New helper `helpers/introspection.rs`; check-site edits in `subscribe.rs` + `helpers/delegation.rs`. TS client exports `UNKNOWN_INIT_ID`.
- Fail-closed: sentinel without a matching co-init → `StaleSubscriptionAuthority`. Introspection reads only top-level instructions, so CPI-reached calls fall back to the stored-`init_id` check.

## Test Plan
- `just integration-test` — 256 existing + 6 new co-init tests (`test_co_init_introspection.rs`): co-init success for subscribe/fixed/recurring, idempotent-init + subscribe, sentinel-without-init rejected, different-mint co-init rejected.
- `just unit-test` — 59 pass. TS client builds; `just check` (fmt + lint) passes.

## Notes for review
- The Init-owner match is defense-in-depth and **unreachable via valid transactions**: `Init` enforces `authority_pda == find_pda(owner, mint)` and subscribe/delegation enforce `subscriber == authority.user`, so a PDA match implies an owner match. Kept as insurance against future weakening of `check_owner`.
- Ships as a future upgrade — **requires re-audit** (relaxes the consent-pinning semantic to same-transaction atomicity).

Closes TOO-559