### PR TITLE
feat(webapp): enable 0.4.0 features on stable networks

### DIFF
--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -58,9 +58,9 @@ const SOAK_FEATURES: Features = {
 };
 
 const STABLE_FEATURES: Features = {
-    revokeAbandonedDelegation: false,
-    revokeSubscriptionAuthority: false,
-    startNowRecurringDelegation: false,
+    revokeAbandonedDelegation: true,
+    revokeSubscriptionAuthority: true,
+    startNowRecurringDelegation: true,
 };
 
 export const FEATURES: Record<Network, Features> = {


### PR DESCRIPTION
## Summary
- Flip the webapp `STABLE_FEATURES` gates to `true`: `revokeAbandonedDelegation`, `revokeSubscriptionAuthority`, `startNowRecurringDelegation`
- Enables the reclaim-abandoned, disable-delegations (close Subscription Authority), and start-on-landing flows on mainnet/testnet UI

## Merge gate
**Hold until the `program-v0.4.0` mainnet deploy executes (target 2026-07-13).** These flows call v0.4.0 instructions; flipping early would surface UI actions the deployed v0.3.0 program rejects. Mark ready + merge right after `just verify-mainnet` passes.

## Test Plan
- `pnpm --filter webapp build` — type-check + build pass
- Flows already exercised on devnet, which runs the v0.4.0 binary with the same features enabled via `SOAK_FEATURES`