### PR TITLE
fix(program)!: bind cancel_subscription_now to subscription incarnation

### DIFF
--- a/clients/typescript/src/plugin.ts
+++ b/clients/typescript/src/plugin.ts
@@ -283,6 +283,7 @@ export type CancelSubscriptionInput = WithProgramAddress & {
 };
 
 export type CancelSubscriptionNowInput = WithProgramAddress & {
+    expectedCurrentPeriodStartTs: bigint;
     merchant: TransactionSigner;
     planPda: Address;
     subscriber: TransactionSigner;
@@ -690,6 +691,7 @@ export async function getCancelSubscriptionNowOverlayInstructionAsync(
     return await getCancelSubscriptionNowInstructionAsync(
         {
             ...(await eventAccounts(input.programAddress)),
+            cancelSubscriptionNowData: { expectedCurrentPeriodStartTs: input.expectedCurrentPeriodStartTs },
             merchant: input.merchant,
             planPda: input.planPda,
             subscriber: input.subscriber,

--- a/clients/typescript/test/event-account-defaults.test.ts
+++ b/clients/typescript/test/event-account-defaults.test.ts
@@ -32,7 +32,7 @@ describe('generated event-emitting builders resolve event accounts from the acti
         const planPda = (await generateKeyPairSigner()).address;
 
         const ix = await getCancelSubscriptionNowInstructionAsync(
-            { merchant, planPda, subscriber },
+            { merchant, planPda, subscriber, cancelSubscriptionNowData: { expectedCurrentPeriodStartTs: 0n } },
             { programAddress },
         );
 

--- a/clients/typescript/test/subscription-lifecycle.test.ts
+++ b/clients/typescript/test/subscription-lifecycle.test.ts
@@ -249,8 +249,14 @@ describe('Subscription Lifecycle', () => {
             .subscribe({ subscriber, merchant: t.payerKeypair.address, planId: 20n, tokenMint: t.tokenMint })
             .sendTransaction();
 
+        const beforeCancelNow = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda)).data;
         await t.client.subscriptions.instructions
-            .cancelSubscriptionNow({ subscriber, planPda, subscriptionPda })
+            .cancelSubscriptionNow({
+                subscriber,
+                planPda,
+                subscriptionPda,
+                expectedCurrentPeriodStartTs: beforeCancelNow.currentPeriodStartTs,
+            })
             .sendTransaction();
 
         const cancelled = (await fetchSubscriptionDelegation(t.rpc, subscriptionPda)).data;

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -324,6 +324,24 @@
     "definedTypes": [
       {
         "kind": "definedTypeNode",
+        "name": "cancelSubscriptionNowData",
+        "type": {
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expectedCurrentPeriodStartTs",
+              "type": {
+                "endian": "le",
+                "format": "i64",
+                "kind": "numberTypeNode"
+              }
+            }
+          ],
+          "kind": "structTypeNode"
+        }
+      },
+      {
+        "kind": "definedTypeNode",
         "name": "createFixedDelegationData",
         "type": {
           "fields": [
@@ -3738,6 +3756,14 @@
               "endian": "le",
               "format": "u8",
               "kind": "numberTypeNode"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "cancelSubscriptionNowData",
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "cancelSubscriptionNowData"
             }
           }
         ],

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -33,7 +33,7 @@ pub fn process_instruction(
         SubscriptionsInstruction::TransferSubscription(data) => transfer_subscription::process(accounts, &data),
         SubscriptionsInstruction::Subscribe(data) => subscribe::process(accounts, &data),
         SubscriptionsInstruction::CancelSubscription => cancel_subscription::process(accounts),
-        SubscriptionsInstruction::CancelSubscriptionNow => cancel_subscription_now::process(accounts),
+        SubscriptionsInstruction::CancelSubscriptionNow(data) => cancel_subscription_now::process(accounts, &data),
         SubscriptionsInstruction::ResumeSubscription(data) => resume_subscription::process(accounts, &data),
         SubscriptionsInstruction::RevokeSubscriptionAuthority => revoke_subscription_authority::process(accounts),
         SubscriptionsInstruction::RevokeAbandonedDelegation => revoke_abandoned_delegation::process(accounts),

--- a/program/src/instructions/cancel_subscription_now.rs
+++ b/program/src/instructions/cancel_subscription_now.rs
@@ -1,3 +1,5 @@
+use codama::CodamaType;
+use core::mem::{size_of, transmute};
 use pinocchio::{
     error::ProgramError,
     sysvars::{clock::Clock, Sysvar},
@@ -15,13 +17,37 @@ use crate::{
 /// Instruction discriminator byte for `CancelSubscriptionNow`.
 pub const DISCRIMINATOR: &u8 = &17;
 
+/// Instruction data payload for immediate cancellation.
+#[repr(C, packed)]
+#[derive(CodamaType, Debug, Clone)]
+pub struct CancelSubscriptionNowData {
+    /// The `current_period_start_ts` both parties observed when signing. The
+    /// subscription PDA is reused across `(plan, subscriber)` incarnations, so
+    /// this binds the dual approval to the specific incarnation and rejects a
+    /// signed transaction replayed against a later re-subscription.
+    pub expected_current_period_start_ts: i64,
+}
+
+impl CancelSubscriptionNowData {
+    /// Serialized size in bytes.
+    pub const LEN: usize = size_of::<CancelSubscriptionNowData>();
+
+    /// Zero-copy deserialize from raw instruction bytes.
+    pub fn load(data: &[u8]) -> Result<&Self, ProgramError> {
+        if data.len() != Self::LEN {
+            return Err(SubscriptionsError::InvalidInstructionData.into());
+        }
+        Ok(unsafe { &*transmute::<*const u8, *const Self>(data.as_ptr()) })
+    }
+}
+
 /// Cancels a subscription immediately with approval from both the subscriber
 /// and the plan owner.
 ///
 /// The subscription can be closed via
 /// [`RevokeDelegation`](crate::instructions::revoke_delegation) as soon as this
 /// instruction succeeds. Emits a [`SubscriptionCancelledEvent`].
-pub fn process(accounts: &mut [AccountView]) -> ProgramResult {
+pub fn process(accounts: &mut [AccountView], data: &CancelSubscriptionNowData) -> ProgramResult {
     let accounts = CancelSubscriptionNowAccounts::try_from(accounts)?;
     let current_ts = Clock::get()?.unix_timestamp;
 
@@ -44,6 +70,10 @@ pub fn process(accounts: &mut [AccountView]) -> ProgramResult {
 
         if subscription.header.delegatee != *accounts.plan_pda.address() {
             return Err(SubscriptionsError::SubscriptionPlanMismatch.into());
+        }
+
+        if subscription.current_period_start_ts != data.expected_current_period_start_ts {
+            return Err(SubscriptionsError::StaleSubscriptionApproval.into());
         }
 
         if subscription.expires_at_ts != 0 && subscription.expires_at_ts <= current_ts {

--- a/program/src/instructions/mod.rs
+++ b/program/src/instructions/mod.rs
@@ -35,6 +35,7 @@ use codama::CodamaInstructions;
 use pinocchio::error::ProgramError;
 
 use crate::event_engine::EMIT_EVENT_IX_DISC;
+use crate::instructions::cancel_subscription_now::CancelSubscriptionNowData;
 use crate::instructions::create_plan::PlanData;
 use crate::instructions::resume_subscription::ResumeData;
 use crate::instructions::subscribe::SubscribeData;
@@ -383,7 +384,7 @@ pub enum SubscriptionsInstruction {
         docs = "This program (for self-CPI)",
         default_value = public_key("De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44")
     ))]
-    CancelSubscriptionNow = 17,
+    CancelSubscriptionNow(#[codama(name = "cancel_subscription_now_data")] CancelSubscriptionNowData) = 17,
 
     #[codama(skip)]
     #[codama(account(
@@ -439,7 +440,10 @@ impl SubscriptionsInstruction {
                 Ok(Self::Subscribe(loaded.clone()))
             }
             cancel_subscription::DISCRIMINATOR => Ok(Self::CancelSubscription),
-            cancel_subscription_now::DISCRIMINATOR => Ok(Self::CancelSubscriptionNow),
+            cancel_subscription_now::DISCRIMINATOR => {
+                let loaded = CancelSubscriptionNowData::load(rest)?;
+                Ok(Self::CancelSubscriptionNow(loaded.clone()))
+            }
             resume_subscription::DISCRIMINATOR => {
                 let loaded = ResumeData::load(rest)?;
                 Ok(Self::ResumeSubscription(loaded.clone()))
@@ -469,7 +473,7 @@ impl fmt::Display for SubscriptionsInstruction {
             Self::TransferSubscription(_) => write!(f, "transfer_subscription"),
             Self::Subscribe(_) => write!(f, "subscribe"),
             Self::CancelSubscription => write!(f, "cancel_subscription"),
-            Self::CancelSubscriptionNow => write!(f, "cancel_subscription_now"),
+            Self::CancelSubscriptionNow(_) => write!(f, "cancel_subscription_now"),
             Self::ResumeSubscription(_) => write!(f, "resume_subscription"),
             Self::RevokeSubscriptionAuthority => write!(f, "revoke_subscription_authority"),
             Self::RevokeAbandonedDelegation => write!(f, "revoke_abandoned_delegation"),

--- a/tests/integration-tests/src/test_cancel_subscription_now.rs
+++ b/tests/integration-tests/src/test_cancel_subscription_now.rs
@@ -7,8 +7,9 @@ use crate::{
         constants::PROGRAM_ID,
         pda::{get_plan_pda, get_subscription_authority_pda, get_subscription_pda},
         utils::{
-            build_and_send_transaction, current_ts, days, init_ata, init_wallet, setup_with_subscription,
-            CancelSubscription, CancelSubscriptionNow, CreatePlan, RevokeSubscription, Subscribe, TransferSubscription,
+            build_and_send_transaction, current_ts, days, hours, init_ata, init_wallet, move_clock_forward,
+            setup_with_subscription, CancelSubscription, CancelSubscriptionNow, CreatePlan, RevokeSubscription,
+            Subscribe, TransferSubscription,
         },
     },
     SubscriptionsError,
@@ -25,8 +26,11 @@ fn cancel_subscription_now_instruction(
     merchant_is_signer: bool,
     plan_pda: Pubkey,
     subscription_pda: Pubkey,
+    expected_current_period_start_ts: i64,
 ) -> Instruction {
     let event_authority = Pubkey::new_from_array(event_authority_pda::ID.to_bytes());
+    let mut data = vec![*cancel_subscription_now::DISCRIMINATOR];
+    data.extend_from_slice(&expected_current_period_start_ts.to_le_bytes());
     Instruction {
         program_id: PROGRAM_ID,
         accounts: vec![
@@ -37,7 +41,7 @@ fn cancel_subscription_now_instruction(
             AccountMeta::new_readonly(event_authority, false),
             AccountMeta::new_readonly(PROGRAM_ID, false),
         ],
-        data: vec![*cancel_subscription_now::DISCRIMINATOR],
+        data,
     }
 }
 
@@ -55,6 +59,10 @@ fn cancel_subscription_now_expires_at_current_clock() {
 #[test]
 fn cancel_subscription_now_requires_both_signatures() {
     let (mut litesvm, subscriber, merchant, _mint, plan_pda, _, subscription_pda) = setup_with_subscription();
+    let period_start = {
+        let account = litesvm.get_account(&subscription_pda).unwrap();
+        SubscriptionDelegation::load(&account.data).unwrap().current_period_start_ts
+    };
 
     let missing_subscriber = cancel_subscription_now_instruction(
         subscriber.pubkey(),
@@ -63,6 +71,7 @@ fn cancel_subscription_now_requires_both_signatures() {
         true,
         plan_pda,
         subscription_pda,
+        period_start,
     );
     build_and_send_transaction(&mut litesvm, &[&merchant], &merchant.pubkey(), &missing_subscriber)
         .assert_err(SubscriptionsError::NotSigner);
@@ -74,9 +83,33 @@ fn cancel_subscription_now_requires_both_signatures() {
         false,
         plan_pda,
         subscription_pda,
+        period_start,
     );
     build_and_send_transaction(&mut litesvm, &[&subscriber], &subscriber.pubkey(), &missing_merchant)
         .assert_err(SubscriptionsError::NotSigner);
+}
+
+#[test]
+fn cancel_subscription_now_rejects_legacy_zero_payload() {
+    let (mut litesvm, subscriber, merchant, _mint, plan_pda, _, subscription_pda) = setup_with_subscription();
+
+    // Discriminator-only payload (the pre-binding wire format) must be rejected:
+    // the instruction now requires the 8-byte expected_current_period_start_ts.
+    let event_authority = Pubkey::new_from_array(event_authority_pda::ID.to_bytes());
+    let legacy_ix = Instruction {
+        program_id: PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new_readonly(subscriber.pubkey(), true),
+            AccountMeta::new_readonly(merchant.pubkey(), true),
+            AccountMeta::new_readonly(plan_pda, false),
+            AccountMeta::new(subscription_pda, false),
+            AccountMeta::new_readonly(event_authority, false),
+            AccountMeta::new_readonly(PROGRAM_ID, false),
+        ],
+        data: vec![*cancel_subscription_now::DISCRIMINATOR],
+    };
+    build_and_send_transaction(&mut litesvm, &[&subscriber, &merchant], &merchant.pubkey(), &legacy_ix)
+        .assert_err(SubscriptionsError::InvalidInstructionData);
 }
 
 #[test]
@@ -173,6 +206,28 @@ fn cancel_subscription_now_preserves_other_subscriptions_on_shared_authority() {
     .to(second_merchant_ata)
     .execute()
     .assert_ok();
+}
+
+#[test]
+fn cancel_subscription_now_rejects_stale_approval_after_resubscribe() {
+    let (mut litesvm, subscriber, merchant, mint, plan_pda, plan_bump, subscription_pda) = setup_with_subscription();
+
+    let first_period_start = {
+        let account = litesvm.get_account(&subscription_pda).unwrap();
+        SubscriptionDelegation::load(&account.data).unwrap().current_period_start_ts
+    };
+
+    CancelSubscription::new(&mut litesvm, &subscriber, plan_pda, subscription_pda).execute().assert_ok();
+    move_clock_forward(&mut litesvm, hours(2));
+    RevokeSubscription::new(&mut litesvm, &subscriber, subscription_pda, plan_pda).execute().assert_ok();
+    Subscribe::new(&mut litesvm, &subscriber, merchant.pubkey(), plan_pda, 1, plan_bump, mint).execute().assert_ok();
+
+    // A dual-signed approval bound to the first incarnation must not cancel the
+    // re-subscribed account at the same PDA.
+    CancelSubscriptionNow::new(&mut litesvm, &subscriber, &merchant, plan_pda, subscription_pda)
+        .expected_current_period_start_ts(first_period_start)
+        .execute()
+        .assert_err(SubscriptionsError::StaleSubscriptionApproval);
 }
 
 #[test]

--- a/tests/integration-tests/src/utils/test_helpers.rs
+++ b/tests/integration-tests/src/utils/test_helpers.rs
@@ -1525,6 +1525,7 @@ pub struct CancelSubscriptionNow<'a> {
     merchant: &'a Keypair,
     plan_pda: Pubkey,
     subscription_pda: Pubkey,
+    expected_current_period_start_ts: Option<i64>,
 }
 
 impl<'a> CancelSubscriptionNow<'a> {
@@ -1535,7 +1536,12 @@ impl<'a> CancelSubscriptionNow<'a> {
         plan_pda: Pubkey,
         subscription_pda: Pubkey,
     ) -> Self {
-        Self { litesvm, subscriber, merchant, plan_pda, subscription_pda }
+        Self { litesvm, subscriber, merchant, plan_pda, subscription_pda, expected_current_period_start_ts: None }
+    }
+
+    pub fn expected_current_period_start_ts(mut self, ts: i64) -> Self {
+        self.expected_current_period_start_ts = Some(ts);
+        self
     }
 
     #[allow(clippy::result_large_err)]
@@ -1549,7 +1555,15 @@ impl<'a> CancelSubscriptionNow<'a> {
             AccountMeta::new_readonly(event_authority, false),
             AccountMeta::new_readonly(PROGRAM_ID, false),
         ];
-        let ix = Instruction { program_id: PROGRAM_ID, accounts, data: vec![*cancel_subscription_now::DISCRIMINATOR] };
+
+        let expected_current_period_start_ts = self.expected_current_period_start_ts.unwrap_or_else(|| {
+            let account = self.litesvm.get_account(&self.subscription_pda).unwrap();
+            crate::SubscriptionDelegation::load(&account.data).unwrap().current_period_start_ts
+        });
+
+        let mut data = vec![*cancel_subscription_now::DISCRIMINATOR];
+        data.extend_from_slice(&expected_current_period_start_ts.to_le_bytes());
+        let ix = Instruction { program_id: PROGRAM_ID, accounts, data };
 
         build_and_send_transaction(self.litesvm, &[self.subscriber, self.merchant], &self.merchant.pubkey(), &ix)
     }


### PR DESCRIPTION
Stacked on #214.

## Summary
- The subscription PDA is reused for a given `(plan, subscriber)`, so a dual-signed `cancel_subscription_now` transaction prepared for an earlier subscription could be replayed after that subscription is closed and the subscriber re-subscribes — cancelling the new subscription without fresh merchant approval.
- Adds `expected_current_period_start_ts` to the instruction data and rejects when it differs from the live account, binding the dual approval to the specific incarnation.
- Adds the `StaleSubscriptionApproval` error and threads the value through the TS SDK overlay wrapper.

## Test Plan
- `cargo test -p tests-subscriptions` — 268 pass, incl. new `cancel_subscription_now_rejects_stale_approval_after_resubscribe`
- IDL regenerated; TS client builds; `just check` passes

## Breaking Changes
- `cancel_subscription_now` instruction data now requires an 8-byte `expected_current_period_start_ts` (i64). Clients built against the prior zero-data format fail with `InvalidInstructionData`. No account-layout / migration change.