### PR TITLE
chore(release): v0.4.0 program and clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog — Subscriptions program
 
-On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `program-vX.Y.Z` git tags.
+On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `vX.Y.Z` git tags.
 SDK client changelogs are tracked separately: [`clients/typescript`](clients/typescript/CHANGELOG.md) and [`clients/rust`](clients/rust/CHANGELOG.md).
 
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Targets `program-v1.1.0` (target deploy 2026-06-26). Reproducible via `solana-verify`. **Includes breaking changes vs the deployed v1.0.0 — see Changed / Security.** Audit status: [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md)._
+## [0.4.0] — 2026-07-13
+
+_Target mainnet deploy 2026-07-13. Reproducible via `solana-verify`. **Includes breaking changes vs the deployed v0.3.0 — see Changed / Security.** Audit status: [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md)._
 
 ### Added
 
@@ -17,7 +19,7 @@ _Targets `program-v1.1.0` (target deploy 2026-06-26). Reproducible via `solana-v
 - `PlanUpdatedEvent` (discriminator 6) emitted by `update_plan`.
 - Token-2022 Transfer Hook support — hooked mints work end-to-end for fixed, recurring, and subscription transfers; hook accounts are forwarded transparently to Token-2022's `TransferChecked` (no `ExtraAccountMetaList` validation PDA required), up to the runtime CPI account ceiling (`MAX_CPI_ACCOUNTS`, 128). ([#160])
 - The published IDL registers all emitted events (discriminators + field schemas) so indexers can decode them.
-- The published IDL now models the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) trailing accounts so generated clients name them. No on-chain change — the program has accepted these accounts since v1.0.0 (`resolve_optional_payer`); only the IDL/client modeling is new.
+- The published IDL now models the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) trailing accounts so generated clients name them. No on-chain change — the program has accepted these accounts since v0.3.0 (`resolve_optional_payer`); only the IDL/client modeling is new.
 
 ### Changed
 
@@ -48,12 +50,13 @@ _Targets `program-v1.1.0` (target deploy 2026-06-26). Reproducible via `solana-v
 - `RecurringTransferEvent.period_end_ts` is capped at the delegation's finite `expiry_ts` (matches `transfer_subscription`).
 - The published IDL models the `event_authority` default as the `eventAuthority` PDA instead of a hardcoded key, so builders resolve event accounts on cloned/local deployments.
 
-## [1.0.0] — 2026-06-01
+## [0.3.0] — 2026-06-01
 
-Initial audited mainnet release (`program-v1.0.0`, commit `0221a37`).
+Initial audited mainnet release (`v0.3.0`, commit `0221a37`).
 
-[Unreleased]: https://github.com/solana-foundation/subscriptions/compare/0221a37...main
-[1.0.0]: https://github.com/solana-foundation/subscriptions/commit/0221a37
+[Unreleased]: https://github.com/solana-foundation/subscriptions/compare/v0.4.0...main
+[0.4.0]: https://github.com/solana-foundation/subscriptions/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/solana-foundation/subscriptions/commit/0221a37
 [#160]: https://github.com/solana-foundation/subscriptions/pull/160
 [#162]: https://github.com/solana-foundation/subscriptions/pull/162
 [#163]: https://github.com/solana-foundation/subscriptions/pull/163

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — Subscriptions program
 
-On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `vX.Y.Z` git tags.
+On-chain program `De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44`, versioned by `program-vX.Y.Z` git tags.
 SDK client changelogs are tracked separately: [`clients/typescript`](clients/typescript/CHANGELOG.md) and [`clients/rust`](clients/rust/CHANGELOG.md).
 
 Versioning follows [Semantic Versioning](https://semver.org/).
@@ -25,6 +25,7 @@ _Target mainnet deploy 2026-07-13. Reproducible via `solana-verify`. **Includes 
 
 - `CreateRecurringDelegation` accepts `start_ts = 0` as a sentinel: the first period starts at the on-chain clock time when the transaction lands. Requires a non-zero `expiry_ts`. ([#164])
 - Tightened account and state validation. ([#163])
+- The last Token-2022 extension guard is removed — v0.3.0 rejected mints with a configured `TransferHook` (`MintHasTransferHook`, 121); such mints are now accepted and their hooks executed via account forwarding. The program no longer rejects any mint by extension; extension-guard error codes 118–124 are retained so existing clients keep decoding them, but are never raised. ([#160], [#186])
 - **Breaking** — event wire format: transfer events gain `receiver_token_account`, `SubscriptionCreatedEvent` gains `payer`, and `SubscriptionTransferEvent` gains `puller` (appended; existing field offsets preserved, total event size changed).
 - **Breaking** — `UpdatePlan` now requires two additional accounts (`event_authority`, `self_program`) for self-CPI event emission.
 
@@ -52,12 +53,13 @@ _Target mainnet deploy 2026-07-13. Reproducible via `solana-verify`. **Includes 
 
 ## [0.3.0] — 2026-06-01
 
-Initial audited mainnet release (`v0.3.0`, commit `0221a37`).
+Initial audited mainnet release (`program-v0.3.0`, commit `0221a37`).
 
-[Unreleased]: https://github.com/solana-foundation/subscriptions/compare/v0.4.0...main
-[0.4.0]: https://github.com/solana-foundation/subscriptions/compare/v0.3.0...v0.4.0
+[Unreleased]: https://github.com/solana-foundation/subscriptions/compare/program-v0.4.0...main
+[0.4.0]: https://github.com/solana-foundation/subscriptions/compare/program-v0.3.0...program-v0.4.0
 [0.3.0]: https://github.com/solana-foundation/subscriptions/commit/0221a37
 [#160]: https://github.com/solana-foundation/subscriptions/pull/160
 [#162]: https://github.com/solana-foundation/subscriptions/pull/162
 [#163]: https://github.com/solana-foundation/subscriptions/pull/163
 [#164]: https://github.com/solana-foundation/subscriptions/pull/164
+[#186]: https://github.com/solana-foundation/subscriptions/pull/186

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 just build
 
 # Individual steps
-just generate-idl          # Generate IDL via Codama (cargo build with build.rs)
-just generate-client       # Generate TypeScript + Rust clients from IDL
+just generate-idl          # Generate IDL via Codama (GENERATE_IDL=1 cargo check, build.rs writes it)
+just generate-clients      # Generate TypeScript + Rust clients from IDL
 just build-program         # Build .so binary only (cargo build-sbf)
 just build-client          # Build TypeScript client (tsup)
 
@@ -48,7 +48,7 @@ Solana program using **Pinocchio** (lightweight `no_std` framework) with **Codam
 ### Code Flow
 
 ```
-program/src/lib.rs (declares ID, dispatches via SubscriptionsInstruction enum)
+program/src/lib.rs (declares ID) + entrypoint.rs (dispatches via SubscriptionsInstruction enum)
     ↓
 program/src/instructions/*.rs (instruction processors)
     ↓
@@ -80,14 +80,14 @@ clients/typescript/src/generated/  (auto-generated; wrapped by hand-written SDK 
 ### Key Modules
 
 - `program/src/instructions/` — 17 instruction handlers (discriminators 0–16) + an internal `emit_event` self-CPI handler + `helpers/` (validation, token ops, traits)
-- `program/src/state/` — Account structs (SubscriptionAuthority, FixedDelegation, RecurringDelegation, Plan, Subscription) + `versioning/`
+- `program/src/state/` — Account structs (SubscriptionAuthority, FixedDelegation, RecurringDelegation, Plan, SubscriptionDelegation) + `versioning/`
 - `program/src/events/` — Event structs and self-CPI emission
 - `program/src/errors.rs` — Error codes (ranges 100-699)
 - `program/src/event_engine.rs` — Self-CPI dispatcher for events
 
 ### Testing
 
-- Rust unit tests: located in `program/src/tests/`. Run via `just unit-test`.
+- Rust unit tests: inline `#[cfg(test)]` modules across `program/src/` plus `program/src/tests/`. Run via `just unit-test`.
 - Rust integration tests: LiteSVM-based workspace crate in `tests/integration-tests/`. Run via `just integration-test`.
 - TypeScript: Vitest against Surfpool, in `clients/typescript/test/`. Includes Squads + Swig smart-wallet integration tests and security-focused tests.
 - CU benchmarks: set `CU_REPORT=1` to write `cu_report.md` (posted as PR comment in CI).
@@ -109,7 +109,7 @@ Audited by Cantina. See [audits/AUDIT_STATUS.md](audits/AUDIT_STATUS.md) for the
 - `docs/` — Numbered ADRs
 - `audits/` — Audit report and AUDIT_STATUS.md
 - `runbooks/` — txtx Surfpool deployment runbooks
-- `scripts/` — Validator + webapp shell scripts
+- `scripts/` — Validator + webapp shell scripts, client codegen TS (`generate-clients.ts`)
 
 ## Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,7 +5432,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.4.0-rc.2"
+version = "0.4.0"
 dependencies = [
  "borsh",
  "num-derive",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "subscriptions-program"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "codama",
  "const-crypto",
@@ -5549,7 +5549,7 @@ dependencies = [
 
 [[package]]
 name = "tests-subscriptions"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "dtor",
  "litesvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/subscriptions"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Supported delegation models:
 - **Recurring delegation**: authorize a delegatee to spend up to a per-period amount that resets each period, with configurable period length and overall expiry.
 - **Subscription plan**: a merchant publishes a plan with pricing terms; subscribers accept those terms and the merchant (or whitelisted pullers) can pull funds each billing period.
 
+Rent stays recoverable even after a user closes or re-initializes their Subscription Authority: the recorded payer can reclaim rent from the stranded delegation or subscription PDAs via the generated `RevokeAbandonedDelegation` / `RevokeAbandonedSubscription` instructions.
+
 The program emits on-chain events via self-CPI for indexer integration (subscription created/cancelled/resumed, plan updated, and fixed/recurring/subscription transfers). The events are registered in the Codama IDL, so indexers can decode them.
 
 Token-2022 mints are supported, including mints with a configured `TransferHook`. On delegated transfers the program forwards the caller-supplied hook accounts into the Token-2022 `TransferChecked` CPI, which resolves and runs the hook exactly as it would for a direct transfer; the program does not add or require extra hook-account guards of its own.
@@ -66,15 +68,16 @@ subscriptions/
 │   │   ├── event_engine.rs        # Self-CPI event emission
 │   │   ├── errors.rs              # Error codes
 │   │   ├── constants.rs           # Program constants
-│   │   └── tests/                 # Rust unit tests (LiteSVM)
+│   │   └── tests/                 # Rust unit tests
 ├── idl/                           # Generated IDL (subscriptions.json)
 ├── clients/
 │   ├── typescript/                # TypeScript SDK + integration tests
 │   └── rust/                      # Rust generated client
+├── tests/                         # LiteSVM integration tests + transfer-hook example program
 ├── webapp/                        # Demo UI (React) + local API server
 │   ├── src/                       # React app (routes, components, hooks)
 │   ├── api/                       # Node.js API server (faucet, deploy, config)
-│   └── scripts/                   # Environment init, mock USDC minting
+│   └── scripts/                   # Environment init, mock test-token minting
 ├── scripts/                       # Shell scripts (validator, webapp launcher)
 ├── docs/                          # Architecture Decision Records
 ├── runbooks/                      # Surfpool deployment runbooks
@@ -140,7 +143,7 @@ curl -sL https://run.surfpool.run/ | bash
 
 6. Node.js (required by `webapp/` scripts)
 
-## Program ID
+## Program ID Declaration
 
 The program ID is declared in `program/src/lib.rs`. Local Surfpool workflows install the program at that canonical address via `runbooks/surfnet-setup`, so a checked-in program keypair is not required for local tests.
 
@@ -197,7 +200,7 @@ The `justfile` is the main entrypoint for day-to-day development.
 
 Two local validator flows are available:
 
-- **`just test-client`** starts a [Surfpool](https://www.surfpool.run/) validator automatically via `ensure-surfpool`. The program is deployed from `target/deploy/` using Surfpool's built-in deployment.
+- **`just test-client`** starts fresh [Surfpool](https://www.surfpool.run/) validators (a mainnet-fork pass, then an offline pass). The program is deployed from `target/deploy/` using Surfpool's built-in deployment.
 - **`just webapp-run`** starts `solana-test-validator` via `scripts/start-webapp.sh`, then deploys the program and initializes the test environment.
 
 Both default to `http://localhost:8899`.
@@ -232,6 +235,16 @@ pnpm add @solana/subscriptions
 import { subscriptionsProgram } from '@solana/subscriptions';
 ```
 
+Rust client:
+
+```bash
+cargo add subscriptions
+```
+
+```rust
+use subscriptions::instructions::*;
+```
+
 ## Webapp Demo
 
 The demo app in `webapp/` provides a local UI and API for development flows.
@@ -251,17 +264,17 @@ Expected local endpoints:
 
 ### Features
 
-| Route            | Feature                                             |
-| ---------------- | --------------------------------------------------- |
-| `/setup`         | Setup wizard (validator, program deploy, mock USDC) |
-| `/`              | Dashboard overview                                  |
-| `/delegations`   | Create and manage fixed/recurring delegations       |
-| `/plans`         | Create and manage merchant subscription plans       |
-| `/plans/collect` | Collect subscription payments                       |
-| `/subscriptions` | View and manage active subscriptions                |
-| `/marketplace`   | Browse available plans                              |
-| `/faucet`        | SOL and USDC airdrops (localnet/devnet)             |
-| `/program`       | Program deploy/upgrade status                       |
+| Route            | Feature                                                   |
+| ---------------- | --------------------------------------------------------- |
+| `/setup`         | Setup wizard (validator, program deploy, mock test token) |
+| `/`              | Dashboard overview                                        |
+| `/delegations`   | Create and manage fixed/recurring delegations             |
+| `/plans`         | Create and manage merchant subscription plans             |
+| `/plans/collect` | Collect subscription payments                             |
+| `/subscriptions` | View and manage active subscriptions                      |
+| `/marketplace`   | Browse available plans                                    |
+| `/faucet`        | SOL and test-token airdrops (localnet/devnet)             |
+| `/program`       | Program deploy/upgrade status                             |
 
 Stop local processes:
 
@@ -306,6 +319,7 @@ GitHub Actions runs split workflows on PRs and pushes to `main`:
 | [ADR-001](docs/001-program-architecture.md)              | Core program architecture: SA, fixed/recurring delegations, PDA design            |
 | [ADR-002](docs/002-subscriptions-architecture.md)        | Subscription plans: merchant plans, subscriber flow, pull payments                |
 | [ADR-003](docs/003-versioning-migration-architecture.md) | Versioning and migration: three-tier fallback chain for on-chain account upgrades |
+| [ADR-004](docs/004-program-upgrade-mechanism.md)         | Program upgrades: Squads-governed upgrade authority and deployment flow           |
 
 ## Smart Wallet Support
 

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [0.4.0] — 2026-07-13
 
-_Matches on-chain program `v0.4.0`._
+_Matches on-chain program `program-v0.4.0`._
 
 ### Added
 

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -6,14 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Targets `0.4.0` (release candidate `0.4.0-rc.1` published to crates.io)._
+## [0.4.0] — 2026-07-13
+
+_Matches on-chain program `v0.4.0`._
 
 ### Added
 
 - Instruction builders for `RevokeSubscriptionAuthority` (requires `subscription_authority`, optional `receiver`, `user` writable) and `RevokeAbandonedDelegation`. ([#162], [#163])
 - Token-2022 transfer-hook account resolution for fixed, recurring, and subscription transfers. ([#160])
 - `revokeAbandonedSubscription` instruction builder.
-- Generated builders now expose the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) accounts (the program has accepted them on-chain since v1.0.0; only the IDL/client modeling is new). Omitting them preserves the prior self-funded layout.
+- Generated builders now expose the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) accounts (the program has accepted them on-chain since v0.3.0; only the IDL/client modeling is new). Omitting them preserves the prior self-funded layout.
 - Generated decoders for all program events (now registered in the IDL): transfer events include `receiverTokenAccount`, `SubscriptionCreatedEvent` includes `payer`, `SubscriptionTransferEvent` includes `puller`, plus the new `PlanUpdatedEvent`.
 - Generated error variants `PlanEndTsCannotExtend` (520) and `InvalidSelfProgram` (604).
 

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.4.0-rc.2"
+version = "0.4.0"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [0.4.0] — 2026-07-13
 
-_Matches on-chain program `v0.4.0`._
+_Matches on-chain program `program-v0.4.0`._
 
 ### Added
 

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -6,14 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_Targets `0.4.0` (release candidate `0.4.0-rc.1` published to npm)._
+## [0.4.0] — 2026-07-13
+
+_Matches on-chain program `v0.4.0`._
 
 ### Added
 
 - `revokeSubscriptionAuthority` (overlay derives `subscriptionAuthority`, accepts an optional `receiver`; `user` writable) and `revokeAbandonedDelegation` instruction builders. ([#162], [#163])
 - `resolveTransferHookAccounts`, plus automatic Token-2022 transfer-hook account resolution in `transferFixed`, `transferRecurring`, and `transferSubscription` on the plugin client. ([#160])
 - `revokeAbandonedSubscription` instruction builder.
-- Generated builders now expose the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) accounts (the program has accepted them on-chain since v1.0.0; only the IDL/client modeling is new). Omitting them preserves the prior self-funded layout.
+- Generated builders now expose the optional sponsor `payer` (`initSubscriptionAuthority`, `createFixedDelegation`, `createRecurringDelegation`, `subscribe`) and optional `receiver` (`closeSubscriptionAuthority`) accounts (the program has accepted them on-chain since v0.3.0; only the IDL/client modeling is new). Omitting them preserves the prior self-funded layout.
 - Decoders for all program events (now registered in the IDL): transfer events include `receiverTokenAccount`, `SubscriptionCreatedEvent` includes `payer`, `SubscriptionTransferEvent` includes `puller`, plus the new `PlanUpdatedEvent`.
 - Generated error constants `SUBSCRIPTIONS_ERROR__PLAN_END_TS_CANNOT_EXTEND` (520) and `SUBSCRIPTIONS_ERROR__INVALID_SELF_PROGRAM` (604).
 

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -28,7 +28,7 @@ const client = createClient()
 // 1. Initialize the SubscriptionAuthority for a user's token account (once per mint)
 await client.subscriptions.instructions
     .initSubscriptionAuthority({
-        tokenMint: address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+        tokenMint: address('TokenMintAddress...'),
         userAta: address('...'),
         tokenProgram: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
     })
@@ -37,7 +37,7 @@ await client.subscriptions.instructions
 // 2. Create a fixed delegation (e.g., allow spending 1,000,000 tokens)
 await client.subscriptions.instructions
     .createFixedDelegation({
-        tokenMint: address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+        tokenMint: address('TokenMintAddress...'),
         delegatee: address('DelegateeAddress...'),
         nonce: 0n,
         amount: 1_000_000n,
@@ -62,6 +62,8 @@ For custom wallet flows, use the exported `get*OverlayInstruction*` functions. T
 | `revokeSubscription` / `getRevokeSubscriptionOverlayInstruction`                        | Close a subscription delegation PDA (requires `planPda`) and reclaim rent                                                            |
 | `revokeSubscriptionAuthority` / `getRevokeSubscriptionAuthorityOverlayInstructionAsync` | Revoke the per-mint SPL delegate and close the SubscriptionAuthority PDA, reclaiming rent (pass `receiver` when a sponsor funded it) |
 
+Abandoned delegation and subscription PDAs (Subscription Authority closed or re-initialized) can be closed by the recorded payer via the generated `getRevokeAbandonedDelegationInstruction` / `getRevokeAbandonedSubscriptionInstruction` builders (no overlay wrapper).
+
 ### Transfers
 
 | Plugin instruction / builder                                              | Description                                |
@@ -69,6 +71,8 @@ For custom wallet flows, use the exported `get*OverlayInstruction*` functions. T
 | `transferFixed` / `getTransferFixedOverlayInstructionAsync`               | Pull tokens from a fixed delegation        |
 | `transferRecurring` / `getTransferRecurringOverlayInstructionAsync`       | Pull tokens from a recurring delegation    |
 | `transferSubscription` / `getTransferSubscriptionOverlayInstructionAsync` | Pull tokens from a subscription delegation |
+
+For Token-2022 mints with a configured transfer hook, the plugin resolves and appends the hook accounts automatically. For standalone overlay usage, call `resolveTransferHookAccounts` and pass the result as `transferHookAccounts`.
 
 ### Subscription Plans
 
@@ -107,7 +111,7 @@ seed is the constant `"event_authority"`).
 
 ## API Reference
 
-Full API documentation is generated from source with [TypeDoc](https://typedoc.org/). Run `npx typedoc` to generate locally, or browse `./docs/`.
+Full API documentation is generated from source with [TypeDoc](https://typedoc.org/). Run `npx typedoc` to generate the reference into `./docs/` locally.
 
 ## Development
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/subscriptions",
-    "version": "0.4.0-rc.2",
+    "version": "0.4.0",
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",

--- a/docs/001-program-architecture.md
+++ b/docs/001-program-architecture.md
@@ -211,8 +211,9 @@ build the sponsored variants; the program reads them from the trailing remainder
 **delegation-type dependent** and cannot be expressed as a single static
 optional list, so it is documented here rather than in the IDL account list.
 
-- **Fixed / recurring:** optional `[receiver]` — the rent recipient when a
-  sponsor revokes (defaults to the recorded payer).
+- **Fixed / recurring:** optional `[receiver]` — required when the delegator
+  revokes a sponsor-funded delegation; must match the recorded payer. A revoking
+  sponsor is the payer and receives rent directly.
 - **Subscription:** required `[plan_pda]`, then optional `[receiver]` — the
   `plan_pda` is needed to evaluate plan-state revocation conditions.
 
@@ -397,6 +398,7 @@ Creates a one-time delegation with nonce-based PDA.
 - `nonce: u64` - Unique identifier to create distinct PDAs for same (delegator, delegatee) pair
 - `amount: u64` - Maximum amount transferable
 - `expiry_ts: i64` - Unix timestamp when delegation expires
+- `expected_subscription_authority_init_id: i64` - The SA `init_id` the delegator consented to; creation fails on mismatch
 
 **Process:**
 
@@ -422,15 +424,16 @@ Creates a recurring delegation with period tracking.
 - `nonce: u64` - Unique identifier
 - `amount_per_period: u64` - Maximum amount per period
 - `period_length_s: u64` - Seconds in each period
-- `start_ts: i64` - Timestamp when the first period starts
+- `start_ts: i64` - Timestamp when the first period starts, or `0` to start when the transaction lands (requires a non-zero `expiry_ts`)
 - `expiry_ts: i64` - Delegation expiry timestamp
+- `expected_subscription_authority_init_id: i64` - The SA `init_id` the delegator consented to; creation fails on mismatch
 
 **Process:**
 
 1. Validate SubscriptionAuthority exists and belongs to delegator
 2. Derive and validate Delegation PDA with nonce
 3. Create Delegation account with header and terms
-4. Initialize `current_period_start_ts` to `start_ts`
+4. Initialize `current_period_start_ts` to `start_ts` (or to the on-chain clock time when `start_ts == 0`)
 5. Initialize `amount_pulled_in_period` to 0
 
 ### `revoke_delegation` (Discriminator: 3)
@@ -450,18 +453,19 @@ Revokes a delegation by closing the delegation PDA and returning rent to the ori
 
 ### `close_subscription_authority` (Discriminator: 6)
 
-Closes a SubscriptionAuthority PDA and returns rent to the owner.
+Closes a SubscriptionAuthority PDA and returns rent to the recorded payer (the user by default).
 
-| Account | Type             | Description                                     |
-| ------- | ---------------- | ----------------------------------------------- |
-| 0       | signer, writable | The user who owns the SubscriptionAuthority PDA |
-| 1       | writable         | SubscriptionAuthority PDA to close              |
+| Account | Type             | Description                                                                                              |
+| ------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| 0       | signer, writable | The user who owns the SubscriptionAuthority PDA                                                          |
+| 1       | writable         | SubscriptionAuthority PDA to close                                                                       |
+| 2       | writable         | Receiver (optional; required when the recorded payer differs from the user, must match the stored payer) |
 
 **Process:**
 
 1. Verify signer matches the SA's `user` field
 2. Verify PDA derivation from `["SubscriptionAuthority", user, token_mint]`
-3. Close account and transfer lamports to user
+3. Close account and transfer lamports to the recorded payer (via `receiver` when sponsor-funded)
 
 > **Authority close and rotation:** Closing does not revoke existing delegation PDAs, but they
 > become non-transferable while the SubscriptionAuthority account does not exist. If the user
@@ -488,10 +492,12 @@ Executes a transfer for a fixed delegation.
 | 1       |          | SubscriptionAuthority PDA                  |
 | 2       | writable | Delegator's ATA                            |
 | 3       | writable | Receiver's ATA                             |
-| 4       |          | Token Program                              |
-| 5       | signer   | Delegatee (beneficiary)                    |
-| 6       |          | Event authority PDA                        |
-| 7       |          | This program (for self-CPI event emission) |
+| 4       |          | Token mint                                 |
+| 5       |          | Token Program                              |
+| 6       | signer   | Delegatee (beneficiary)                    |
+| 7       |          | Event authority PDA                        |
+| 8       |          | This program (for self-CPI event emission) |
+| 9+      |          | Optional Token-2022 transfer-hook accounts |
 
 **Parameters (in instruction data):**
 
@@ -518,10 +524,12 @@ Executes a transfer for a recurring delegation.
 | 1       |          | SubscriptionAuthority PDA                  |
 | 2       | writable | Delegator's ATA                            |
 | 3       | writable | Receiver's ATA                             |
-| 4       |          | Token Program                              |
-| 5       | signer   | Delegatee (beneficiary)                    |
-| 6       |          | Event authority PDA                        |
-| 7       |          | This program (for self-CPI event emission) |
+| 4       |          | Token mint                                 |
+| 5       |          | Token Program                              |
+| 6       | signer   | Delegatee (beneficiary)                    |
+| 7       |          | Event authority PDA                        |
+| 8       |          | This program (for self-CPI event emission) |
+| 9+      |          | Optional Token-2022 transfer-hook accounts |
 
 **Parameters (in instruction data):**
 

--- a/docs/002-subscriptions-architecture.md
+++ b/docs/002-subscriptions-architecture.md
@@ -116,7 +116,7 @@ ADR-001 provides the core delegation infrastructure. Plans add a subscription mo
 5. **Management Flexibility**
     - `update_plan` allows:
         - Set status to Sunset (stop accepting new subscribers; effectively terminal — status/end_ts/metadata can no longer change, though the owner may still remove existing pullers; requires non-zero end_ts)
-        - Set end_ts (graceful discontinuation, or 0 to remove expiry; cannot be 0 when sunsetting)
+        - Shorten a finite end_ts (graceful discontinuation; a finite end_ts can never be extended or cleared — `PlanEndTsCannotExtend`; 0 is valid only when the plan already has no expiry)
         - Update pullers array (change authorized callers)
         - Update metadata_uri (change plan description/branding)
     - Without modifying core terms (mint, terms, destinations)
@@ -161,7 +161,7 @@ When a subscriber subscribes, the plan's `PlanTerms` (amount, period_hours, crea
 
 **What SubscriptionDelegation Stores:**
 
-- `header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber, `init_id` = the subscriber's SubscriptionAuthority incarnation at subscribe time) — `resume`/abandon paths compare this `init_id` against the live authority to detect a stale (closed-and-reinitialized) authority
+- `header` (delegator = subscriber, delegatee = plan_pda, payer = rent payer: the subscriber, or a sponsor when provided, `init_id` = the subscriber's SubscriptionAuthority incarnation at subscribe time) — `resume`/abandon paths compare this `init_id` against the live authority to detect a stale (closed-and-reinitialized) authority
 - `terms` - snapshot of plan's PlanTerms (amount, period_hours, created_at)
 - `amount_pulled_in_period` - tracking for the current billing period
 - `current_period_start_ts` - start of the current billing period
@@ -269,7 +269,7 @@ The `destinations` array controls where pulled funds can be sent. If the array i
 
 Per-subscriber billing state linked to a Plan:
 
-- `header`: 107 bytes - shared `Header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber)
+- `header`: 107 bytes - shared `Header` (delegator = subscriber, delegatee = plan_pda, payer = subscriber or sponsor)
 - `terms`: 24 bytes (`PlanTerms`) - snapshot of the plan's billing terms at subscribe time
 - `amount_pulled_in_period`: 8 bytes (`u64`) - tokens transferred in the current billing period
 - `current_period_start_ts`: 8 bytes (`i64`) - start of the current billing period
@@ -385,7 +385,7 @@ Subscriber subscribes to a Plan, creating a lightweight `SubscriptionDelegation`
 
 | Account | Type             | Description                                                   |
 | ------- | ---------------- | ------------------------------------------------------------- |
-| 0       | signer, writable | Subscriber (pays rent)                                        |
+| 0       | signer, writable | Subscriber                                                    |
 | 1       |                  | Merchant (Plan owner)                                         |
 | 2       |                  | Plan PDA being subscribed to                                  |
 | 3       | writable         | SubscriptionDelegation PDA being created                      |
@@ -393,11 +393,14 @@ Subscriber subscribes to a Plan, creating a lightweight `SubscriptionDelegation`
 | 5       |                  | System program                                                |
 | 6       |                  | Event authority PDA                                           |
 | 7       |                  | This program (for self-CPI event emission)                    |
+| 8       | signer, writable | Payer (optional; sponsor funds rent, defaults to subscriber)  |
 
 **Parameters (SubscribeData):**
 
 - `plan_id: u64` - The plan's identifier (used with merchant to derive plan PDA)
 - `plan_bump: u8` - The plan PDA's bump seed (avoids on-chain `find_program_address`)
+- `expected_mint`, `expected_amount`, `expected_period_hours`, `expected_created_at` - the plan terms the subscriber consented to; mismatch with the live plan fails with `PlanTermsMismatch`
+- `expected_subscription_authority_init_id: i64` - the SA `init_id` the subscriber consented to; mismatch fails with `StaleSubscriptionAuthority`
 
 **Process:**
 
@@ -406,11 +409,12 @@ Subscriber subscribes to a Plan, creating a lightweight `SubscriptionDelegation`
 3. Validate subscriber's SubscriptionAuthority PDA exists and matches the plan's mint (else `MintMismatch`)
 4. Derive SubscriptionDelegation PDA from `["subscription", plan_pda, subscriber]`
 5. Check subscription doesn't already exist (else `AlreadySubscribed`)
-6. Create SubscriptionDelegation account with:
-    - `header.delegator = subscriber`, `header.delegatee = plan_pda`, `header.payer = subscriber`
+6. Verify the live plan terms match the `expected_*` consent fields (else `PlanTermsMismatch`) and the SA `init_id` matches `expected_subscription_authority_init_id` (else `StaleSubscriptionAuthority`)
+7. Create SubscriptionDelegation account with:
+    - `header.delegator = subscriber`, `header.delegatee = plan_pda`, `header.payer = rent payer (subscriber or sponsor)`
     - `terms = plan.data.terms` (snapshot of plan's billing terms)
     - `amount_pulled_in_period = 0`, `current_period_start_ts = current_ts`, `expires_at_ts = 0`
-7. Emit `SubscriptionCreatedEvent` via self-CPI
+8. Emit `SubscriptionCreatedEvent` via self-CPI
 
 ---
 
@@ -523,8 +527,8 @@ Subscriber resumes a cancelled subscription by clearing `expires_at_ts`. This do
 4. Verify the plan account is still program-owned (else `PlanClosed`)
 5. Verify the plan has not reached `end_ts` (else `PlanExpired`)
 6. Verify the live plan terms still match the subscription's snapshotted terms (else `PlanTermsMismatch`)
-7. Verify `expires_at_ts > current_ts` (else `SubscriptionCancelled`)
-8. Verify the SubscriptionAuthority is owned by the subscriber (else `Unauthorized`), its mint matches the plan (else `MintMismatch`), and its `init_id` equals the subscription's recorded `init_id` (else `StaleSubscriptionAuthority`) — prevents resuming against a closed-and-reinitialized authority.
+7. Verify the SubscriptionAuthority is owned by the subscriber (else `Unauthorized`), its mint matches the plan (else `MintMismatch`), and its `init_id` equals the subscription's recorded `init_id` (else `StaleSubscriptionAuthority`) — prevents resuming against a closed-and-reinitialized authority.
+8. Verify `expires_at_ts > current_ts` (else `SubscriptionCancelled`)
 
 **Process:**
 

--- a/docs/003-versioning-migration-architecture.md
+++ b/docs/003-versioning-migration-architecture.md
@@ -23,7 +23,7 @@ flowchart TD
 
 ### Tier 1 - Lazy update (transparent)
 
-Triggered automatically during normal instructions (transfer, cancel, revoke).
+Triggered automatically during normal instructions (transfer, cancel, resume).
 Transforms raw bytes in-place without realloc or extra accounts.
 
 - **When**: field value transforms, new fields fitting in existing padding

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -3811,7 +3811,7 @@
       }
     ],
     "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44",
-    "version": "0.1.0"
+    "version": "0.4.0"
   },
   "standard": "codama",
   "version": "1.0.0"

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ setup-hooks:
     git config core.hooksPath .githooks
     @echo "✓ Git hooks configured"
 
-# Print program ID from keypair
+# Print program ID from declare_id! in program source
 program-id:
     @sed -n 's/.*declare_id!("\([^"]*\)").*/\1/p' "{{program_dir}}/src/lib.rs"
 

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -83,7 +83,7 @@ Our [Surfpool 101 Series](https://www.youtube.com/playlist?list=PL0FMgRjJMRzO1Fd
 $ surfpool ls
 Name                                    Description
 deployment                              Deploy programs
-surfnet-setup                           Install subscriptions program at canonical address
+surfnet-setup                           Install program at canonical address on surfnet (no keypair required)
 ```
 
 ### Start a Surfnet, automatically executing the `deployment` runbook on program recompile:

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,29 +1,32 @@
 # Subscriptions Webapp
 
-Web interface for managing Solana token delegations (USDC). Connects to the Subscriptions on-chain program, allowing users to create, manage, and revoke delegations with controlled spending limits and time-based expiry.
+Web interface for managing Solana token delegations and pull-payment subscriptions. Connects to the Subscriptions on-chain program (SPL Token and Token-2022 mints), allowing users to create, manage, and revoke delegations with controlled spending limits and time-based expiry, and to publish and subscribe to merchant billing plans.
 
 ## Features
 
-- **Wallet Connection** - Solana wallet integration (tested with Phantom) with real-time SOL and USDC balance display
-- **Create Delegations** - Three delegation types:
+- **Wallet Connection** - Solana wallet integration (tested with Phantom) with real-time SOL and token balance display
+- **Create Delegations** - Two delegation types:
     - **Fixed**: one-time total amount with an expiry date
-    - **Recurring**: per-period amount with configurable period length
-    - **Subscription**: plan-based recurring billing with merchant-defined terms
+    - **Recurring**: per-period amount with configurable period length, optional start-on-landing (`startTs = 0`)
+- **Marketplace** - Browse merchant plans and subscribe; manage subscriptions (cancel, resume, delete expired) under My Subscriptions
+- **Plans** - Create, edit, sunset, and delete billing plans; manage pullers and destination accounts; collect payments
 - **View Delegations** - Separate tabs for outgoing (delegator) and incoming (delegatee) delegations, with active/expired filtering
-- **Revoke Delegations** - Cancel active outgoing delegations on-chain
+- **Revoke & Reclaim** - Cancel active outgoing delegations, reclaim rent from abandoned delegations, and disable delegations by closing the Subscription Authority (feature-gated per network)
 - **Transfer Under Delegation** - Delegatees can withdraw amounts within the delegation rules
 - **SA Initialization** - Subscription Authority Account setup flow required before creating delegations
-- **Dev Faucet** - Request SOL/USDC airdrops for local testing (hidden on mainnet)
+- **Dev Tooling** - Faucet for SOL/test-token airdrops, first-run setup wizard, program deploy page, and time travel (hidden on mainnet)
 - **Theme Support** - Dark/light mode toggle
 
 ## Scripts
 
-| Script            | Description                                           |
-| ----------------- | ----------------------------------------------------- |
-| `npm run dev`     | Start the Vite dev server with hot module replacement |
-| `npm run build`   | Type-check with TypeScript and build for production   |
-| `npm run test`    | Run the Node test runner over `test/*.test.ts`        |
-| `npm run preview` | Preview the production build locally                  |
+Run from `webapp/` (or from the root with `pnpm --filter webapp <script>`):
+
+| Script         | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `pnpm dev`     | Start the Vite dev server with hot module replacement |
+| `pnpm build`   | Type-check with TypeScript and build for production   |
+| `pnpm test`    | Run the Node test runner over `test/*.test.ts`        |
+| `pnpm preview` | Preview the production build locally                  |
 
 From the project root, `just webapp-run` builds the program and clients, starts a local validator + API, and launches the webapp.
 


### PR DESCRIPTION
## Summary
- Bump `subscriptions` crate and `@solana/subscriptions` from `0.4.0-rc.2` to `0.4.0`
- Align workspace/program version to `0.4.0` so the on-chain IDL metadata reports the real program version (was `0.1.0`); binary hash unaffected (version is not embedded in the .so)
- Finalize all three changelogs for the 2026-07-13 mainnet deploy
- Renumber program versions into lockstep with the clients: deployed release (commit `0221a37`, mainnet since 2026-06-01) is `program-v0.3.0`, this release is `program-v0.4.0`
- Full documentation re-verification against code (README, TS client README, ADRs 001-003, CLAUDE.md, justfile, runbooks, webapp README): transfer account tables, subscribe/close/revoke account+parameter lists, extension-guard removal changelog entry, feature lists, and stale version references

## Test Plan
- `just check` — fmt + lint pass
- `just unit-test` — 59/59 pass
- `just generate-idl && pnpm run generate-clients` — only the IDL version field changes, no generated-client drift
- CI runs the full suite including integration tests

## Breaking Changes
- None in this PR itself (metadata/docs only). The 0.4.0 release train it finalizes carries the breaking changes already documented in the changelogs (event wire format, `updatePlan`/`resumeSubscription` accounts); those ship with the mainnet deploy.

## Release sequence (after merge)
1. Run `Release` workflow (mainnet) from main → Squads buffers
2. Squads proposal → approve → execute (target 2026-07-13)
3. `just verify-mainnet`; tag `program-v0.4.0` at the release commit, backfill `program-v0.3.0` at `0221a37`; retarget the existing "Subscriptions Program v0.4.0" GitHub release to `program-v0.4.0` and delete the old `v0.4.0` tag
4. Publish Rust crate + npm package (stable `0.4.0`, npm `latest`)
5. Merge solana-com docs PR solana-foundation/solana-com#1562
