### PR TITLE
fix(program)!: bind resume_subscription to observed expiry

### DIFF
--- a/clients/typescript/src/plugin.ts
+++ b/clients/typescript/src/plugin.ts
@@ -290,6 +290,7 @@ export type CancelSubscriptionNowInput = WithProgramAddress & {
 };
 
 export type ResumeSubscriptionInput = WithProgramAddress & {
+    expectedExpiresAtTs: bigint;
     planPda: Address;
     subscriber: TransactionSigner;
     subscriptionPda?: Address;
@@ -709,6 +710,7 @@ export async function getResumeSubscriptionOverlayInstructionAsync(
         {
             ...(await eventAccounts(input.programAddress)),
             planPda: input.planPda,
+            resumeData: { expectedExpiresAtTs: input.expectedExpiresAtTs },
             subscriber: input.subscriber,
             subscriptionAuthority,
             subscriptionPda: input.subscriptionPda,

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -461,7 +461,13 @@ describe('Subscription Lifecycle', () => {
         const amountPulled = subAfterCancel.amountPulledInPeriod;
 
         await t.client.subscriptions.instructions
-            .resumeSubscription({ subscriber, planPda, subscriptionPda, tokenMint: t.tokenMint })
+            .resumeSubscription({
+                subscriber,
+                planPda,
+                subscriptionPda,
+                tokenMint: t.tokenMint,
+                expectedExpiresAtTs: subAfterCancel.expiresAtTs,
+            })
             .sendTransaction();
 
         const subAfterResume = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda)).data;
@@ -522,7 +528,13 @@ describe('Subscription Lifecycle', () => {
 
         await expectProgramError(
             t.client.subscriptions.instructions
-                .resumeSubscription({ subscriber, planPda, subscriptionPda, tokenMint: t.tokenMint })
+                .resumeSubscription({
+                    subscriber,
+                    planPda,
+                    subscriptionPda,
+                    tokenMint: t.tokenMint,
+                    expectedExpiresAtTs: 0n,
+                })
                 .sendTransaction(),
             SUBSCRIPTIONS_ERROR__SUBSCRIPTION_NOT_CANCELLED,
         );
@@ -568,7 +580,13 @@ describe('Subscription Lifecycle', () => {
         const attacker = await t.createFundedKeypair();
         await expectProgramError(
             t.client.subscriptions.instructions
-                .resumeSubscription({ subscriber: attacker, planPda, subscriptionPda, tokenMint: t.tokenMint })
+                .resumeSubscription({
+                    subscriber: attacker,
+                    planPda,
+                    subscriptionPda,
+                    tokenMint: t.tokenMint,
+                    expectedExpiresAtTs: 0n,
+                })
                 .sendTransaction(),
             SUBSCRIPTIONS_ERROR__INVALID_SUBSCRIPTION_AUTHORITY_PDA,
         );

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -705,6 +705,24 @@
       },
       {
         "kind": "definedTypeNode",
+        "name": "resumeData",
+        "type": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedExpiresAtTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        }
+      },
+      {
+        "kind": "definedTypeNode",
         "name": "accountDiscriminator",
         "type": {
           "kind": "enumTypeNode",
@@ -1259,6 +1277,12 @@
         "kind": "errorNode",
         "message": "A finite plan end timestamp can only be shortened, not removed or extended",
         "name": "planEndTsCannotExtend"
+      },
+      {
+        "code": 521,
+        "kind": "errorNode",
+        "message": "Subscription approval does not match the current subscription",
+        "name": "staleSubscriptionApproval"
       },
       {
         "code": 600,
@@ -3355,6 +3379,14 @@
               "endian": "le",
               "format": "u8",
               "kind": "numberTypeNode"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "resumeData",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "resumeData"
             }
           }
         ],

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -34,7 +34,7 @@ pub fn process_instruction(
         SubscriptionsInstruction::Subscribe(data) => subscribe::process(accounts, &data),
         SubscriptionsInstruction::CancelSubscription => cancel_subscription::process(accounts),
         SubscriptionsInstruction::CancelSubscriptionNow => cancel_subscription_now::process(accounts),
-        SubscriptionsInstruction::ResumeSubscription => resume_subscription::process(accounts),
+        SubscriptionsInstruction::ResumeSubscription(data) => resume_subscription::process(accounts, &data),
         SubscriptionsInstruction::RevokeSubscriptionAuthority => revoke_subscription_authority::process(accounts),
         SubscriptionsInstruction::RevokeAbandonedDelegation => revoke_abandoned_delegation::process(accounts),
         SubscriptionsInstruction::RevokeAbandonedSubscription => revoke_abandoned_subscription::process(accounts),

--- a/program/src/errors.rs
+++ b/program/src/errors.rs
@@ -89,6 +89,7 @@ impl TryFrom<u32> for SubscriptionsError {
             518 => Ok(Self::PlanAlreadyExists),
             519 => Ok(Self::PlanTermsMismatch),
             520 => Ok(Self::PlanEndTsCannotExtend),
+            521 => Ok(Self::StaleSubscriptionApproval),
             // Event errors (600-699)
             600 => Ok(Self::InvalidEventAuthority),
             601 => Ok(Self::InvalidEventData),
@@ -270,6 +271,8 @@ pub enum SubscriptionsError {
     PlanTermsMismatch,
     #[error("A finite plan end timestamp can only be shortened, not removed or extended")]
     PlanEndTsCannotExtend,
+    #[error("Subscription approval does not match the current subscription")]
+    StaleSubscriptionApproval,
 
     // --- Event errors (600--699) ---
     #[error("Invalid event authority PDA")]

--- a/program/src/instructions/mod.rs
+++ b/program/src/instructions/mod.rs
@@ -36,6 +36,7 @@ use pinocchio::error::ProgramError;
 
 use crate::event_engine::EMIT_EVENT_IX_DISC;
 use crate::instructions::create_plan::PlanData;
+use crate::instructions::resume_subscription::ResumeData;
 use crate::instructions::subscribe::SubscribeData;
 use crate::instructions::update_plan::UpdatePlanData;
 use crate::SubscriptionsError;
@@ -316,7 +317,7 @@ pub enum SubscriptionsInstruction {
         docs = "This program (for self-CPI)",
         default_value = public_key("De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44")
     ))]
-    ResumeSubscription = 13,
+    ResumeSubscription(#[codama(name = "resume_data")] ResumeData) = 13,
 
     #[codama(account(
         name = "user",
@@ -439,7 +440,10 @@ impl SubscriptionsInstruction {
             }
             cancel_subscription::DISCRIMINATOR => Ok(Self::CancelSubscription),
             cancel_subscription_now::DISCRIMINATOR => Ok(Self::CancelSubscriptionNow),
-            resume_subscription::DISCRIMINATOR => Ok(Self::ResumeSubscription),
+            resume_subscription::DISCRIMINATOR => {
+                let loaded = ResumeData::load(rest)?;
+                Ok(Self::ResumeSubscription(loaded.clone()))
+            }
             revoke_subscription_authority::DISCRIMINATOR => Ok(Self::RevokeSubscriptionAuthority),
             revoke_abandoned_delegation::DISCRIMINATOR => Ok(Self::RevokeAbandonedDelegation),
             revoke_abandoned_subscription::DISCRIMINATOR => Ok(Self::RevokeAbandonedSubscription),
@@ -466,7 +470,7 @@ impl fmt::Display for SubscriptionsInstruction {
             Self::Subscribe(_) => write!(f, "subscribe"),
             Self::CancelSubscription => write!(f, "cancel_subscription"),
             Self::CancelSubscriptionNow => write!(f, "cancel_subscription_now"),
-            Self::ResumeSubscription => write!(f, "resume_subscription"),
+            Self::ResumeSubscription(_) => write!(f, "resume_subscription"),
             Self::RevokeSubscriptionAuthority => write!(f, "revoke_subscription_authority"),
             Self::RevokeAbandonedDelegation => write!(f, "revoke_abandoned_delegation"),
             Self::RevokeAbandonedSubscription => write!(f, "revoke_abandoned_subscription"),

--- a/program/src/instructions/resume_subscription.rs
+++ b/program/src/instructions/resume_subscription.rs
@@ -1,3 +1,5 @@
+use codama::CodamaType;
+use core::mem::{size_of, transmute};
 use pinocchio::{
     error::ProgramError,
     sysvars::{clock::Clock, Sysvar},
@@ -18,13 +20,36 @@ use crate::{
 /// Instruction discriminator byte for `ResumeSubscription`.
 pub const DISCRIMINATOR: &u8 = &13;
 
+/// Instruction data payload for resuming a cancelled subscription.
+#[repr(C, packed)]
+#[derive(CodamaType, Debug, Clone)]
+pub struct ResumeData {
+    /// The `expires_at_ts` the subscriber observed when signing. The program
+    /// rejects if the live value differs, so a stale signed resume cannot clear
+    /// a later cancellation the subscriber never approved.
+    pub expected_expires_at_ts: i64,
+}
+
+impl ResumeData {
+    /// Serialized size in bytes.
+    pub const LEN: usize = size_of::<ResumeData>();
+
+    /// Zero-copy deserialize from raw instruction bytes.
+    pub fn load(data: &[u8]) -> Result<&Self, ProgramError> {
+        if data.len() != Self::LEN {
+            return Err(SubscriptionsError::InvalidInstructionData.into());
+        }
+        Ok(unsafe { &*transmute::<*const u8, *const Self>(data.as_ptr()) })
+    }
+}
+
 /// Resumes a cancelled subscription by clearing its `expires_at_ts`.
 ///
 /// Rejects when the cancellation period has elapsed, the plan account is
 /// closed, expired, or no longer matches the subscription's snapshotted terms.
 /// Period accounting (`current_period_start_ts`, `amount_pulled_in_period`) is
 /// unchanged. Emits a [`SubscriptionResumedEvent`].
-pub fn process(accounts: &mut [AccountView]) -> ProgramResult {
+pub fn process(accounts: &mut [AccountView], data: &ResumeData) -> ProgramResult {
     let accounts_struct = ResumeSubscriptionAccounts::try_from(accounts)?;
     let current_ts = Clock::get()?.unix_timestamp;
 
@@ -44,6 +69,10 @@ pub fn process(accounts: &mut [AccountView]) -> ProgramResult {
 
         if subscription.expires_at_ts == 0 {
             return Err(SubscriptionsError::SubscriptionNotCancelled.into());
+        }
+
+        if subscription.expires_at_ts != data.expected_expires_at_ts {
+            return Err(SubscriptionsError::StaleSubscriptionApproval.into());
         }
 
         if !accounts_struct.plan_pda.owned_by(&crate::ID) {

--- a/tests/integration-tests/src/test_resume_subscription.rs
+++ b/tests/integration-tests/src/test_resume_subscription.rs
@@ -213,6 +213,28 @@ fn resume_subscription_cancel_resume_cancel_across_period_boundary() {
 }
 
 #[test]
+fn resume_subscription_rejects_stale_expected_expiry() {
+    let (mut litesvm, alice, _merchant, mint, plan_pda, _plan_bump, subscription_pda) = setup_with_subscription();
+
+    CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda).execute().assert_ok();
+    let first_expires_at = {
+        let account = litesvm.get_account(&subscription_pda).unwrap();
+        SubscriptionDelegation::load(&account.data).unwrap().expires_at_ts
+    };
+
+    ResumeSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda, mint).execute().assert_ok();
+    move_clock_forward(&mut litesvm, hours(2));
+    CancelSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda).execute().assert_ok();
+
+    // A resume signed against the first (now stale) expiry must not clear the
+    // newer cancellation boundary the subscriber never re-approved.
+    ResumeSubscription::new(&mut litesvm, &alice, plan_pda, subscription_pda, mint)
+        .expected_expires_at_ts(first_expires_at)
+        .execute()
+        .assert_err(SubscriptionsError::StaleSubscriptionApproval);
+}
+
+#[test]
 fn resume_subscription_rejects_reinitialized_authority() {
     let (mut litesvm, alice, _merchant, mint, plan_pda, _plan_bump, subscription_pda) = setup_with_subscription();
 

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -1562,6 +1562,7 @@ pub struct ResumeSubscription<'a> {
     subscription_pda: Pubkey,
     mint: Pubkey,
     subscription_authority: Option<Pubkey>,
+    expected_expires_at_ts: Option<i64>,
 }
 
 impl<'a> ResumeSubscription<'a> {
@@ -1572,11 +1573,24 @@ impl<'a> ResumeSubscription<'a> {
         subscription_pda: Pubkey,
         mint: Pubkey,
     ) -> Self {
-        Self { litesvm, subscriber, plan_pda, subscription_pda, mint, subscription_authority: None }
+        Self {
+            litesvm,
+            subscriber,
+            plan_pda,
+            subscription_pda,
+            mint,
+            subscription_authority: None,
+            expected_expires_at_ts: None,
+        }
     }
 
     pub fn subscription_authority(mut self, authority: Pubkey) -> Self {
         self.subscription_authority = Some(authority);
+        self
+    }
+
+    pub fn expected_expires_at_ts(mut self, ts: i64) -> Self {
+        self.expected_expires_at_ts = Some(ts);
         self
     }
 
@@ -1587,6 +1601,11 @@ impl<'a> ResumeSubscription<'a> {
             .subscription_authority
             .unwrap_or_else(|| get_subscription_authority_pda(&self.subscriber.pubkey(), &self.mint).0);
 
+        let expected_expires_at_ts = self.expected_expires_at_ts.unwrap_or_else(|| {
+            let account = self.litesvm.get_account(&self.subscription_pda).unwrap();
+            crate::SubscriptionDelegation::load(&account.data).unwrap().expires_at_ts
+        });
+
         let accounts = vec![
             AccountMeta::new_readonly(self.subscriber.pubkey(), true),
             AccountMeta::new_readonly(self.plan_pda, false),
@@ -1596,7 +1615,9 @@ impl<'a> ResumeSubscription<'a> {
             AccountMeta::new_readonly(PROGRAM_ID, false),
         ];
 
-        let ix = Instruction { program_id: PROGRAM_ID, accounts, data: vec![*resume_subscription::DISCRIMINATOR] };
+        let mut data = vec![*resume_subscription::DISCRIMINATOR];
+        data.extend_from_slice(&expected_expires_at_ts.to_le_bytes());
+        let ix = Instruction { program_id: PROGRAM_ID, accounts, data };
 
         build_and_send_transaction(self.litesvm, &[self.subscriber], &self.subscriber.pubkey(), &ix)
     }

--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -933,6 +933,7 @@ export function PlanCard({
                                     onClick={(e: React.MouseEvent) => {
                                         e.stopPropagation();
                                         resumeSubscription.mutate({
+                                            expectedExpiresAtTs: matchingSub.subscription.expiresAtTs,
                                             planPda: plan.address,
                                             subscriptionPda: matchingSub.address,
                                             tokenMint: plan.data.mint,

--- a/webapp/src/components/subscription/my-subscriptions-panel.tsx
+++ b/webapp/src/components/subscription/my-subscriptions-panel.tsx
@@ -161,6 +161,7 @@ function ResumeSubscriptionDialog({
                         onClick={() =>
                             resumeSubscription.mutate(
                                 {
+                                    expectedExpiresAtTs: item.subscription.expiresAtTs,
                                     planPda: item.subscription.header.delegatee,
                                     subscriptionPda: item.address,
                                     tokenMint: item.mint ?? '',

--- a/webapp/src/hooks/use-subscriptions-mutations.ts
+++ b/webapp/src/hooks/use-subscriptions-mutations.ts
@@ -579,10 +579,12 @@ export function useSubscriptionsMutations() {
 
     const resumeSubscription = useMutation({
         mutationFn: async ({
+            expectedExpiresAtTs,
             planPda,
             subscriptionPda,
             tokenMint,
         }: {
+            expectedExpiresAtTs: bigint;
             planPda: string;
             subscriptionPda: string;
             tokenMint: string;
@@ -591,6 +593,7 @@ export function useSubscriptionsMutations() {
             if (!progId) throw new Error('Program address not configured');
 
             const instruction = await getResumeSubscriptionOverlayInstructionAsync({
+                expectedExpiresAtTs,
                 planPda: address(planPda),
                 programAddress: progId,
                 subscriber: signer,


### PR DESCRIPTION
## Summary
- `resume_subscription` carried no binding to the cancellation state the subscriber signed against, so a withheld or durable-nonce resume could clear a newer cancellation boundary (a later `expires_at_ts`) the subscriber never re-approved and keep the subscription billable.
- Adds `expected_expires_at_ts` to the instruction data and rejects when the stored `expires_at_ts` differs.
- Regenerates the IDL and threads the value through the TS SDK overlay wrapper and the webapp resume flows.

## Test Plan
- `cargo test -p tests-subscriptions resume_subscription` — 13 pass, incl. new `resume_subscription_rejects_stale_expected_expiry`
- IDL regenerated; TS client builds; webapp typechecks; `just check` passes

## Breaking Changes
- `resume_subscription` instruction data now requires an 8-byte `expected_expires_at_ts` (i64). Clients built against the prior zero-data format fail with `InvalidInstructionData`. No account-layout / migration change.