### PR TITLE
refactor: rename Pubkey terminology to Address

### DIFF
--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -12,9 +12,9 @@ export const ZERO_ADDRESS =
 
 /** Byte offset of the account discriminator in the Header struct. */
 export const DISCRIMINATOR_OFFSET = 0;
-/** Byte offset of the delegator pubkey in the Header struct. */
+/** Byte offset of the delegator address in the Header struct. */
 export const DELEGATOR_OFFSET = 3;
-/** Byte offset of the delegatee pubkey in the Header struct. */
+/** Byte offset of the delegatee address in the Header struct. */
 export const DELEGATEE_OFFSET = 35;
 
 /** Byte size of a u64 value (used in nonce encoding). */
@@ -38,7 +38,7 @@ export const PLAN_SIZE = 491;
 /** On-chain SubscriptionDelegation account size in bytes: header(107) + terms(24) + pulled(8) + periodStart(8) + expiresAt(8). */
 export const SUBSCRIPTION_SIZE = 155;
 
-/** Byte offset of the owner pubkey in a Plan account. */
+/** Byte offset of the owner address in a Plan account. */
 export const PLAN_OWNER_OFFSET = 1;
 
 /** Maximum number of destination addresses in a Plan. */

--- a/clients/typescript/src/transfer-hook.ts
+++ b/clients/typescript/src/transfer-hook.ts
@@ -34,7 +34,7 @@ const EXTRA_ACCOUNT_METAS_SEED = 'extra-account-metas';
 const TLV_HEADER_LEN = 12; // u64 discriminator + u32 length
 const POD_SLICE_COUNT_LEN = 4;
 const EXTRA_ACCOUNT_META_LEN = 35;
-const PUBKEY_LEN = 32;
+const ADDRESS_LEN = 32;
 const PDA_PROGRAM_INDEX_OFFSET = 1 << 7;
 // sha256("spl-transfer-hook-interface:execute")[..8]
 const EXECUTE_DISCRIMINATOR = Uint8Array.from([0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a]);
@@ -120,7 +120,7 @@ async function unpackSeeds(
     return seeds;
 }
 
-async function unpackPubkeyData(
+async function unpackAddressData(
     config: ReadonlyUint8Array,
     previous: TransferHookAccount[],
     instructionData: Uint8Array,
@@ -129,14 +129,14 @@ async function unpackPubkeyData(
     const rest = config.subarray(1);
     if (config[0] === 1) {
         const offset = rest[0];
-        return addressDecoder.decode(instructionData.subarray(offset, offset + PUBKEY_LEN));
+        return addressDecoder.decode(instructionData.subarray(offset, offset + ADDRESS_LEN));
     }
     if (config[0] === 2) {
         const [accountIndex, offset] = [rest[0], rest[1]];
         const data = await fetchData(rpc, previous[accountIndex].address);
-        return addressDecoder.decode(data.subarray(offset, offset + PUBKEY_LEN));
+        return addressDecoder.decode(data.subarray(offset, offset + ADDRESS_LEN));
     }
-    throw new Error('transfer hook: invalid pubkey data');
+    throw new Error('transfer hook: invalid address data');
 }
 
 async function resolveMeta(
@@ -151,7 +151,7 @@ async function resolveMeta(
         return { address: addressDecoder.decode(meta.addressConfig), role };
     }
     if (meta.discriminator === 2) {
-        return { address: await unpackPubkeyData(meta.addressConfig, previous, instructionData, rpc), role };
+        return { address: await unpackAddressData(meta.addressConfig, previous, instructionData, rpc), role };
     }
     const programId =
         meta.discriminator === 1 ? hookProgram : previous[meta.discriminator - PDA_PROGRAM_INDEX_OFFSET].address;

--- a/docs/001-program-architecture.md
+++ b/docs/001-program-architecture.md
@@ -161,7 +161,7 @@ Delegates discover their delegations via `getProgramAccounts` with `memcmp` filt
 ```typescript
 // Delegatee discovers Bob's delegations:
 getProgramAccounts(PROGRAM_ID, {
-    filters: [{ memcmp: { offset: DELEGATEE_OFFSET, bytes: bobPubkey } }],
+    filters: [{ memcmp: { offset: DELEGATEE_OFFSET, bytes: bobAddress } }],
 });
 ```
 

--- a/program/src/constants.rs
+++ b/program/src/constants.rs
@@ -19,26 +19,26 @@ pub const TOKEN_2022_MINT_DISCRIMINATOR: u8 = 0x01;
 /// Token-2022 discriminator value indicating a **token account**.
 pub const TOKEN_2022_TOKEN_ACCOUNT_DISCRIMINATOR: u8 = 0x02;
 
-/// Byte offset where the `mint` pubkey begins in an SPL token account's data.
+/// Byte offset where the `mint` address begins in an SPL token account's data.
 pub const TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
 
-/// Byte offset one past the end of the `mint` pubkey (i.e., `MINT_OFFSET + 32`).
+/// Byte offset one past the end of the `mint` address (i.e., `MINT_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_MINT_END: usize = TOKEN_ACCOUNT_MINT_OFFSET + 32;
 
-/// Byte offset where the `owner` pubkey begins in an SPL token account's data.
+/// Byte offset where the `owner` address begins in an SPL token account's data.
 pub const TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 
-/// Byte offset one past the end of the `owner` pubkey (i.e., `OWNER_OFFSET + 32`).
+/// Byte offset one past the end of the `owner` address (i.e., `OWNER_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_OWNER_END: usize = TOKEN_ACCOUNT_OWNER_OFFSET + 32;
 
 /// Byte offset of the `delegate` `COption` tag in an SPL token account's data.
-/// `0` means no delegate; `1` means the 32-byte pubkey at [`TOKEN_ACCOUNT_DELEGATE_OFFSET`] is set.
+/// `0` means no delegate; `1` means the 32-byte address at [`TOKEN_ACCOUNT_DELEGATE_OFFSET`] is set.
 pub const TOKEN_ACCOUNT_DELEGATE_TAG_OFFSET: usize = 72;
 
-/// Byte offset where the `delegate` pubkey begins (immediately after its 4-byte `COption` tag).
+/// Byte offset where the `delegate` address begins (immediately after its 4-byte `COption` tag).
 pub const TOKEN_ACCOUNT_DELEGATE_OFFSET: usize = TOKEN_ACCOUNT_DELEGATE_TAG_OFFSET + 4;
 
-/// Byte offset one past the end of the `delegate` pubkey (i.e., `DELEGATE_OFFSET + 32`).
+/// Byte offset one past the end of the `delegate` address (i.e., `DELEGATE_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_DELEGATE_END: usize = TOKEN_ACCOUNT_DELEGATE_OFFSET + 32;
 
 /// Byte offset of the `decimals` field in an SPL Token / Token-2022 base mint.

--- a/program/src/instructions/helpers/transfer_utils.rs
+++ b/program/src/instructions/helpers/transfer_utils.rs
@@ -37,7 +37,7 @@ pub fn check_token_account_mint(data: &[u8], expected: &Address) -> Result<(), S
     Ok(())
 }
 
-/// Reads the owner pubkey from raw SPL token account data.
+/// Reads the owner address from raw SPL token account data.
 pub fn get_token_account_owner(data: &[u8]) -> Result<Address, SubscriptionsError> {
     if data.len() < TOKEN_ACCOUNT_OWNER_END {
         return Err(SubscriptionsError::InvalidAccountData);

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -20,13 +20,13 @@ pub const VERSION_OFFSET: usize = 1;
 /// Byte offset of the PDA bump seed.
 pub const BUMP_OFFSET: usize = 2;
 
-/// Byte offset of the delegator pubkey.
+/// Byte offset of the delegator address.
 pub const DELEGATOR_OFFSET: usize = 3;
 
-/// Byte offset of the delegatee pubkey.
+/// Byte offset of the delegatee address.
 pub const DELEGATEE_OFFSET: usize = 35;
 
-/// Byte offset of the payer pubkey (who funded the account creation).
+/// Byte offset of the payer address (who funded the account creation).
 pub const PAYER_OFFSET: usize = 67;
 
 /// Byte offset of the init_id field.

--- a/webapp/api/lib/bpf-loader.ts
+++ b/webapp/api/lib/bpf-loader.ts
@@ -134,10 +134,10 @@ export function buildCloseBufferIx(buffer: Address, recipient: Address, authorit
 }
 
 export async function deriveProgramDataAddress(programId: Address): Promise<Address> {
-    const pubkeyEncoder = getAddressEncoder();
+    const addressEncoder = getAddressEncoder();
     const [pda] = await getProgramDerivedAddress({
         programAddress: BPF_LOADER_UPGRADEABLE,
-        seeds: [pubkeyEncoder.encode(programId)],
+        seeds: [addressEncoder.encode(programId)],
     });
     return pda;
 }

--- a/webapp/api/lib/program-status.ts
+++ b/webapp/api/lib/program-status.ts
@@ -2,14 +2,14 @@ import { getAddressDecoder } from '@solana/kit';
 
 const PROGRAM_ACCOUNT_TAG = 2;
 const PROGRAM_DATA_OFFSET = 4;
-const PROGRAM_DATA_PUBKEY_LEN = 32;
-const PROGRAM_ACCOUNT_MIN_LEN = PROGRAM_DATA_OFFSET + PROGRAM_DATA_PUBKEY_LEN;
+const PROGRAM_DATA_ADDRESS_LEN = 32;
+const PROGRAM_ACCOUNT_MIN_LEN = PROGRAM_DATA_OFFSET + PROGRAM_DATA_ADDRESS_LEN;
 const SLOT_OFFSET = 4;
 const SLOT_SIZE = 8;
 const AUTHORITY_FLAG_OFFSET = 12;
-const AUTHORITY_PUBKEY_OFFSET = 13;
-const AUTHORITY_PUBKEY_LEN = 32;
-const HEADER_SIZE = AUTHORITY_PUBKEY_OFFSET + AUTHORITY_PUBKEY_LEN;
+const AUTHORITY_ADDRESS_OFFSET = 13;
+const AUTHORITY_ADDRESS_LEN = 32;
+const HEADER_SIZE = AUTHORITY_ADDRESS_OFFSET + AUTHORITY_ADDRESS_LEN;
 
 export interface ProgramStatus {
     deployed: boolean;
@@ -71,7 +71,7 @@ export async function checkProgramStatus(rpcUrl: string, programAddress: string)
     if (data.length < PROGRAM_ACCOUNT_MIN_LEN || data[0] !== PROGRAM_ACCOUNT_TAG) return notDeployed;
 
     const addressDecoder = getAddressDecoder();
-    const programDataBytes = data.slice(PROGRAM_DATA_OFFSET, PROGRAM_DATA_OFFSET + PROGRAM_DATA_PUBKEY_LEN);
+    const programDataBytes = data.slice(PROGRAM_DATA_OFFSET, PROGRAM_DATA_OFFSET + PROGRAM_DATA_ADDRESS_LEN);
     const programDataAddress = addressDecoder.decode(programDataBytes);
 
     const pdResult = (await rpcCall(rpcUrl, 'getAccountInfo', [
@@ -100,7 +100,7 @@ export async function checkProgramStatus(rpcUrl: string, programAddress: string)
     let upgradeAuthority: string | null = null;
     if (hasAuthority && pdData.length >= HEADER_SIZE) {
         upgradeAuthority = addressDecoder.decode(
-            pdData.slice(AUTHORITY_PUBKEY_OFFSET, AUTHORITY_PUBKEY_OFFSET + AUTHORITY_PUBKEY_LEN),
+            pdData.slice(AUTHORITY_ADDRESS_OFFSET, AUTHORITY_ADDRESS_OFFSET + AUTHORITY_ADDRESS_LEN),
         );
     }
 

--- a/webapp/src/lib/bpf-loader-browser.ts
+++ b/webapp/src/lib/bpf-loader-browser.ts
@@ -194,11 +194,11 @@ export function buildCloseProgramIx(
 }
 
 export async function deriveProgramDataAddress(programId: Address | string): Promise<Address> {
-    const pubkeyEncoder = getAddressEncoder();
+    const addressEncoder = getAddressEncoder();
     const addr = typeof programId === 'string' ? address(programId) : programId;
     const [pda] = await getProgramDerivedAddress({
         programAddress: BPF_LOADER_UPGRADEABLE,
-        seeds: [pubkeyEncoder.encode(addr)],
+        seeds: [addressEncoder.encode(addr)],
     });
     return pda;
 }


### PR DESCRIPTION
## Summary
- Rename the remaining `Pubkey` stragglers to `Address` to align with the ecosystem rename. Actual type usages already used `Address`; this catches local identifiers, constants, and doc comments that lagged.
- TS client (`transfer-hook.ts`): `PUBKEY_LEN`→`ADDRESS_LEN`, `unpackPubkeyData`→`unpackAddressData`, error string; `constants.ts` doc comments.
- webapp: `pubkeyEncoder`→`addressEncoder` in both bpf-loader files (they wrap `getAddressEncoder()`); `program-status.ts` layout constants (`PROGRAM_DATA_ADDRESS_LEN`, `AUTHORITY_ADDRESS_OFFSET`, `AUTHORITY_ADDRESS_LEN`).
- program: doc comments in `constants.rs`, `state/header.rs`, `transfer_utils.rs`; ADR example variable.

## Left unchanged (library API surface — renaming would break)
- `solana-pubkey` `Pubkey` in Rust integration tests (off-chain crate still names the type `Pubkey`).
- kit RPC fields: `raw.pubkey`, `AccountInfoWithPubkey`, and interfaces mirroring the RPC shape.
- web3.js `PublicKey` in Swig smart-wallet tests.
- `deploy-builder.ts` `bufferPubKey` is a `CryptoKey` fed to `getAddressFromPublicKey` — genuinely a public key, correctly named.

## Test Plan
- `just fmt-check` passes.
- webapp `tsc --noEmit` passes clean.
- Renames are within-file only; no cross-file references (grep-verified). No public API changed.
- Note: full client build (`just build-client`) requires the generated client (IDL→codegen), not run in this worktree.