### PR TITLE
test(fuzz): add token-2022 mint variant

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,6 +31,10 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [invariant_subscriptions, invariant_subscriptions_t22]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -51,11 +55,11 @@ jobs:
         run: command -v crucible >/dev/null || just install-fuzzer
 
       - name: Fuzz (smoke)
-        run: just fuzz invariant_subscriptions 60
+        run: just fuzz ${{ matrix.test }} 60
 
       - name: Check for crashes
         run: |
-          crashes="fuzz/subscriptions/crashes/invariant_subscriptions"
+          crashes="fuzz/subscriptions/crashes/${{ matrix.test }}"
           if [ -d "$crashes" ] && [ -n "$(ls -A "$crashes" 2>/dev/null)" ]; then
             echo "::error::Fuzzer found crashes"
             ls -la "$crashes"
@@ -67,7 +71,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-smoke-crashes
+          name: fuzz-smoke-crashes-${{ matrix.test }}
           path: fuzz/subscriptions/crashes/
           if-no-files-found: ignore
 
@@ -77,6 +81,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [invariant_subscriptions, invariant_subscriptions_t22]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -99,32 +107,32 @@ jobs:
       - name: Restore corpus
         uses: actions/cache@v4
         with:
-          path: fuzz/subscriptions/corpus
-          key: fuzz-corpus-${{ github.run_id }}
-          restore-keys: fuzz-corpus-
+          path: fuzz/subscriptions/corpus-${{ matrix.test }}
+          key: fuzz-corpus-${{ matrix.test }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-${{ matrix.test }}-
 
       - name: Build program and clients
         run: just build-program && just generate-clients
 
       - name: Fuzz (deep)
         run: |
-          crucible run subscriptions invariant_subscriptions \
+          crucible run subscriptions ${{ matrix.test }} \
             --release -j 4 \
             --timeout ${{ github.event.inputs.timeout || '7200' }} \
-            --corpus-in fuzz/subscriptions/corpus \
-            --corpus-out fuzz/subscriptions/corpus
+            --corpus-in fuzz/subscriptions/corpus-${{ matrix.test }} \
+            --corpus-out fuzz/subscriptions/corpus-${{ matrix.test }}
 
       - name: Upload crashes
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-nightly-crashes
+          name: fuzz-nightly-crashes-${{ matrix.test }}
           path: fuzz/subscriptions/crashes/
           if-no-files-found: ignore
 
       - name: Fail on crashes
         run: |
-          crashes="fuzz/subscriptions/crashes/invariant_subscriptions"
+          crashes="fuzz/subscriptions/crashes/${{ matrix.test }}"
           if [ -d "$crashes" ] && [ -n "$(ls -A "$crashes" 2>/dev/null)" ]; then
             echo "::error::Fuzzer found crashes"
             ls -la "$crashes"

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4919,6 +4919,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "spl-associated-token-account-interface",
+ "spl-token-2022-interface",
  "spl-token-interface 3.0.0",
  "subscriptions",
 ]

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4913,6 +4913,7 @@ dependencies = [
  "libafl_bolts",
  "solana-clock",
  "solana-keypair",
+ "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -23,6 +23,7 @@ solana-program-pack = "3.0"
 solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
+spl-token-2022-interface = "2.1"
 
 [[bin]]
 name = "invariant_test"

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -19,6 +19,7 @@ solana-keypair = "3.0"
 solana-pubkey = "3.0"
 solana-rent = "3.0"
 solana-sdk-ids = "3.0"
+solana-program-pack = "3.0"
 solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
@@ -29,3 +30,4 @@ path = "src/main.rs"
 
 [features]
 invariant_subscriptions = []
+invariant_subscriptions_t22 = []

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -22,7 +22,8 @@ use crate::constants::{
     GENESIS_TS, INITIAL_TOKENS, MINT_DECIMALS, PLAN_AMOUNT, PLAN_ID, PLAN_PERIOD_HOURS, SUBSCRIBER_COUNT,
 };
 use crate::helpers::{
-    ata_address, create_ata, create_funded_wallet, delegation_pda_address, plan_pda_address, set_clock,
+    ata_address, create_ata, create_funded_wallet, create_mint, delegation_pda_address, plan_pda_address, set_clock,
+    TOKEN_PROGRAM,
 };
 
 #[derive(Clone)]
@@ -87,12 +88,7 @@ impl SubscriptionsFixture {
 
         let mint_authority = Keypair::new();
         let mint = Pubkey::new_unique();
-        ctx.create_mint()
-            .pubkey(mint)
-            .mint_authority(mint_authority.pubkey())
-            .decimals(MINT_DECIMALS)
-            .create()
-            .expect("create mint");
+        create_mint(&mut ctx, &mint, &mint_authority.pubkey(), MINT_DECIMALS);
 
         let merchant = create_funded_wallet(&mut ctx);
         let merchant_ata = create_ata(&mut ctx, &merchant.pubkey(), &mint, 0);
@@ -107,7 +103,7 @@ impl SubscriptionsFixture {
                 .subscription_authority(authority_pda)
                 .token_mint(mint)
                 .user_ata(user_ata)
-                .token_program(spl_token_interface::ID)
+                .token_program(TOKEN_PROGRAM)
                 .instruction();
             ctx.raw_call(ix).signers(&[&subscriber]).send().expect("send init authority").unwrap();
             subscribers.push(subscriber);
@@ -122,6 +118,7 @@ impl SubscriptionsFixture {
             .merchant(merchant.pubkey())
             .plan_pda(plan_pda)
             .token_mint(mint)
+            .token_program(TOKEN_PROGRAM)
             .plan_data(PlanData {
                 plan_id: PLAN_ID,
                 mint,
@@ -194,7 +191,7 @@ impl SubscriptionsFixture {
             .receiver_ata(self.merchant_ata)
             .caller(self.merchant.pubkey())
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
@@ -329,7 +326,7 @@ impl SubscriptionsFixture {
             .delegator_ata(ata_address(&subscriber.pubkey(), &self.mint))
             .receiver_ata(self.merchant_ata)
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .delegatee(delegatee)
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
@@ -411,7 +408,7 @@ impl SubscriptionsFixture {
             .user(subscriber.pubkey())
             .user_ata(ata_address(&subscriber.pubkey(), &self.mint))
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .subscription_authority(authority_pda)
             .instruction();
         self.ctx.raw_call(ix).signers(&[&subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
@@ -435,7 +432,7 @@ impl SubscriptionsFixture {
             .subscription_authority(authority_pda)
             .token_mint(self.mint)
             .user_ata(ata_address(&subscriber.pubkey(), &self.mint))
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .instruction();
         self.ctx.raw_call(ix).signers(&[&subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
     }

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -14,7 +14,7 @@ use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 #[cfg(not(feature = "invariant_subscriptions_t22"))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
 #[cfg(feature = "invariant_subscriptions_t22")]
-pub const TOKEN_PROGRAM: Pubkey = Pubkey::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+pub const TOKEN_PROGRAM: Pubkey = spl_token_2022_interface::ID;
 
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
@@ -60,7 +60,7 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
 #[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
     use solana_program_pack::Pack;
-    use spl_token_interface::state::Mint;
+    use spl_token_2022_interface::state::Mint;
 
     let mut data = vec![0u8; Mint::LEN];
     Mint {
@@ -83,7 +83,7 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
 #[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     use solana_program_pack::Pack;
-    use spl_token_interface::state::{Account, AccountState};
+    use spl_token_2022_interface::state::{Account, AccountState};
 
     let ata = ata_address(owner, mint);
     let mut data = vec![0u8; Account::LEN];

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -3,9 +3,11 @@ use std::rc::Rc;
 use crucible_fuzzer::{AccountBuilderBase, TestContext};
 use solana_clock::Clock;
 use solana_keypair::Keypair;
+use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+use spl_token_2022_interface::state::{Account, AccountState, Mint};
 use subscriptions::accounts::Plan;
 use subscriptions::SUBSCRIPTIONS_ID;
 
@@ -43,25 +45,9 @@ pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
     get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
+// The base mint (82 bytes) and token-account (165 bytes) layouts are identical for classic SPL
+// and Token-2022, so both mints are packed the same way and differ only in the owning program.
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    ctx.create_mint().pubkey(*mint).mint_authority(*authority).decimals(decimals).create().expect("create mint");
-}
-
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
-pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
-    let ata = ata_address(owner, mint);
-    ctx.create_token_account().pubkey(ata).mint(*mint).token_owner(*owner).amount(amount).create().expect("create ata");
-    ata
-}
-
-// Token-2022 base accounts share the classic SPL layout (82-byte mint, 165-byte token account) and
-// are accepted by the program without an account-type discriminator, so they are packed directly.
-#[cfg(feature = "invariant_subscriptions_t22")]
-pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    use solana_program_pack::Pack;
-    use spl_token_2022_interface::state::Mint;
-
     let mut data = vec![0u8; Mint::LEN];
     Mint {
         mint_authority: Some(*authority).into(),
@@ -77,14 +63,10 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
         .owner(TOKEN_PROGRAM)
         .data(&data)
         .create()
-        .expect("create token-2022 mint");
+        .expect("create mint");
 }
 
-#[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
-    use solana_program_pack::Pack;
-    use spl_token_2022_interface::state::{Account, AccountState};
-
     let ata = ata_address(owner, mint);
     let mut data = vec![0u8; Account::LEN];
     Account {
@@ -104,7 +86,7 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         .owner(TOKEN_PROGRAM)
         .data(&data)
         .create()
-        .expect("create token-2022 ata");
+        .expect("create ata");
     ata
 }
 

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -11,6 +11,11 @@ use subscriptions::SUBSCRIPTIONS_ID;
 
 use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
+pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub const TOKEN_PROGRAM: Pubkey = Pubkey::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
     ctx.warp_to_slot(slot);
@@ -35,18 +40,71 @@ pub fn create_funded_wallet(ctx: &mut TestContext) -> Rc<Keypair> {
 }
 
 pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
-    get_associated_token_address_with_program_id(owner, mint, &spl_token_interface::ID)
+    get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
+pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
+    ctx.create_mint().pubkey(*mint).mint_authority(*authority).decimals(decimals).create().expect("create mint");
+}
+
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     let ata = ata_address(owner, mint);
-    ctx.create_token_account()
-        .pubkey(ata)
-        .mint(*mint)
-        .token_owner(*owner)
-        .amount(amount)
+    ctx.create_token_account().pubkey(ata).mint(*mint).token_owner(*owner).amount(amount).create().expect("create ata");
+    ata
+}
+
+// Token-2022 base accounts share the classic SPL layout (82-byte mint, 165-byte token account) and
+// are accepted by the program without an account-type discriminator, so they are packed directly.
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
+    use solana_program_pack::Pack;
+    use spl_token_interface::state::Mint;
+
+    let mut data = vec![0u8; Mint::LEN];
+    Mint {
+        mint_authority: Some(*authority).into(),
+        supply: 0,
+        decimals,
+        is_initialized: true,
+        freeze_authority: None.into(),
+    }
+    .pack_into_slice(&mut data);
+    ctx.create_account()
+        .pubkey(*mint)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
         .create()
-        .expect("create token account");
+        .expect("create token-2022 mint");
+}
+
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
+    use solana_program_pack::Pack;
+    use spl_token_interface::state::{Account, AccountState};
+
+    let ata = ata_address(owner, mint);
+    let mut data = vec![0u8; Account::LEN];
+    Account {
+        mint: *mint,
+        owner: *owner,
+        amount,
+        delegate: None.into(),
+        state: AccountState::Initialized,
+        is_native: None.into(),
+        delegated_amount: 0,
+        close_authority: None.into(),
+    }
+    .pack_into_slice(&mut data);
+    ctx.create_account()
+        .pubkey(ata)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
+        .create()
+        .expect("create token-2022 ata");
     ata
 }
 

--- a/fuzz/subscriptions/src/main.rs
+++ b/fuzz/subscriptions/src/main.rs
@@ -11,10 +11,21 @@ use crate::invariants::{
     check_token_conservation,
 };
 
-#[invariant_test]
-fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
+fn check_all(fixture: &mut SubscriptionsFixture) {
     check_subscriptions_decodable_and_capped(fixture);
     check_recurring_delegation_caps(fixture);
     check_token_conservation(fixture);
     check_dead_authority_inert(fixture);
+}
+
+#[invariant_test]
+fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
+}
+
+// Same actions and invariants against a Token-2022 mint; the token program is selected at
+// build time by the matching feature (see helpers::TOKEN_PROGRAM).
+#[invariant_test]
+fn invariant_subscriptions_t22(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
 }


### PR DESCRIPTION
Stacked on #223 (base branch `test/crucible-fuzz-harness`).

## Summary
- Adds `invariant_subscriptions_t22`: the same 16 actions and all 4 invariants run against a **Token-2022** mint instead of classic SPL
- Token program is selected at build time by the active feature (`helpers::TOKEN_PROGRAM`); the fixture, actions, and invariants are otherwise shared verbatim
- Base Token-2022 mints (82 bytes) and token accounts (165 bytes) share the classic SPL layout and are accepted by the program without an account-type discriminator, so they're packed with the already-resolved `spl-token-interface` and given the Token-2022 owner — no new dependency (avoids a litesvm-0.9 solana-pin conflict)
- CI smoke + nightly now matrix over both mints, with per-mint corpus caches

## Why it matters
The program dispatches token operations on the mint's owner and CPIs to whichever token program owns it. The classic-only harness never exercised the Token-2022 branches. This variant covers them: branch coverage 61% → 65%, and the Token-2022 CPI transfer path is now fuzzed.

## Test plan
- `crucible run subscriptions invariant_subscriptions_t22 --timeout 90` → 0 crashes, 35.6% edges / 65.2% branches, 15/16 actions
- `crucible run subscriptions invariant_subscriptions --timeout 30` → classic path unchanged, 0 crashes
- Both features `cargo check` clean

## Note
One setup gotcha the fuzzer caught: `CreatePlan`'s builder defaults `token_program` to classic SPL, so it must be set explicitly to match a Token-2022 mint (else `InvalidTokenProgram`). Worth knowing for any client creating plans on Token-2022 mints.

Follow-ups (separate PRs): Token-2022 *extensions* (transfer-fee, transfer-hook) — the paths that hit the most program logic.