### PR TITLE
fix(webapp): drop redundant close after revoke subscription authority

### DIFF
--- a/tests/integration-tests/src/test_transfer_recurring_delegation.rs
+++ b/tests/integration-tests/src/test_transfer_recurring_delegation.rs
@@ -819,13 +819,15 @@ fn test_recurring_transfer_token_2022_transfer_fee() {
 
     initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
 
+    let start_ts = current_ts();
     let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
         50_000_000,
         hours(1),
-        current_ts(),
-        current_ts() + days(1) as i64,
+        start_ts,
+        start_ts + days(1) as i64,
     );
     res.assert_ok();
+    set_clock(&mut litesvm, start_ts);
 
     TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
         .amount(10_000_000)
@@ -937,13 +939,15 @@ fn test_recurring_transfer_token_2022_active_transfer_hook() {
     let bob_ata = init_ata(&mut litesvm, mint, bob.pubkey(), 0);
 
     initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let start_ts = current_ts();
     let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
         50_000_000,
         hours(1),
-        current_ts(),
-        current_ts() + days(1) as i64,
+        start_ts,
+        start_ts + days(1) as i64,
     );
     res.assert_ok();
+    set_clock(&mut litesvm, start_ts);
 
     let missing_accounts = TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
         .amount(10_000_000)
@@ -989,13 +993,15 @@ fn recurring_active_hook_transfer_without_hook_accounts_fails() {
     init_ata(&mut litesvm, mint, bob.pubkey(), 0);
 
     initialize_subscription_authority_action(&mut litesvm, &alice, mint).0.assert_ok();
+    let start_ts = current_ts();
     let (res, delegation_pda) = CreateDelegation::new(&mut litesvm, &alice, mint, bob.pubkey()).recurring(
         50_000_000,
         hours(1),
-        current_ts(),
-        current_ts() + days(1) as i64,
+        start_ts,
+        start_ts + days(1) as i64,
     );
     res.assert_ok();
+    set_clock(&mut litesvm, start_ts);
 
     let result = TransferDelegation::new(&mut litesvm, &bob, alice.pubkey(), mint, delegation_pda)
         .amount(10_000_000)

--- a/webapp/src/components/plan/create-plan-dialog.tsx
+++ b/webapp/src/components/plan/create-plan-dialog.tsx
@@ -9,7 +9,7 @@ import { useTokenConfig } from '@/hooks/use-token-config';
 import { cn, ellipsify } from '@/lib/utils';
 import { getBlockTimestamp } from '@/hooks/use-time-travel';
 import { useClusterConfig } from '@/hooks/use-cluster-config';
-import { PLAN_ICONS } from '@/lib/plan-constants';
+import { MIN_END_TS_MARGIN_SECS, PLAN_ICONS } from '@/lib/plan-constants';
 import { parseTokenAmount } from '@/lib/token-display';
 
 const PLAN_TEMPLATES = [
@@ -70,7 +70,7 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
     const [periodUnit, setPeriodUnit] = useState<'hours' | 'days' | 'weeks' | 'months'>('days');
     const [noEndDate, setNoEndDate] = useState(true);
     const [endDate, setEndDate] = useState('');
-    const [endHour, setEndHour] = useState('12');
+    const [endTime, setEndTime] = useState('12:00');
     const [destinations, setDestinations] = useState<string[]>([]);
     const [pullers, setPullers] = useState<string[]>([]);
     const [selectedMint, setSelectedMint] = useState('');
@@ -124,7 +124,7 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
         setPeriodUnit('days');
         setNoEndDate(true);
         setEndDate('');
-        setEndHour('12');
+        setEndTime('12:00');
         setDestinations([]);
         setPullers([]);
         setSelectedMint('');
@@ -159,11 +159,9 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
         setPeriodUnit(t.periodUnit);
     };
 
-    const endTsComputed = endDate
-        ? Math.floor(new Date(`${endDate}T${endHour.padStart(2, '0')}:00:00`).getTime() / 1000)
-        : 0;
+    const endTsComputed = endDate ? Math.floor(new Date(`${endDate}T${endTime}:00`).getTime() / 1000) : 0;
     const minEndTs = blockTs + periodHours * 3600;
-    const isEndDateValid = endTsComputed === 0 || endTsComputed > minEndTs;
+    const isEndDateValid = endTsComputed === 0 || endTsComputed >= minEndTs + MIN_END_TS_MARGIN_SECS;
 
     const isFormValid =
         planName.length > 0 &&
@@ -180,10 +178,7 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
 
         const planId = crypto.getRandomValues(new BigUint64Array(1))[0];
         const amountInSmallestUnits = parseTokenAmount(amount, selectedToken.decimals);
-        const endTsRaw = endDate
-            ? Math.floor(new Date(`${endDate}T${endHour.padStart(2, '0')}:00:00`).getTime() / 1000)
-            : 0;
-        const endTs = Number.isNaN(endTsRaw) ? 0 : endTsRaw;
+        const endTs = Number.isNaN(endTsComputed) ? 0 : endTsComputed;
 
         const filteredDestinations = destinations.filter(d => d.length > 0);
         const filteredPullers = pullers.filter(p => p.length > 0);
@@ -444,19 +439,14 @@ export function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) 
                                             min={new Date(minEndTs * 1000).toLocaleDateString('en-CA')}
                                             className="flex-1"
                                         />
-                                        <Select
-                                            value={endHour}
-                                            onValueChange={value => {
-                                                if (value) setEndHour(value);
-                                            }}
+                                        <TextInput
+                                            type="time"
+                                            value={endTime}
+                                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                                setEndTime(e.target.value)
+                                            }
                                             className="w-28 shrink-0"
-                                        >
-                                            {Array.from({ length: 24 }, (_, i) => (
-                                                <SelectItem key={i} value={i.toString()}>
-                                                    {i.toString().padStart(2, '0')}:00
-                                                </SelectItem>
-                                            ))}
-                                        </Select>
+                                        />
                                     </div>
                                     {endDate && !isEndDateValid && (
                                         <p className="text-xs text-destructive">

--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -699,8 +699,11 @@ export function PlanCard({
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [subscribeOpen, setSubscribeOpen] = useState(false);
-    const { resumeSubscription } = useSubscriptionsMutations();
+    const { resumeSubscription, resubscribeStaleSubscription } = useSubscriptionsMutations();
     const { data: mySubscriptions } = useMySubscriptions();
+    const { data: authorityStatus } = useSubscriptionAuthorityStatus(plan.data.mint);
+    const { account } = useWallet();
+    const authorityInitId = authorityStatus?.data?.initId;
     const matchingSub = useMemo(
         () => mySubscriptions?.find(s => s.subscription.header.delegatee === plan.address) ?? null,
         [mySubscriptions, plan.address],
@@ -713,8 +716,19 @@ export function PlanCard({
         (plan.data.terms.amount !== matchingSub.subscription.terms.amount ||
             plan.data.terms.periodHours !== matchingSub.subscription.terms.periodHours ||
             plan.data.terms.createdAt !== matchingSub.subscription.terms.createdAt);
+    const isStaleSub =
+        matchingSub != null && (authorityInitId == null || matchingSub.subscription.header.initId !== authorityInitId);
     const [subDaysLeft, setSubDaysLeft] = useState<number | null>(null);
-    const canResumeSubscription = isCancelledSub && !isGhostSubscription && subDaysLeft !== null && subDaysLeft > 0;
+    const canResumeSubscription =
+        isCancelledSub && !isGhostSubscription && !isStaleSub && subDaysLeft !== null && subDaysLeft > 0;
+    const canResubscribe =
+        isCancelledSub &&
+        isStaleSub &&
+        !isGhostSubscription &&
+        authorityInitId != null &&
+        matchingSub != null &&
+        account != null &&
+        matchingSub.subscription.header.payer === account;
 
     const meta = useMemo(() => parsePlanMeta(plan.data.metadataUri), [plan.data.metadataUri]);
     const { data: tokens } = useTokenConfig();
@@ -931,6 +945,35 @@ export function PlanCard({
                                 >
                                     Resume Subscription
                                 </SolanaButton>
+                            ) : canResubscribe && matchingSub ? (
+                                <SolanaButton
+                                    size="sm"
+                                    onClick={(e: React.MouseEvent) => {
+                                        e.stopPropagation();
+                                        if (authorityInitId == null) return;
+                                        resubscribeStaleSubscription.mutate({
+                                            merchant: plan.owner,
+                                            planId: plan.data.planId,
+                                            planPda: plan.address,
+                                            subscriptionPda: matchingSub.address,
+                                            tokenMint: plan.data.mint,
+                                            expectedAmount: plan.data.terms.amount,
+                                            expectedPeriodHours: plan.data.terms.periodHours,
+                                            expectedCreatedAt: plan.data.terms.createdAt,
+                                            expectedSubscriptionAuthorityInitId: authorityInitId,
+                                        });
+                                    }}
+                                    disabled={resubscribeStaleSubscription.isPending || isSunset || planExpired}
+                                    loading={resubscribeStaleSubscription.isPending}
+                                    iconLeft={<RotateCcw />}
+                                    style={{ width: '100%' }}
+                                >
+                                    Re-subscribe
+                                </SolanaButton>
+                            ) : isCancelledSub && isStaleSub ? (
+                                <Badge variant="danger" className="w-full justify-center" style={{ height: '2.25rem' }}>
+                                    Stale subscription \u2014 re-enable delegations for this token to re-subscribe
+                                </Badge>
                             ) : isCancelledSub ? (
                                 <Badge variant="danger" className="w-full justify-center" style={{ height: '2.25rem' }}>
                                     Cancelled{' '}

--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -38,7 +38,7 @@ import { useTokenConfig } from '@/hooks/use-token-config';
 import { resolveTokenProgram } from '@/lib/token-program';
 import type { PlanItem } from '@/hooks/use-plans';
 import { useMySubscriptions, useSubscriberCount } from '@/hooks/use-subscriptions';
-import { PLAN_ICONS, ICON_MAP, parsePlanMeta, type PlanMeta } from '@/lib/plan-constants';
+import { MIN_END_TS_MARGIN_SECS, PLAN_ICONS, ICON_MAP, parsePlanMeta, type PlanMeta } from '@/lib/plan-constants';
 import { ExplorerLink } from '@/components/cluster/cluster-ui';
 import { formatPlanTokenAmount, resolvePlanTokenDisplay, type PlanTokenDisplay } from '@/lib/token-display';
 
@@ -84,12 +84,12 @@ function EditPlanDialog({
     const [endDate, setEndDate] = useState(() => {
         const ts = Number(plan.data.endTs);
         if (ts === 0) return '';
-        return new Date(ts * 1000).toISOString().slice(0, 10);
+        return new Date(ts * 1000).toLocaleDateString('en-CA');
     });
-    const [endHour, setEndHour] = useState(() => {
+    const [endTime, setEndTime] = useState(() => {
         const ts = Number(plan.data.endTs);
-        if (ts === 0) return '12';
-        return new Date(ts * 1000).getHours().toString();
+        if (ts === 0) return '12:00';
+        return new Date(ts * 1000).toTimeString().slice(0, 5);
     });
     const [sunsetMode, setSunsetMode] = useState(false);
     const [pullers, setPullers] = useState<string[]>(() => plan.data.pullers.filter(p => p !== ZERO_ADDRESS));
@@ -120,11 +120,9 @@ function EditPlanDialog({
 
     const metadataBytes = useMemo(() => new TextEncoder().encode(metadataJson).length, [metadataJson]);
 
-    const endTsComputed = endDate
-        ? Math.floor(new Date(`${endDate}T${endHour.padStart(2, '0')}:00:00`).getTime() / 1000)
-        : 0;
+    const endTsComputed = endDate ? Math.floor(new Date(`${endDate}T${endTime}:00`).getTime() / 1000) : 0;
     const minEndTs = (blockTime ?? 0) + Number(plan.data.terms.periodHours) * 3600;
-    const isEndDateValid = endTsComputed === 0 || endTsComputed > minEndTs;
+    const isEndDateValid = endTsComputed === 0 || endTsComputed >= minEndTs + MIN_END_TS_MARGIN_SECS;
 
     const handleUpdate = () => {
         const endTs = endTsComputed;
@@ -250,20 +248,13 @@ function EditPlanDialog({
                                     className="flex-1"
                                     disabled={isSunset}
                                 />
-                                <Select
-                                    value={endHour}
+                                <TextInput
+                                    type="time"
+                                    value={endTime}
                                     disabled={isSunset}
-                                    onValueChange={value => {
-                                        if (value) setEndHour(value);
-                                    }}
+                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEndTime(e.target.value)}
                                     className="w-28 shrink-0"
-                                >
-                                    {Array.from({ length: 24 }, (_, i) => (
-                                        <SelectItem key={i} value={i.toString()}>
-                                            {i.toString().padStart(2, '0')}:00
-                                        </SelectItem>
-                                    ))}
-                                </Select>
+                                />
                             </div>
                             {endDate && !isEndDateValid && (
                                 <p className="text-xs text-destructive">

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -174,11 +174,11 @@ export function useSubscriptionsMutations() {
                     ? [
                           await getRevokeSubscriptionAuthorityOverlayInstructionAsync({
                               programAddress: progId,
+                              receiver,
                               tokenMint: address(tokenMint),
                               tokenProgram,
                               user: signer,
                           }),
-                          closeInstruction,
                       ]
                     : [closeInstruction];
 

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -12,6 +12,7 @@ import {
     getInitSubscriptionAuthorityOverlayInstructionAsync,
     getResumeSubscriptionOverlayInstructionAsync,
     getRevokeAbandonedDelegationInstruction,
+    getRevokeAbandonedSubscriptionInstruction,
     getRevokeDelegationOverlayInstruction,
     getRevokeSubscriptionAuthorityOverlayInstructionAsync,
     getRevokeSubscriptionOverlayInstruction,
@@ -607,6 +608,69 @@ export function useSubscriptionsMutations() {
         },
     });
 
+    const resubscribeStaleSubscription = useMutation({
+        mutationFn: async ({
+            merchant,
+            planId,
+            planPda,
+            subscriptionPda,
+            tokenMint,
+            expectedAmount,
+            expectedPeriodHours,
+            expectedCreatedAt,
+            expectedSubscriptionAuthorityInitId,
+        }: {
+            expectedAmount: bigint;
+            expectedCreatedAt: bigint;
+            expectedPeriodHours: bigint;
+            expectedSubscriptionAuthorityInitId: bigint;
+            merchant: string;
+            planId: bigint;
+            planPda: string;
+            subscriptionPda: string;
+            tokenMint: string;
+        }) => {
+            if (!signer) throw new Error('Wallet not connected');
+            if (!progId) throw new Error('Program address not configured');
+
+            const [subscriptionAuthority] = await findSubscriptionAuthorityPda(
+                { tokenMint: address(tokenMint), user: signer.address },
+                { programAddress: progId },
+            );
+
+            const revokeInstruction = getRevokeAbandonedSubscriptionInstruction(
+                {
+                    payer: signer,
+                    planPda: address(planPda),
+                    subscriptionAccount: address(subscriptionPda),
+                    subscriptionAuthority,
+                },
+                { programAddress: progId },
+            );
+
+            const subscribeInstruction = await getSubscribeOverlayInstructionAsync({
+                expectedAmount,
+                expectedCreatedAt,
+                expectedPeriodHours,
+                expectedSubscriptionAuthorityInitId,
+                merchant: address(merchant),
+                planId,
+                programAddress: progId,
+                subscriber: signer,
+                tokenMint: address(tokenMint),
+            });
+
+            const signature = await signAndSend([revokeInstruction, subscribeInstruction], signer);
+            return { signature };
+        },
+        onError: error => toast.onError(error),
+        onSuccess: res => {
+            toast.onSuccess(res.signature);
+            queryClient.invalidateQueries({ queryKey: ['subscriptions'] });
+            queryClient.invalidateQueries({ queryKey: ['delegations'] });
+        },
+    });
+
     const revokeSubscription = useMutation({
         mutationFn: async ({
             subscriptionPda,
@@ -1027,6 +1091,7 @@ export function useSubscriptionsMutations() {
         createRecurringDelegation,
         deletePlan,
         initSubscriptionAuthority,
+        resubscribeStaleSubscription,
         resumeSubscription,
         revokeAbandonedDelegations,
         revokeDelegation,

--- a/webapp/src/lib/plan-constants.ts
+++ b/webapp/src/lib/plan-constants.ts
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
+export const MIN_END_TS_MARGIN_SECS = 120;
+
 export const PLAN_ICONS = [
     { name: 'BarChart3', label: 'Finance', icon: BarChart3 },
     { name: 'Newspaper', label: 'News', icon: Newspaper },


### PR DESCRIPTION
## Summary
- "Disable Delegations" on the delegations page failed with `InvalidAccountOwner` against the new program: the tx sent `RevokeSubscriptionAuthority` followed by `CloseSubscriptionAuthority`, but the revoke instruction already closes the SubscriptionAuthority PDA when open, so the trailing close always hit a system-owned account.
- Send the revoke instruction alone in the feature-flagged branch and pass `receiver` to it, so sponsored authorities (stored payer != user) return rent to the correct account instead of failing with `NotEnoughAccountKeys`.

## Test Plan
- `tsc -b` clean in `webapp/`, prettier clean.
- Manual: on devnet, disable delegations for a mint with an active authority; tx should land with a single program instruction and the authority account closed.