### PR TITLE
feat(program): support gasless create_plan via optional payer

### DIFF
--- a/clients/typescript/src/constants.ts
+++ b/clients/typescript/src/constants.ts
@@ -12,9 +12,9 @@ export const ZERO_ADDRESS =
 
 /** Byte offset of the account discriminator in the Header struct. */
 export const DISCRIMINATOR_OFFSET = 0;
-/** Byte offset of the delegator pubkey in the Header struct. */
+/** Byte offset of the delegator address in the Header struct. */
 export const DELEGATOR_OFFSET = 3;
-/** Byte offset of the delegatee pubkey in the Header struct. */
+/** Byte offset of the delegatee address in the Header struct. */
 export const DELEGATEE_OFFSET = 35;
 
 /** Byte size of a u64 value (used in nonce encoding). */
@@ -38,7 +38,7 @@ export const PLAN_SIZE = 491;
 /** On-chain SubscriptionDelegation account size in bytes: header(107) + terms(24) + pulled(8) + periodStart(8) + expiresAt(8). */
 export const SUBSCRIPTION_SIZE = 155;
 
-/** Byte offset of the owner pubkey in a Plan account. */
+/** Byte offset of the owner address in a Plan account. */
 export const PLAN_OWNER_OFFSET = 1;
 
 /** Maximum number of destination addresses in a Plan. */

--- a/clients/typescript/src/plugin.ts
+++ b/clients/typescript/src/plugin.ts
@@ -237,6 +237,7 @@ export type CreatePlanInput = WithProgramAddress & {
     metadataUri: string;
     mint: Address;
     owner: TransactionSigner;
+    payer?: TransactionSigner;
     periodHours: bigint | number;
     planId: bigint | number;
     pullers: Address[];
@@ -566,27 +567,30 @@ export async function getCreatePlanOverlayInstructionAsync(input: CreatePlanInpu
         pdaConfig(input.programAddress),
     );
 
-    return getCreatePlanInstruction(
-        {
-            merchant: input.owner,
-            planData: {
-                destinations,
-                endTs: input.endTs,
-                metadataUri: input.metadataUri,
-                mint: input.mint,
-                planId: input.planId,
-                pullers,
-                terms: {
-                    amount: input.amount,
-                    createdAt: 0n,
-                    periodHours: input.periodHours,
+    return appendPayer(
+        getCreatePlanInstruction(
+            {
+                merchant: input.owner,
+                planData: {
+                    destinations,
+                    endTs: input.endTs,
+                    metadataUri: input.metadataUri,
+                    mint: input.mint,
+                    planId: input.planId,
+                    pullers,
+                    terms: {
+                        amount: input.amount,
+                        createdAt: 0n,
+                        periodHours: input.periodHours,
+                    },
                 },
+                planPda,
+                tokenMint: input.mint,
+                tokenProgram: input.tokenProgram,
             },
-            planPda,
-            tokenMint: input.mint,
-            tokenProgram: input.tokenProgram,
-        },
-        pdaConfig(input.programAddress),
+            pdaConfig(input.programAddress),
+        ),
+        input.payer,
     );
 }
 
@@ -862,6 +866,7 @@ export function subscriptionsProgram() {
                         getCreatePlanOverlayInstructionAsync({
                             ...input,
                             owner: input.owner ?? client.identity,
+                            payer: input.payer ?? (client.payer === client.identity ? undefined : client.payer),
                         }),
                     ),
                 createRecurringDelegation: input =>

--- a/clients/typescript/src/transfer-hook.ts
+++ b/clients/typescript/src/transfer-hook.ts
@@ -34,7 +34,7 @@ const EXTRA_ACCOUNT_METAS_SEED = 'extra-account-metas';
 const TLV_HEADER_LEN = 12; // u64 discriminator + u32 length
 const POD_SLICE_COUNT_LEN = 4;
 const EXTRA_ACCOUNT_META_LEN = 35;
-const PUBKEY_LEN = 32;
+const ADDRESS_LEN = 32;
 const PDA_PROGRAM_INDEX_OFFSET = 1 << 7;
 // sha256("spl-transfer-hook-interface:execute")[..8]
 const EXECUTE_DISCRIMINATOR = Uint8Array.from([0x69, 0x25, 0x65, 0xc5, 0x4b, 0xfb, 0x66, 0x1a]);
@@ -120,7 +120,7 @@ async function unpackSeeds(
     return seeds;
 }
 
-async function unpackPubkeyData(
+async function unpackAddressData(
     config: ReadonlyUint8Array,
     previous: TransferHookAccount[],
     instructionData: Uint8Array,
@@ -129,14 +129,14 @@ async function unpackPubkeyData(
     const rest = config.subarray(1);
     if (config[0] === 1) {
         const offset = rest[0];
-        return addressDecoder.decode(instructionData.subarray(offset, offset + PUBKEY_LEN));
+        return addressDecoder.decode(instructionData.subarray(offset, offset + ADDRESS_LEN));
     }
     if (config[0] === 2) {
         const [accountIndex, offset] = [rest[0], rest[1]];
         const data = await fetchData(rpc, previous[accountIndex].address);
-        return addressDecoder.decode(data.subarray(offset, offset + PUBKEY_LEN));
+        return addressDecoder.decode(data.subarray(offset, offset + ADDRESS_LEN));
     }
-    throw new Error('transfer hook: invalid pubkey data');
+    throw new Error('transfer hook: invalid address data');
 }
 
 async function resolveMeta(
@@ -151,7 +151,7 @@ async function resolveMeta(
         return { address: addressDecoder.decode(meta.addressConfig), role };
     }
     if (meta.discriminator === 2) {
-        return { address: await unpackPubkeyData(meta.addressConfig, previous, instructionData, rpc), role };
+        return { address: await unpackAddressData(meta.addressConfig, previous, instructionData, rpc), role };
     }
     const programId =
         meta.discriminator === 1 ? hookProgram : previous[meta.discriminator - PDA_PROGRAM_INDEX_OFFSET].address;

--- a/docs/001-program-architecture.md
+++ b/docs/001-program-architecture.md
@@ -161,7 +161,7 @@ Delegates discover their delegations via `getProgramAccounts` with `memcmp` filt
 ```typescript
 // Delegatee discovers Bob's delegations:
 getProgramAccounts(PROGRAM_ID, {
-    filters: [{ memcmp: { offset: DELEGATEE_OFFSET, bytes: bobPubkey } }],
+    filters: [{ memcmp: { offset: DELEGATEE_OFFSET, bytes: bobAddress } }],
 });
 ```
 

--- a/docs/002-subscriptions-architecture.md
+++ b/docs/002-subscriptions-architecture.md
@@ -289,13 +289,20 @@ Per-subscriber billing state linked to a Plan:
 
 Merchant publishes a Plan with subscription terms.
 
-| Account | Type             | Description           |
-| ------- | ---------------- | --------------------- |
-| 0       | signer, writable | Merchant (Plan owner) |
-| 1       | writable         | Plan PDA to create    |
-| 2       |                  | Token mint            |
-| 3       |                  | System program        |
-| 4       |                  | Token program         |
+| Account | Type             | Description                     |
+| ------- | ---------------- | ------------------------------- |
+| 0       | signer, writable | Merchant (Plan owner)           |
+| 1       | writable         | Plan PDA to create              |
+| 2       |                  | Token mint                      |
+| 3       |                  | System program                  |
+| 4       |                  | Token program                   |
+| 5       | signer, writable | Optional payer/sponsor for rent |
+
+When account 5 is supplied it funds plan rent (gasless create); the merchant
+still owns the plan. **Security:** sponsored rent is not recoverable by the
+payer — `delete_plan` refunds the owner, not the payer. Sponsor only merchants
+you trust and gate sponsorship off-chain; never expose it through an open
+relayer, which would let merchants siphon rent by creating and deleting plans.
 
 **Parameters (PlanData):**
 
@@ -372,6 +379,8 @@ Plan owner deletes an expired plan, closing the account and reclaiming rent. Doe
 1. Verify caller is Plan owner (else `NotPlanOwner`)
 2. Verify plan is expired: `end_ts != 0 && current_ts > end_ts` (else `PlanNotExpired`)
 3. Close account: zero all data, transfer lamports to owner
+
+Rent always returns to the owner, even when a sponsor funded creation via `create_plan`'s optional payer. The payer does not recover sponsored rent.
 
 **Lifecycle paths to deletion:**
 

--- a/program/src/constants.rs
+++ b/program/src/constants.rs
@@ -19,26 +19,26 @@ pub const TOKEN_2022_MINT_DISCRIMINATOR: u8 = 0x01;
 /// Token-2022 discriminator value indicating a **token account**.
 pub const TOKEN_2022_TOKEN_ACCOUNT_DISCRIMINATOR: u8 = 0x02;
 
-/// Byte offset where the `mint` pubkey begins in an SPL token account's data.
+/// Byte offset where the `mint` address begins in an SPL token account's data.
 pub const TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
 
-/// Byte offset one past the end of the `mint` pubkey (i.e., `MINT_OFFSET + 32`).
+/// Byte offset one past the end of the `mint` address (i.e., `MINT_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_MINT_END: usize = TOKEN_ACCOUNT_MINT_OFFSET + 32;
 
-/// Byte offset where the `owner` pubkey begins in an SPL token account's data.
+/// Byte offset where the `owner` address begins in an SPL token account's data.
 pub const TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 
-/// Byte offset one past the end of the `owner` pubkey (i.e., `OWNER_OFFSET + 32`).
+/// Byte offset one past the end of the `owner` address (i.e., `OWNER_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_OWNER_END: usize = TOKEN_ACCOUNT_OWNER_OFFSET + 32;
 
 /// Byte offset of the `delegate` `COption` tag in an SPL token account's data.
-/// `0` means no delegate; `1` means the 32-byte pubkey at [`TOKEN_ACCOUNT_DELEGATE_OFFSET`] is set.
+/// `0` means no delegate; `1` means the 32-byte address at [`TOKEN_ACCOUNT_DELEGATE_OFFSET`] is set.
 pub const TOKEN_ACCOUNT_DELEGATE_TAG_OFFSET: usize = 72;
 
-/// Byte offset where the `delegate` pubkey begins (immediately after its 4-byte `COption` tag).
+/// Byte offset where the `delegate` address begins (immediately after its 4-byte `COption` tag).
 pub const TOKEN_ACCOUNT_DELEGATE_OFFSET: usize = TOKEN_ACCOUNT_DELEGATE_TAG_OFFSET + 4;
 
-/// Byte offset one past the end of the `delegate` pubkey (i.e., `DELEGATE_OFFSET + 32`).
+/// Byte offset one past the end of the `delegate` address (i.e., `DELEGATE_OFFSET + 32`).
 pub const TOKEN_ACCOUNT_DELEGATE_END: usize = TOKEN_ACCOUNT_DELEGATE_OFFSET + 32;
 
 /// Byte offset of the `decimals` field in an SPL Token / Token-2022 base mint.

--- a/program/src/instructions/create_plan.rs
+++ b/program/src/instructions/create_plan.rs
@@ -105,6 +105,11 @@ pub const DISCRIMINATOR: &u8 = &7;
 ///
 /// Validates the plan data, creates the plan account via CPI, and initializes
 /// its fields including owner, status, and the embedded [`PlanData`].
+///
+/// A trailing `payer` account, if supplied, funds plan rent while the merchant
+/// still owns the plan. Sponsored rent is NOT recoverable by the payer:
+/// `delete_plan` refunds the owner, not the payer. Only sponsor merchants you
+/// trust; never expose plan-creation sponsorship through an open relayer.
 pub fn process(accounts: &mut [AccountView], data: &PlanData) -> ProgramResult {
     let current_ts = Clock::get()?.unix_timestamp;
     data.validate(current_ts)?;

--- a/program/src/instructions/helpers/plan.rs
+++ b/program/src/instructions/helpers/plan.rs
@@ -1,8 +1,9 @@
 use pinocchio::{cpi::Seed, error::ProgramError, AccountView};
 
 use crate::{
-    find_plan_pda, state::plan::Plan, AccountCheck, MintInterface, ProgramAccount, ProgramAccountInit, SignerAccount,
-    SubscriptionsError, SystemAccount, TokenProgramInterface, WritableAccount,
+    find_plan_pda, helpers::system::resolve_optional_payer, state::plan::Plan, AccountCheck, MintInterface,
+    ProgramAccount, ProgramAccountInit, SignerAccount, SubscriptionsError, SystemAccount, TokenProgramInterface,
+    WritableAccount,
 };
 
 /// Validated accounts for the [`CreatePlan`](crate::SubscriptionsInstruction::CreatePlan) instruction.
@@ -12,13 +13,15 @@ pub struct CreatePlanAccounts<'a> {
     pub token_mint: &'a AccountView,
     pub system_program: &'a AccountView,
     pub token_program: &'a AccountView,
+    /// The account funding rent. Defaults to `merchant` if no extra account is provided.
+    pub payer: &'a AccountView,
 }
 
 impl<'a> TryFrom<&'a mut [AccountView]> for CreatePlanAccounts<'a> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'a mut [AccountView]) -> Result<Self, Self::Error> {
-        let [merchant, plan_pda, token_mint, system_program, token_program] = accounts else {
+        let [merchant, plan_pda, token_mint, system_program, token_program, rem @ ..] = accounts else {
             return Err(SubscriptionsError::NotEnoughAccountKeys.into());
         };
 
@@ -29,7 +32,9 @@ impl<'a> TryFrom<&'a mut [AccountView]> for CreatePlanAccounts<'a> {
         TokenProgramInterface::check(token_program)?;
         SystemAccount::check(system_program)?;
 
-        Ok(Self { merchant, plan_pda, token_mint, system_program, token_program })
+        let payer = resolve_optional_payer(merchant, rem)?;
+
+        Ok(Self { merchant, plan_pda, token_mint, system_program, token_program, payer })
     }
 }
 
@@ -57,7 +62,7 @@ pub fn create_plan_account(accounts: &CreatePlanAccounts, plan_id: u64) -> Resul
         Seed::from(&bump_bytes[..]),
     ];
 
-    ProgramAccount::init::<()>(accounts.merchant, accounts.plan_pda, &seeds, Plan::LEN)?;
+    ProgramAccount::init::<()>(accounts.payer, accounts.plan_pda, &seeds, Plan::LEN)?;
 
     Ok(bump)
 }

--- a/program/src/instructions/helpers/transfer_utils.rs
+++ b/program/src/instructions/helpers/transfer_utils.rs
@@ -37,7 +37,7 @@ pub fn check_token_account_mint(data: &[u8], expected: &Address) -> Result<(), S
     Ok(())
 }
 
-/// Reads the owner pubkey from raw SPL token account data.
+/// Reads the owner address from raw SPL token account data.
 pub fn get_token_account_owner(data: &[u8]) -> Result<Address, SubscriptionsError> {
     if data.len() < TOKEN_ACCOUNT_OWNER_END {
         return Err(SubscriptionsError::InvalidAccountData);

--- a/program/src/state/header.rs
+++ b/program/src/state/header.rs
@@ -20,13 +20,13 @@ pub const VERSION_OFFSET: usize = 1;
 /// Byte offset of the PDA bump seed.
 pub const BUMP_OFFSET: usize = 2;
 
-/// Byte offset of the delegator pubkey.
+/// Byte offset of the delegator address.
 pub const DELEGATOR_OFFSET: usize = 3;
 
-/// Byte offset of the delegatee pubkey.
+/// Byte offset of the delegatee address.
 pub const DELEGATEE_OFFSET: usize = 35;
 
-/// Byte offset of the payer pubkey (who funded the account creation).
+/// Byte offset of the payer address (who funded the account creation).
 pub const PAYER_OFFSET: usize = 67;
 
 /// Byte offset of the init_id field.

--- a/tests/integration-tests/src/test_create_plan.rs
+++ b/tests/integration-tests/src/test_create_plan.rs
@@ -9,7 +9,7 @@ use crate::{
         asserts::TransactionResultExt,
         constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         pda::get_plan_pda,
-        utils::{current_ts, days, init_mint, setup, CreatePlan},
+        utils::{current_ts, days, init_mint, init_wallet, setup, CreatePlan},
     },
 };
 
@@ -57,6 +57,36 @@ fn create_plan_happy_path() {
     assert_eq!(dests[0].to_bytes(), dest.to_bytes());
     assert_eq!(pulls[0].to_bytes(), puller.to_bytes());
     assert_ne!(bump, 0);
+}
+
+#[test]
+fn create_plan_gasless_sponsor_funds_rent() {
+    let (litesvm, merchant) = &mut setup();
+    let sponsor = init_wallet(litesvm, 10_000_000_000);
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, None, &[]);
+    let dest = Pubkey::new_unique();
+
+    let merchant_before = litesvm.get_account(&merchant.pubkey()).unwrap().lamports;
+    let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    let (res, plan_pda) = CreatePlan::new(litesvm, merchant, mint)
+        .plan_id(1)
+        .amount(1_000_000)
+        .period_hours(720)
+        .destinations(vec![dest])
+        .sponsor(&sponsor)
+        .execute();
+    res.assert_ok();
+
+    let account = litesvm.get_account(&plan_pda).unwrap();
+    let rent = account.lamports;
+    let owner = Plan::load(&account.data).unwrap().owner;
+    let merchant_after = litesvm.get_account(&merchant.pubkey()).unwrap().lamports;
+    let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+
+    assert_eq!(merchant_after, merchant_before, "merchant must pay nothing for a sponsored create");
+    assert!(sponsor_before - sponsor_after >= rent, "sponsor must fund the plan rent");
+    assert_eq!(owner.to_bytes(), merchant.pubkey().to_bytes(), "merchant still owns the sponsored plan");
 }
 
 #[test]

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -907,6 +907,7 @@ pub struct CreatePlan<'a> {
     destinations_vec: Vec<Pubkey>,
     pullers_vec: Vec<Pubkey>,
     custom_pda: Option<Pubkey>,
+    sponsor: Option<&'a Keypair>,
 }
 
 impl<'a> CreatePlan<'a> {
@@ -927,7 +928,13 @@ impl<'a> CreatePlan<'a> {
             destinations_vec: vec![],
             pullers_vec: vec![],
             custom_pda: None,
+            sponsor: None,
         }
+    }
+
+    pub fn sponsor(mut self, sponsor: &'a Keypair) -> Self {
+        self.sponsor = Some(sponsor);
+        self
     }
 
     pub fn plan_id(mut self, plan_id: u64) -> Self {
@@ -1004,7 +1011,7 @@ impl<'a> CreatePlan<'a> {
             .map(|a| a.owner)
             .unwrap_or(crate::tests::constants::TOKEN_PROGRAM_ID);
 
-        let accounts = vec![
+        let mut accounts = vec![
             AccountMeta::new(self.owner.pubkey(), true),
             AccountMeta::new(plan_pda, false),
             AccountMeta::new_readonly(mint_pubkey, false),
@@ -1012,9 +1019,17 @@ impl<'a> CreatePlan<'a> {
             AccountMeta::new_readonly(token_program, false),
         ];
 
+        let mut signers = vec![self.owner];
+        let mut fee_payer = self.owner.pubkey();
+        if let Some(sponsor) = self.sponsor {
+            accounts.push(AccountMeta::new(sponsor.pubkey(), true));
+            signers.push(sponsor);
+            fee_payer = sponsor.pubkey();
+        }
+
         let ix = Instruction { program_id: PROGRAM_ID, accounts, data };
 
-        (build_and_send_transaction(self.litesvm, &[self.owner], &self.owner.pubkey(), &ix), plan_pda)
+        (build_and_send_transaction(self.litesvm, &signers, &fee_payer, &ix), plan_pda)
     }
 }
 

--- a/webapp/api/lib/bpf-loader.ts
+++ b/webapp/api/lib/bpf-loader.ts
@@ -134,10 +134,10 @@ export function buildCloseBufferIx(buffer: Address, recipient: Address, authorit
 }
 
 export async function deriveProgramDataAddress(programId: Address): Promise<Address> {
-    const pubkeyEncoder = getAddressEncoder();
+    const addressEncoder = getAddressEncoder();
     const [pda] = await getProgramDerivedAddress({
         programAddress: BPF_LOADER_UPGRADEABLE,
-        seeds: [pubkeyEncoder.encode(programId)],
+        seeds: [addressEncoder.encode(programId)],
     });
     return pda;
 }

--- a/webapp/api/lib/program-status.ts
+++ b/webapp/api/lib/program-status.ts
@@ -2,14 +2,14 @@ import { getAddressDecoder } from '@solana/kit';
 
 const PROGRAM_ACCOUNT_TAG = 2;
 const PROGRAM_DATA_OFFSET = 4;
-const PROGRAM_DATA_PUBKEY_LEN = 32;
-const PROGRAM_ACCOUNT_MIN_LEN = PROGRAM_DATA_OFFSET + PROGRAM_DATA_PUBKEY_LEN;
+const PROGRAM_DATA_ADDRESS_LEN = 32;
+const PROGRAM_ACCOUNT_MIN_LEN = PROGRAM_DATA_OFFSET + PROGRAM_DATA_ADDRESS_LEN;
 const SLOT_OFFSET = 4;
 const SLOT_SIZE = 8;
 const AUTHORITY_FLAG_OFFSET = 12;
-const AUTHORITY_PUBKEY_OFFSET = 13;
-const AUTHORITY_PUBKEY_LEN = 32;
-const HEADER_SIZE = AUTHORITY_PUBKEY_OFFSET + AUTHORITY_PUBKEY_LEN;
+const AUTHORITY_ADDRESS_OFFSET = 13;
+const AUTHORITY_ADDRESS_LEN = 32;
+const HEADER_SIZE = AUTHORITY_ADDRESS_OFFSET + AUTHORITY_ADDRESS_LEN;
 
 export interface ProgramStatus {
     deployed: boolean;
@@ -71,7 +71,7 @@ export async function checkProgramStatus(rpcUrl: string, programAddress: string)
     if (data.length < PROGRAM_ACCOUNT_MIN_LEN || data[0] !== PROGRAM_ACCOUNT_TAG) return notDeployed;
 
     const addressDecoder = getAddressDecoder();
-    const programDataBytes = data.slice(PROGRAM_DATA_OFFSET, PROGRAM_DATA_OFFSET + PROGRAM_DATA_PUBKEY_LEN);
+    const programDataBytes = data.slice(PROGRAM_DATA_OFFSET, PROGRAM_DATA_OFFSET + PROGRAM_DATA_ADDRESS_LEN);
     const programDataAddress = addressDecoder.decode(programDataBytes);
 
     const pdResult = (await rpcCall(rpcUrl, 'getAccountInfo', [
@@ -100,7 +100,7 @@ export async function checkProgramStatus(rpcUrl: string, programAddress: string)
     let upgradeAuthority: string | null = null;
     if (hasAuthority && pdData.length >= HEADER_SIZE) {
         upgradeAuthority = addressDecoder.decode(
-            pdData.slice(AUTHORITY_PUBKEY_OFFSET, AUTHORITY_PUBKEY_OFFSET + AUTHORITY_PUBKEY_LEN),
+            pdData.slice(AUTHORITY_ADDRESS_OFFSET, AUTHORITY_ADDRESS_OFFSET + AUTHORITY_ADDRESS_LEN),
         );
     }
 

--- a/webapp/src/lib/bpf-loader-browser.ts
+++ b/webapp/src/lib/bpf-loader-browser.ts
@@ -194,11 +194,11 @@ export function buildCloseProgramIx(
 }
 
 export async function deriveProgramDataAddress(programId: Address | string): Promise<Address> {
-    const pubkeyEncoder = getAddressEncoder();
+    const addressEncoder = getAddressEncoder();
     const addr = typeof programId === 'string' ? address(programId) : programId;
     const [pda] = await getProgramDerivedAddress({
         programAddress: BPF_LOADER_UPGRADEABLE,
-        seeds: [pubkeyEncoder.encode(addr)],
+        seeds: [addressEncoder.encode(addr)],
     });
     return pda;
 }


### PR DESCRIPTION
> Stacked PR 1/3 — split from #191 for easier review. Merge order: this → #205 → #206.

## Summary
- Add an optional trailing `payer` account to `create_plan`; when present it funds plan rent (gasless create) while the merchant remains the plan owner. Mirrors the existing sponsor pattern (`resolve_optional_payer`) used by `init_subscription_authority`, `subscribe`, and the delegation creators.
- Wire the optional `payer` through the TS SDK (`CreatePlanInput`, `appendPayer`, plugin passthrough).
- Document the security invariant: sponsored rent is **not** recoverable by the payer (`delete_plan` refunds the owner), so sponsorship must be gated off-chain to avoid a rent-siphon via create/delete cycles.

## Test Plan
- `just unit-test` → 48 passed
- `just integration-test` → 222 passed, incl. new `create_plan_gasless_sponsor_funds_rent` (asserts merchant pays nothing, sponsor funds rent, merchant still owns the plan)
- `tsc --noEmit` on the TS client → clean
- IDL + Rust client regenerate with no drift (optional payer is a hand-SDK trailing account, not in the IDL — matches `init_subscription_authority`)

## Breaking Changes
- None. No `Plan` account-layout change; existing plans and existing callers (no trailing account → merchant funds rent) are unaffected.
