### PR TITLE
fix(ci): restore pnpm vulnerability audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "subscriptions-monorepo",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -36,15 +36,5 @@
     "tsx": "^4.22.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.62.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "bn.js": "5.2.3",
-      "flatted": "3.4.2",
-      "minimatch": "9.0.9",
-      "picomatch": "4.0.4",
-      "rollup": "4.60.2",
-      "ws@^8.0.0": "8.20.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,18 @@ packages:
   - 'webapp'
   - 'webapp/api'
   - 'webapp/scripts'
+
+allowBuilds:
+  bigint-buffer: false
+  bufferutil: false
+  esbuild: true
+  unrs-resolver: true
+  utf-8-validate: false
+
+overrides:
+  bn.js: 5.2.3
+  flatted: 3.4.2
+  minimatch: 9.0.9
+  picomatch: 4.0.4
+  rollup: 4.60.2
+  ws@^8.0.0: 8.20.1


### PR DESCRIPTION
## Summary

- pin pnpm 11.13.0 so audits use npm's supported bulk advisory endpoint
- move dependency overrides to pnpm-workspace.yaml, where pnpm 11 reads workspace settings
- explicitly allow required platform-binary setup scripts and deny optional native accelerators

## Test plan

- CI=true corepack pnpm install --frozen-lockfile
- corepack pnpm audit --ignore-unfixable
- corepack pnpm format:check
- corepack pnpm lint
- corepack pnpm --filter @solana/subscriptions build
- corepack pnpm --filter webapp build
- just test-client