### PR TITLE
fix(program): gate abandoned recovery until the authority slot passes

### DIFF
--- a/program/src/instructions/revoke_abandoned_delegation.rs
+++ b/program/src/instructions/revoke_abandoned_delegation.rs
@@ -1,4 +1,8 @@
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{
+    error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    AccountView, ProgramResult,
+};
 
 use crate::{
     state::{
@@ -76,8 +80,12 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
             return Err(SubscriptionsError::Unauthorized.into());
         }
 
+        // A closed authority is only terminal once its slot has passed. Within
+        // the same slot the delegator could re-init and recreate the matching
+        // slot-derived init_id, which keeps the delegation transferable.
+        let current_slot = Clock::get()?.slot as i64;
         let authority_is_dead = if !accounts.subscription_authority.owned_by(&crate::ID) {
-            true
+            current_slot > recorded_init_id
         } else {
             let authority_data = accounts.subscription_authority.try_borrow()?;
             match SubscriptionAuthority::load(&authority_data) {

--- a/program/src/instructions/revoke_abandoned_subscription.rs
+++ b/program/src/instructions/revoke_abandoned_subscription.rs
@@ -1,4 +1,8 @@
-use pinocchio::{error::ProgramError, AccountView, ProgramResult};
+use pinocchio::{
+    error::ProgramError,
+    sysvars::{clock::Clock, Sysvar},
+    AccountView, ProgramResult,
+};
 
 use crate::{
     state::{plan::Plan, subscription_delegation::SubscriptionDelegation},
@@ -82,8 +86,11 @@ pub fn process(accounts: &[AccountView]) -> ProgramResult {
         }
 
         // Terminal: authority closed or init_id rotated (inverse of the transfer-time check).
+        // A closed authority counts as terminal only once its slot has passed; within the same
+        // slot the subscriber could re-init and recreate the matching slot-derived init_id.
+        let current_slot = Clock::get()?.slot as i64;
         let authority_is_dead = if !accounts.subscription_authority.owned_by(&crate::ID) {
-            true
+            current_slot > init_id
         } else {
             let authority_data = accounts.subscription_authority.try_borrow()?;
             match SubscriptionAuthority::load(&authority_data) {

--- a/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
+++ b/tests/integration-tests/src/test_revoke_abandoned_delegation.rs
@@ -8,8 +8,8 @@ use crate::{
         asserts::TransactionResultExt,
         constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         utils::{
-            current_ts, hours, init_ata, init_mint, initialize_subscription_authority_action, move_clock_forward,
-            setup, CloseSubscriptionAuthority, CreateDelegation, RevokeAbandonedDelegation,
+            advance_slots, current_ts, hours, init_ata, init_mint, initialize_subscription_authority_action,
+            move_clock_forward, setup, CloseSubscriptionAuthority, CreateDelegation, RevokeAbandonedDelegation,
         },
     },
     SubscriptionsError,
@@ -40,6 +40,8 @@ fn sponsor_recovers_no_expiry_fixed_delegation_after_authority_closed() {
     let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
 
     CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+    // Recovery is terminal only once the creation slot has passed.
+    advance_slots(litesvm, 1);
 
     let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
 
@@ -73,6 +75,8 @@ fn payer_recovers_no_expiry_recurring_delegation_after_authority_closed() {
     let delegation_rent = litesvm.get_account(&delegation_pda).unwrap().lamports;
 
     CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+    // Recovery is terminal only once the creation slot has passed.
+    advance_slots(litesvm, 1);
 
     let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
 
@@ -108,6 +112,29 @@ fn payer_recovers_delegation_after_authority_reinit_bumps_init_id() {
 
     let delegation_after = litesvm.get_account(&delegation_pda);
     assert!(delegation_after.is_none() || delegation_after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0);
+}
+
+#[test]
+fn revoke_abandoned_delegation_rejects_same_slot_closure() {
+    let (litesvm, user) = &mut setup();
+    let sponsor = fund(litesvm);
+    let delegatee = Pubkey::new_unique();
+
+    let mint = init_mint(litesvm, TOKEN_PROGRAM_ID, MINT_DECIMALS, 1_000_000_000, Some(user.pubkey()), &[]);
+    let _user_ata = init_ata(litesvm, mint, user.pubkey(), 1_000_000);
+    initialize_subscription_authority_action(litesvm, user, mint).0.assert_ok();
+
+    let (res, _delegation_pda) =
+        CreateDelegation::new(litesvm, user, mint, delegatee).payer(&sponsor).fixed(100, NO_EXPIRY);
+    res.assert_ok();
+
+    // Authority closed in the same slot the delegation was created: a same-slot
+    // re-init recreates the matching init_id, so it is not terminally abandoned.
+    CloseSubscriptionAuthority::new(litesvm, user, mint).execute().assert_ok();
+
+    RevokeAbandonedDelegation::new(litesvm, &sponsor, user.pubkey(), mint, delegatee)
+        .execute()
+        .assert_err(SubscriptionsError::Unauthorized);
 }
 
 #[test]

--- a/tests/integration-tests/src/test_revoke_abandoned_subscription.rs
+++ b/tests/integration-tests/src/test_revoke_abandoned_subscription.rs
@@ -8,8 +8,9 @@ use crate::{
         constants::{MINT_DECIMALS, TOKEN_PROGRAM_ID},
         pda::{get_plan_pda, get_subscription_pda},
         utils::{
-            current_ts, days, init_ata, init_mint, init_wallet, initialize_subscription_authority_action,
-            move_clock_forward, setup, CloseSubscriptionAuthority, CreatePlan, RevokeAbandonedSubscription, Subscribe,
+            advance_slots, current_ts, days, init_ata, init_mint, init_wallet,
+            initialize_subscription_authority_action, move_clock_forward, setup, CloseSubscriptionAuthority,
+            CreatePlan, RevokeAbandonedSubscription, Subscribe,
         },
     },
     SubscriptionsError,
@@ -56,6 +57,42 @@ fn sponsor_recovers_subscription_after_authority_rotated() {
     CloseSubscriptionAuthority::new(&mut litesvm, &subscriber, mint).execute().assert_ok();
     move_clock_forward(&mut litesvm, 10);
     initialize_subscription_authority_action(&mut litesvm, &subscriber, mint).0.assert_ok();
+
+    let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+    let subscription_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;
+
+    RevokeAbandonedSubscription::new(&mut litesvm, &sponsor, subscriber.pubkey(), mint, plan_pda).execute().assert_ok();
+
+    let after = litesvm.get_account(&subscription_pda);
+    assert!(after.is_none() || after.as_ref().map(|a| a.lamports).unwrap_or(0) == 0);
+
+    let sponsor_after = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
+    assert!(sponsor_after >= sponsor_before + subscription_rent - 10_000);
+}
+
+#[test]
+fn revoke_abandoned_subscription_rejects_same_slot_closure() {
+    let (mut litesvm, subscriber, sponsor, mint, plan_pda) = setup_sponsored_subscription();
+
+    // Authority closed in the same slot the subscription was created: a same-slot
+    // re-init recreates the matching init_id, so it is not terminally abandoned.
+    CloseSubscriptionAuthority::new(&mut litesvm, &subscriber, mint).execute().assert_ok();
+
+    RevokeAbandonedSubscription::new(&mut litesvm, &sponsor, subscriber.pubkey(), mint, plan_pda)
+        .execute()
+        .assert_err(SubscriptionsError::Unauthorized);
+}
+
+#[test]
+fn revoke_abandoned_subscription_recovers_after_authority_closed_slot_advanced() {
+    let (mut litesvm, subscriber, sponsor, mint, plan_pda) = setup_sponsored_subscription();
+    let (subscription_pda, _) = get_subscription_pda(&plan_pda, &subscriber.pubkey());
+
+    // Authority closed and the creation slot has passed: the subscription is now
+    // terminally abandoned (a same-slot re-init can no longer revive it), so the
+    // sponsor can reclaim its rent.
+    CloseSubscriptionAuthority::new(&mut litesvm, &subscriber, mint).execute().assert_ok();
+    advance_slots(&mut litesvm, 1);
 
     let sponsor_before = litesvm.get_account(&sponsor.pubkey()).unwrap().lamports;
     let subscription_rent = litesvm.get_account(&subscription_pda).unwrap().lamports;


### PR DESCRIPTION
Stacked on #215.

## Summary
- `revoke_abandoned_delegation` and `revoke_abandoned_subscription` treated a closed `SubscriptionAuthority` as terminal immediately. Because `init_id` is slot-granular, a same-slot re-init recreates the matching `init_id` and keeps the delegation/subscription transferable — so the recorded payer could close revivable state in the transient close window and reclaim its rent.
- Now treats a closed authority as terminal only once the current slot has advanced past the recorded `init_id`, so recovery cannot race a same-slot re-init. Recovery in a later slot is unaffected.

## Test Plan
- `cargo test -p tests-subscriptions` — 270 pass, incl. new `revoke_abandoned_delegation_rejects_same_slot_closure` and `revoke_abandoned_subscription_rejects_same_slot_closure`
- Existing same-slot recovery tests updated to advance one slot (reflects that recovery is terminal only after the creation slot)
- No ABI / IDL / state change; `just check` passes

## Notes
- `docs/002` still describes abandoned recovery as "closed authority = recoverable"; the new same-slot gate is an added condition. Happy to update that line if wanted.