### PR TITLE
test(fuzz): advanced cases — Token-2022 mint and adversarial approvals

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,6 +31,10 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [invariant_subscriptions, invariant_subscriptions_t22]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -51,11 +55,11 @@ jobs:
         run: command -v crucible >/dev/null || just install-fuzzer
 
       - name: Fuzz (smoke)
-        run: just fuzz invariant_subscriptions 60
+        run: just fuzz ${{ matrix.test }} 60
 
       - name: Check for crashes
         run: |
-          crashes="fuzz/subscriptions/crashes/invariant_subscriptions"
+          crashes="fuzz/subscriptions/crashes/${{ matrix.test }}"
           if [ -d "$crashes" ] && [ -n "$(ls -A "$crashes" 2>/dev/null)" ]; then
             echo "::error::Fuzzer found crashes"
             ls -la "$crashes"
@@ -67,7 +71,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-smoke-crashes
+          name: fuzz-smoke-crashes-${{ matrix.test }}
           path: fuzz/subscriptions/crashes/
           if-no-files-found: ignore
 
@@ -77,6 +81,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [invariant_subscriptions, invariant_subscriptions_t22]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -99,32 +107,32 @@ jobs:
       - name: Restore corpus
         uses: actions/cache@v4
         with:
-          path: fuzz/subscriptions/corpus
-          key: fuzz-corpus-${{ github.run_id }}
-          restore-keys: fuzz-corpus-
+          path: fuzz/subscriptions/corpus-${{ matrix.test }}
+          key: fuzz-corpus-${{ matrix.test }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-${{ matrix.test }}-
 
       - name: Build program and clients
         run: just build-program && just generate-clients
 
       - name: Fuzz (deep)
         run: |
-          crucible run subscriptions invariant_subscriptions \
+          crucible run subscriptions ${{ matrix.test }} \
             --release -j 4 \
             --timeout ${{ github.event.inputs.timeout || '7200' }} \
-            --corpus-in fuzz/subscriptions/corpus \
-            --corpus-out fuzz/subscriptions/corpus
+            --corpus-in fuzz/subscriptions/corpus-${{ matrix.test }} \
+            --corpus-out fuzz/subscriptions/corpus-${{ matrix.test }}
 
       - name: Upload crashes
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-nightly-crashes
+          name: fuzz-nightly-crashes-${{ matrix.test }}
           path: fuzz/subscriptions/crashes/
           if-no-files-found: ignore
 
       - name: Fail on crashes
         run: |
-          crashes="fuzz/subscriptions/crashes/invariant_subscriptions"
+          crashes="fuzz/subscriptions/crashes/${{ matrix.test }}"
           if [ -d "$crashes" ] && [ -n "$(ls -A "$crashes" 2>/dev/null)" ]; then
             echo "::error::Fuzzer found crashes"
             ls -la "$crashes"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [invariant_subscriptions, invariant_subscriptions_t22]
+        test: [invariant_subscriptions, invariant_subscriptions_t22, invariant_subscriptions_hook]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -53,6 +53,9 @@ jobs:
 
       - name: Install crucible CLI
         run: command -v crucible >/dev/null || just install-fuzzer
+
+      - name: Build transfer-hook program
+        run: just build-test-hook
 
       - name: Fuzz (smoke)
         run: just fuzz ${{ matrix.test }} 60
@@ -84,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [invariant_subscriptions, invariant_subscriptions_t22]
+        test: [invariant_subscriptions, invariant_subscriptions_t22, invariant_subscriptions_hook]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -112,7 +115,7 @@ jobs:
           restore-keys: fuzz-corpus-${{ matrix.test }}-
 
       - name: Build program and clients
-        run: just build-program && just generate-clients
+        run: just build-program && just generate-clients && just build-test-hook
 
       - name: Fuzz (deep)
         run: |

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4919,6 +4919,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "spl-associated-token-account-interface",
+ "spl-token-2022-interface",
  "spl-token-interface 3.0.0",
  "subscriptions",
 ]

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4688,6 +4688,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-program-error"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4f6cf26cb6768110bf024bc7224326c720d711f7ad25d16f40f6cee40edb2d"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-msg",
+ "solana-program-error",
+ "spl-program-error-derive",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec8965aa4dc6c74701cbb48b9cad5af35b9a394514934949edbb357b78f840d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "spl-token"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,6 +4900,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-transfer-hook-interface"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface 2.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "spl-type-length-value"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,6 +4986,7 @@ dependencies = [
  "libafl",
  "libafl_bolts",
  "solana-clock",
+ "solana-instruction",
  "solana-keypair",
  "solana-program-pack",
  "solana-pubkey 3.0.0",
@@ -4919,8 +4994,10 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "spl-associated-token-account-interface",
+ "spl-tlv-account-resolution",
  "spl-token-2022-interface",
  "spl-token-interface 3.0.0",
+ "spl-transfer-hook-interface",
  "subscriptions",
 ]
 

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4913,6 +4913,7 @@ dependencies = [
  "libafl_bolts",
  "solana-clock",
  "solana-keypair",
+ "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -23,6 +23,7 @@ solana-program-pack = "3.0"
 solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
+spl-token-2022-interface = "2.1"
 
 [[bin]]
 name = "invariant_test"

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -19,6 +19,7 @@ solana-keypair = "3.0"
 solana-pubkey = "3.0"
 solana-rent = "3.0"
 solana-sdk-ids = "3.0"
+solana-program-pack = "3.0"
 solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
@@ -29,3 +30,4 @@ path = "src/main.rs"
 
 [features]
 invariant_subscriptions = []
+invariant_subscriptions_t22 = []

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -15,6 +15,7 @@ ctrlc = "3.4"
 libafl = { version = "0.15.1", features = ["std", "cli", "prelude"] }
 libafl_bolts = { version = "0.15.1", features = ["std"] }
 solana-clock = "3.0"
+solana-instruction = "3.1"
 solana-keypair = "3.0"
 solana-pubkey = "3.0"
 solana-rent = "3.0"
@@ -24,6 +25,8 @@ solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
 spl-token-2022-interface = "2.1"
+spl-tlv-account-resolution = "0.11.1"
+spl-transfer-hook-interface = "2.1.0"
 
 [[bin]]
 name = "invariant_test"
@@ -32,3 +35,4 @@ path = "src/main.rs"
 [features]
 invariant_subscriptions = []
 invariant_subscriptions_t22 = []
+invariant_subscriptions_hook = []

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -148,6 +148,52 @@ impl SubscriptionsFixture {
         self.set_time(self.now_ts + hours * 3600);
     }
 
+    // Create plans with fuzzed shapes to reach the CreatePlan validation branches that the single
+    // fixed setup plan never touches: zero amount, out-of-range periods, end_ts bounds, and
+    // varied destination/puller counts. plan_id 1 collides with the setup plan (already-exists
+    // path); 2..5 are fresh.
+    pub fn action_create_plan(
+        &mut self,
+        #[range(1..5)] plan_id: u64,
+        #[range(0..2_000_001)] amount: u64,
+        #[range(0..8762)] period_hours: u64,
+        #[range(0..5)] destination_count: usize,
+        #[range(0..5)] puller_count: usize,
+        #[range(0..100)] end_hours: i64,
+    ) -> bool {
+        let candidates = [
+            self.merchant.pubkey(),
+            self.subscribers[0].pubkey(),
+            self.subscribers[1].pubkey(),
+            self.subscribers[2].pubkey(),
+        ];
+        let mut destinations = [Pubkey::default(); 4];
+        let mut pullers = [Pubkey::default(); 4];
+        for (i, slot) in destinations.iter_mut().enumerate().take(destination_count) {
+            *slot = candidates[i];
+        }
+        for (i, slot) in pullers.iter_mut().enumerate().take(puller_count) {
+            *slot = candidates[i];
+        }
+        let (plan_pda, _) = plan_pda_address(&self.merchant.pubkey(), plan_id);
+        let ix = CreatePlanBuilder::new()
+            .merchant(self.merchant.pubkey())
+            .plan_pda(plan_pda)
+            .token_mint(self.mint)
+            .token_program(TOKEN_PROGRAM)
+            .plan_data(PlanData {
+                plan_id,
+                mint: self.mint,
+                terms: PlanTerms { amount, period_hours, created_at: 0 },
+                end_ts: if end_hours == 0 { 0 } else { self.now_ts + end_hours * 3600 },
+                destinations,
+                pullers,
+                metadata_uri: [0u8; 128],
+            })
+            .instruction();
+        self.ctx.raw_call(ix).signers(&[&self.merchant.clone()]).send().map(|o| o.is_success()).unwrap_or(false)
+    }
+
     fn current_subscribe_data(&self, subscriber: &Pubkey) -> Option<SubscribeData> {
         let plan = self.read_plan()?;
         let authority = self.read_authority(subscriber)?;

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -40,6 +40,9 @@ pub struct SubscriptionsFixture {
     // action runs between checks, so a balance drop observed while the flag was false means
     // tokens moved through a closed authority.
     pub prev_spend_state: Vec<(u64, bool)>,
+    // (hook program, extra-account-metas PDA, counter) when the mint carries a transfer hook;
+    // appended as remaining accounts on transfers so the Token-2022 hook CPI can resolve.
+    pub hook_accounts: Option<(Pubkey, Pubkey, Pubkey)>,
 }
 
 impl SubscriptionsFixture {
@@ -89,6 +92,14 @@ impl SubscriptionsFixture {
         let mint_authority = Keypair::new();
         let mint = Pubkey::new_unique();
         create_mint(&mut ctx, &mint, &mint_authority.pubkey(), MINT_DECIMALS);
+
+        #[cfg(feature = "invariant_subscriptions_hook")]
+        let hook_accounts = {
+            let (validation_pda, counter) = crate::helpers::setup_hook(&mut ctx, &mint);
+            Some((crate::helpers::HOOK_PROGRAM, validation_pda, counter))
+        };
+        #[cfg(not(feature = "invariant_subscriptions_hook"))]
+        let hook_accounts = None;
 
         let merchant = create_funded_wallet(&mut ctx);
         let merchant_ata = create_ata(&mut ctx, &merchant.pubkey(), &mint, 0);
@@ -141,6 +152,15 @@ impl SubscriptionsFixture {
             plan_bump,
             now_ts: GENESIS_TS,
             prev_spend_state: vec![(INITIAL_TOKENS, true); SUBSCRIBER_COUNT],
+            hook_accounts,
+        }
+    }
+
+    fn append_hook_accounts(&self, ix: &mut solana_instruction::Instruction) {
+        if let Some((program, validation, counter)) = self.hook_accounts {
+            ix.accounts.push(solana_instruction::AccountMeta::new_readonly(program, false));
+            ix.accounts.push(solana_instruction::AccountMeta::new_readonly(validation, false));
+            ix.accounts.push(solana_instruction::AccountMeta::new(counter, false));
         }
     }
 
@@ -274,6 +294,8 @@ impl SubscriptionsFixture {
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
+        let mut ix = ix;
+        self.append_hook_accounts(&mut ix);
         self.ctx
             .raw_call(ix)
             .signers(&[&self.merchant.clone()])
@@ -410,6 +432,8 @@ impl SubscriptionsFixture {
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
+        let mut ix = ix;
+        self.append_hook_accounts(&mut ix);
         self.ctx
             .raw_call(ix)
             .signers(&[&self.merchant.clone()])

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -148,10 +148,21 @@ impl SubscriptionsFixture {
         self.set_time(self.now_ts + hours * 3600);
     }
 
-    pub fn action_subscribe(&mut self, #[range(0..3)] subscriber_idx: usize) -> bool {
-        let subscriber = self.subscribers[subscriber_idx].clone();
-        let Some(plan) = self.read_plan() else { return false };
-        let Some(authority) = self.read_authority(&subscriber.pubkey()) else { return false };
+    fn current_subscribe_data(&self, subscriber: &Pubkey) -> Option<SubscribeData> {
+        let plan = self.read_plan()?;
+        let authority = self.read_authority(subscriber)?;
+        Some(SubscribeData {
+            plan_id: PLAN_ID,
+            plan_bump: self.plan_bump,
+            expected_mint: plan.data.mint,
+            expected_amount: plan.data.terms.amount,
+            expected_period_hours: plan.data.terms.period_hours,
+            expected_created_at: plan.data.terms.created_at,
+            expected_subscription_authority_init_id: authority.init_id,
+        })
+    }
+
+    fn send_subscribe(&mut self, subscriber: &Rc<Keypair>, data: SubscribeData) -> bool {
         let (authority_pda, _) = SubscriptionAuthority::find_pda(&subscriber.pubkey(), &self.mint);
         let ix = SubscribeBuilder::new()
             .subscriber(subscriber.pubkey())
@@ -160,17 +171,39 @@ impl SubscriptionsFixture {
             .subscription_pda(self.subscription_pda(&subscriber.pubkey()))
             .subscription_authority_pda(authority_pda)
             .event_authority(EventAuthority::find_pda().0)
-            .subscribe_data(SubscribeData {
-                plan_id: PLAN_ID,
-                plan_bump: self.plan_bump,
-                expected_mint: plan.data.mint,
-                expected_amount: plan.data.terms.amount,
-                expected_period_hours: plan.data.terms.period_hours,
-                expected_created_at: plan.data.terms.created_at,
-                expected_subscription_authority_init_id: authority.init_id,
-            })
+            .subscribe_data(data)
             .instruction();
-        self.ctx.raw_call(ix).signers(&[&subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
+        self.ctx.raw_call(ix).signers(&[subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
+    }
+
+    pub fn action_subscribe(&mut self, #[range(0..3)] subscriber_idx: usize) -> bool {
+        let subscriber = self.subscribers[subscriber_idx].clone();
+        let Some(data) = self.current_subscribe_data(&subscriber.pubkey()) else { return false };
+        self.send_subscribe(&subscriber, data)
+    }
+
+    // Subscribe with one expected_* field deliberately wrong, forcing a compare-and-swap
+    // mismatch. The program's guards must reject every variant (StaleSubscriptionAuthority for a
+    // wrong init_id, PlanTermsMismatch for wrong terms); the shared invariants confirm a rejected
+    // attempt leaves no partial state behind.
+    pub fn action_subscribe_wrong_approval(
+        &mut self,
+        #[range(0..3)] subscriber_idx: usize,
+        #[range(0..5)] field: usize,
+    ) -> bool {
+        let subscriber = self.subscribers[subscriber_idx].clone();
+        let Some(mut data) = self.current_subscribe_data(&subscriber.pubkey()) else { return false };
+        match field {
+            0 => data.expected_amount = data.expected_amount.wrapping_add(1),
+            1 => data.expected_period_hours = data.expected_period_hours.wrapping_add(1),
+            2 => data.expected_created_at = data.expected_created_at.wrapping_add(1),
+            3 => {
+                data.expected_subscription_authority_init_id =
+                    data.expected_subscription_authority_init_id.wrapping_add(1)
+            }
+            _ => data.expected_mint = self.plan_pda,
+        }
+        self.send_subscribe(&subscriber, data)
     }
 
     pub fn action_pull_payment(

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -22,7 +22,8 @@ use crate::constants::{
     GENESIS_TS, INITIAL_TOKENS, MINT_DECIMALS, PLAN_AMOUNT, PLAN_ID, PLAN_PERIOD_HOURS, SUBSCRIBER_COUNT,
 };
 use crate::helpers::{
-    ata_address, create_ata, create_funded_wallet, delegation_pda_address, plan_pda_address, set_clock,
+    ata_address, create_ata, create_funded_wallet, create_mint, delegation_pda_address, plan_pda_address, set_clock,
+    TOKEN_PROGRAM,
 };
 
 #[derive(Clone)]
@@ -87,12 +88,7 @@ impl SubscriptionsFixture {
 
         let mint_authority = Keypair::new();
         let mint = Pubkey::new_unique();
-        ctx.create_mint()
-            .pubkey(mint)
-            .mint_authority(mint_authority.pubkey())
-            .decimals(MINT_DECIMALS)
-            .create()
-            .expect("create mint");
+        create_mint(&mut ctx, &mint, &mint_authority.pubkey(), MINT_DECIMALS);
 
         let merchant = create_funded_wallet(&mut ctx);
         let merchant_ata = create_ata(&mut ctx, &merchant.pubkey(), &mint, 0);
@@ -107,7 +103,7 @@ impl SubscriptionsFixture {
                 .subscription_authority(authority_pda)
                 .token_mint(mint)
                 .user_ata(user_ata)
-                .token_program(spl_token_interface::ID)
+                .token_program(TOKEN_PROGRAM)
                 .instruction();
             ctx.raw_call(ix).signers(&[&subscriber]).send().expect("send init authority").unwrap();
             subscribers.push(subscriber);
@@ -122,6 +118,7 @@ impl SubscriptionsFixture {
             .merchant(merchant.pubkey())
             .plan_pda(plan_pda)
             .token_mint(mint)
+            .token_program(TOKEN_PROGRAM)
             .plan_data(PlanData {
                 plan_id: PLAN_ID,
                 mint,
@@ -194,7 +191,7 @@ impl SubscriptionsFixture {
             .receiver_ata(self.merchant_ata)
             .caller(self.merchant.pubkey())
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
@@ -329,7 +326,7 @@ impl SubscriptionsFixture {
             .delegator_ata(ata_address(&subscriber.pubkey(), &self.mint))
             .receiver_ata(self.merchant_ata)
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .delegatee(delegatee)
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
@@ -411,7 +408,7 @@ impl SubscriptionsFixture {
             .user(subscriber.pubkey())
             .user_ata(ata_address(&subscriber.pubkey(), &self.mint))
             .token_mint(self.mint)
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .subscription_authority(authority_pda)
             .instruction();
         self.ctx.raw_call(ix).signers(&[&subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
@@ -435,7 +432,7 @@ impl SubscriptionsFixture {
             .subscription_authority(authority_pda)
             .token_mint(self.mint)
             .user_ata(ata_address(&subscriber.pubkey(), &self.mint))
-            .token_program(spl_token_interface::ID)
+            .token_program(TOKEN_PROGRAM)
             .instruction();
         self.ctx.raw_call(ix).signers(&[&subscriber]).send().map(|outcome| outcome.is_success()).unwrap_or(false)
     }

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -14,7 +14,7 @@ use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 #[cfg(not(feature = "invariant_subscriptions_t22"))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
 #[cfg(feature = "invariant_subscriptions_t22")]
-pub const TOKEN_PROGRAM: Pubkey = Pubkey::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+pub const TOKEN_PROGRAM: Pubkey = spl_token_2022_interface::ID;
 
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
@@ -60,7 +60,7 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
 #[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
     use solana_program_pack::Pack;
-    use spl_token_interface::state::Mint;
+    use spl_token_2022_interface::state::Mint;
 
     let mut data = vec![0u8; Mint::LEN];
     Mint {
@@ -83,7 +83,7 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
 #[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     use solana_program_pack::Pack;
-    use spl_token_interface::state::{Account, AccountState};
+    use spl_token_2022_interface::state::{Account, AccountState};
 
     let ata = ata_address(owner, mint);
     let mut data = vec![0u8; Account::LEN];

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -3,9 +3,11 @@ use std::rc::Rc;
 use crucible_fuzzer::{AccountBuilderBase, TestContext};
 use solana_clock::Clock;
 use solana_keypair::Keypair;
+use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+use spl_token_2022_interface::state::{Account, AccountState, Mint};
 use subscriptions::accounts::Plan;
 use subscriptions::SUBSCRIPTIONS_ID;
 
@@ -43,25 +45,9 @@ pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
     get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
+// The base mint (82 bytes) and token-account (165 bytes) layouts are identical for classic SPL
+// and Token-2022, so both mints are packed the same way and differ only in the owning program.
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    ctx.create_mint().pubkey(*mint).mint_authority(*authority).decimals(decimals).create().expect("create mint");
-}
-
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
-pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
-    let ata = ata_address(owner, mint);
-    ctx.create_token_account().pubkey(ata).mint(*mint).token_owner(*owner).amount(amount).create().expect("create ata");
-    ata
-}
-
-// Token-2022 base accounts share the classic SPL layout (82-byte mint, 165-byte token account) and
-// are accepted by the program without an account-type discriminator, so they are packed directly.
-#[cfg(feature = "invariant_subscriptions_t22")]
-pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    use solana_program_pack::Pack;
-    use spl_token_2022_interface::state::Mint;
-
     let mut data = vec![0u8; Mint::LEN];
     Mint {
         mint_authority: Some(*authority).into(),
@@ -77,14 +63,10 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
         .owner(TOKEN_PROGRAM)
         .data(&data)
         .create()
-        .expect("create token-2022 mint");
+        .expect("create mint");
 }
 
-#[cfg(feature = "invariant_subscriptions_t22")]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
-    use solana_program_pack::Pack;
-    use spl_token_2022_interface::state::{Account, AccountState};
-
     let ata = ata_address(owner, mint);
     let mut data = vec![0u8; Account::LEN];
     Account {
@@ -104,7 +86,7 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         .owner(TOKEN_PROGRAM)
         .data(&data)
         .create()
-        .expect("create token-2022 ata");
+        .expect("create ata");
     ata
 }
 

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -11,6 +11,11 @@ use subscriptions::SUBSCRIPTIONS_ID;
 
 use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
+pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub const TOKEN_PROGRAM: Pubkey = Pubkey::from_str_const("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
     ctx.warp_to_slot(slot);
@@ -35,18 +40,71 @@ pub fn create_funded_wallet(ctx: &mut TestContext) -> Rc<Keypair> {
 }
 
 pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
-    get_associated_token_address_with_program_id(owner, mint, &spl_token_interface::ID)
+    get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
+pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
+    ctx.create_mint().pubkey(*mint).mint_authority(*authority).decimals(decimals).create().expect("create mint");
+}
+
+#[cfg(not(feature = "invariant_subscriptions_t22"))]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     let ata = ata_address(owner, mint);
-    ctx.create_token_account()
-        .pubkey(ata)
-        .mint(*mint)
-        .token_owner(*owner)
-        .amount(amount)
+    ctx.create_token_account().pubkey(ata).mint(*mint).token_owner(*owner).amount(amount).create().expect("create ata");
+    ata
+}
+
+// Token-2022 base accounts share the classic SPL layout (82-byte mint, 165-byte token account) and
+// are accepted by the program without an account-type discriminator, so they are packed directly.
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
+    use solana_program_pack::Pack;
+    use spl_token_interface::state::Mint;
+
+    let mut data = vec![0u8; Mint::LEN];
+    Mint {
+        mint_authority: Some(*authority).into(),
+        supply: 0,
+        decimals,
+        is_initialized: true,
+        freeze_authority: None.into(),
+    }
+    .pack_into_slice(&mut data);
+    ctx.create_account()
+        .pubkey(*mint)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
         .create()
-        .expect("create token account");
+        .expect("create token-2022 mint");
+}
+
+#[cfg(feature = "invariant_subscriptions_t22")]
+pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
+    use solana_program_pack::Pack;
+    use spl_token_interface::state::{Account, AccountState};
+
+    let ata = ata_address(owner, mint);
+    let mut data = vec![0u8; Account::LEN];
+    Account {
+        mint: *mint,
+        owner: *owner,
+        amount,
+        delegate: None.into(),
+        state: AccountState::Initialized,
+        is_native: None.into(),
+        delegated_amount: 0,
+        close_authority: None.into(),
+    }
+    .pack_into_slice(&mut data);
+    ctx.create_account()
+        .pubkey(ata)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
+        .create()
+        .expect("create token-2022 ata");
     ata
 }
 

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -7,16 +7,37 @@ use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_tlv_account_resolution::account::ExtraAccountMeta;
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_tlv_account_resolution::state::ExtraAccountMetaList;
+use spl_token_2022_interface::extension::transfer_hook::{TransferHook, TransferHookAccount};
+use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
 use spl_token_2022_interface::state::{Account, AccountState, Mint};
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 use subscriptions::accounts::Plan;
 use subscriptions::SUBSCRIPTIONS_ID;
 
 use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
+#[cfg(not(any(feature = "invariant_subscriptions_t22", feature = "invariant_subscriptions_hook")))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
-#[cfg(feature = "invariant_subscriptions_t22")]
+#[cfg(any(feature = "invariant_subscriptions_t22", feature = "invariant_subscriptions_hook"))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_2022_interface::ID;
+
+pub const HOOK_PROGRAM: Pubkey = Pubkey::new_from_array([42u8; 32]);
+
+// Mint / token-account extensions applied per feature. Empty for classic and plain Token-2022;
+// the hook variant carries the paired TransferHook / TransferHookAccount extensions.
+#[cfg(feature = "invariant_subscriptions_hook")]
+const MINT_EXTENSIONS: &[ExtensionType] = &[ExtensionType::TransferHook];
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
+const MINT_EXTENSIONS: &[ExtensionType] = &[];
+#[cfg(feature = "invariant_subscriptions_hook")]
+const ATA_EXTENSIONS: &[ExtensionType] = &[ExtensionType::TransferHookAccount];
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
+const ATA_EXTENSIONS: &[ExtensionType] = &[];
 
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
@@ -45,18 +66,51 @@ pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
     get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
-// The base mint (82 bytes) and token-account (165 bytes) layouts are identical for classic SPL
-// and Token-2022, so both mints are packed the same way and differ only in the owning program.
+// Reads the SPL token `amount` from its fixed base offset (bytes 64..72). Unlike
+// TestContext::token_balance, this works for Token-2022 accounts carrying extensions, whose
+// length exceeds the classic 165-byte layout the unpack there requires.
+pub fn token_amount(ctx: &TestContext, ata: &Pubkey) -> u64 {
+    match ctx.get_account(ata) {
+        Ok(acc) if acc.data.len() >= 72 => u64::from_le_bytes(acc.data[64..72].try_into().unwrap()),
+        _ => 0,
+    }
+}
+
+// One mint/token-account builder for all variants: the base 82/165-byte layout when no
+// extensions apply, otherwise the extension-packed layout. MINT_EXTENSIONS/ATA_EXTENSIONS select
+// the shape per feature, so classic, plain Token-2022, and the hook variant share this path.
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    let mut data = vec![0u8; Mint::LEN];
-    Mint {
+    let base = Mint {
         mint_authority: Some(*authority).into(),
         supply: 0,
         decimals,
         is_initialized: true,
         freeze_authority: None.into(),
-    }
-    .pack_into_slice(&mut data);
+    };
+    let data = if MINT_EXTENSIONS.is_empty() {
+        let mut data = vec![0u8; Mint::LEN];
+        base.pack_into_slice(&mut data);
+        data
+    } else {
+        let space = ExtensionType::try_calculate_account_len::<Mint>(MINT_EXTENSIONS).unwrap();
+        let mut data = vec![0u8; space];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut data).unwrap();
+        state.base = base;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        for ext in MINT_EXTENSIONS {
+            match ext {
+                ExtensionType::TransferHook => {
+                    let hook = state.init_extension::<TransferHook>(true).unwrap();
+                    hook.authority = Some(*authority).try_into().unwrap();
+                    hook.program_id = Some(HOOK_PROGRAM).try_into().unwrap();
+                }
+                other => panic!("unsupported mint extension: {other:?}"),
+            }
+        }
+        drop(state);
+        data
+    };
     ctx.create_account()
         .pubkey(*mint)
         .lamports(INITIAL_LAMPORTS)
@@ -68,8 +122,7 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
 
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     let ata = ata_address(owner, mint);
-    let mut data = vec![0u8; Account::LEN];
-    Account {
+    let base = Account {
         mint: *mint,
         owner: *owner,
         amount,
@@ -78,8 +131,29 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         is_native: None.into(),
         delegated_amount: 0,
         close_authority: None.into(),
-    }
-    .pack_into_slice(&mut data);
+    };
+    let data = if ATA_EXTENSIONS.is_empty() {
+        let mut data = vec![0u8; Account::LEN];
+        base.pack_into_slice(&mut data);
+        data
+    } else {
+        let space = ExtensionType::try_calculate_account_len::<Account>(ATA_EXTENSIONS).unwrap();
+        let mut data = vec![0u8; space];
+        let mut state = StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut data).unwrap();
+        state.base = base;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        for ext in ATA_EXTENSIONS {
+            match ext {
+                ExtensionType::TransferHookAccount => {
+                    state.init_extension::<TransferHookAccount>(true).unwrap();
+                }
+                other => panic!("unsupported account extension: {other:?}"),
+            }
+        }
+        drop(state);
+        data
+    };
     ctx.create_account()
         .pubkey(ata)
         .lamports(INITIAL_LAMPORTS)
@@ -88,6 +162,43 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         .create()
         .expect("create ata");
     ata
+}
+
+// Loads the transfer-hook example program and installs its extra-account-metas list plus the
+// counter account it increments on each transfer. Returns (validation_pda, counter).
+#[cfg(feature = "invariant_subscriptions_hook")]
+pub fn setup_hook(ctx: &mut TestContext, mint: &Pubkey) -> (Pubkey, Pubkey) {
+    ctx.add_program(&HOOK_PROGRAM, "../../tests/transfer-hook-example/target/deploy/transfer_hook_example.so")
+        .expect("load hook program");
+
+    let (validation_pda, _) = Pubkey::find_program_address(&[b"extra-account-metas", mint.as_ref()], &HOOK_PROGRAM);
+    let counter = Pubkey::new_unique();
+
+    let meta = ExtraAccountMeta {
+        discriminator: 0,
+        address_config: counter.to_bytes(),
+        is_signer: false.into(),
+        is_writable: true.into(),
+    };
+    let mut validation_data = vec![0u8; ExtraAccountMetaList::size_of(1).unwrap()];
+    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut validation_data, &[meta]).unwrap();
+
+    ctx.create_account()
+        .pubkey(validation_pda)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(HOOK_PROGRAM)
+        .data(&validation_data)
+        .create()
+        .expect("create validation pda");
+    ctx.create_account()
+        .pubkey(counter)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(HOOK_PROGRAM)
+        .data(&[0u8])
+        .create()
+        .expect("create counter");
+
+    (validation_pda, counter)
 }
 
 // Plan::find_pda in the generated client encodes plan_id as a string; the program derives

--- a/fuzz/subscriptions/src/invariants.rs
+++ b/fuzz/subscriptions/src/invariants.rs
@@ -4,7 +4,7 @@ use subscriptions::accounts::{RecurringDelegation, SubscriptionDelegation};
 
 use crate::constants::{INITIAL_TOKENS, SUBSCRIBER_COUNT};
 use crate::fixture::SubscriptionsFixture;
-use crate::helpers::ata_address;
+use crate::helpers::{ata_address, token_amount};
 
 const RECURRING_NONCES: [u64; 3] = [3, 4, 5];
 
@@ -47,7 +47,7 @@ pub fn check_recurring_delegation_caps(fixture: &SubscriptionsFixture) {
 pub fn check_dead_authority_inert(fixture: &mut SubscriptionsFixture) {
     for idx in 0..fixture.subscribers.len() {
         let subscriber = fixture.subscribers[idx].pubkey();
-        let balance = fixture.ctx.token_balance(&ata_address(&subscriber, &fixture.mint));
+        let balance = token_amount(&fixture.ctx, &ata_address(&subscriber, &fixture.mint));
         let alive = fixture.read_authority(&subscriber).is_some();
         let (prev_balance, prev_alive) = fixture.prev_spend_state[idx];
         if !prev_alive {
@@ -63,8 +63,8 @@ pub fn check_dead_authority_inert(fixture: &mut SubscriptionsFixture) {
 
 pub fn check_token_conservation(fixture: &SubscriptionsFixture) {
     let subscriber_total: u64 =
-        fixture.subscribers.iter().map(|s| fixture.ctx.token_balance(&ata_address(&s.pubkey(), &fixture.mint))).sum();
-    let merchant_balance = fixture.ctx.token_balance(&fixture.merchant_ata);
+        fixture.subscribers.iter().map(|s| token_amount(&fixture.ctx, &ata_address(&s.pubkey(), &fixture.mint))).sum();
+    let merchant_balance = token_amount(&fixture.ctx, &fixture.merchant_ata);
     fuzz_assert_eq!(
         subscriber_total + merchant_balance,
         INITIAL_TOKENS * SUBSCRIBER_COUNT as u64,

--- a/fuzz/subscriptions/src/main.rs
+++ b/fuzz/subscriptions/src/main.rs
@@ -29,3 +29,11 @@ fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
 fn invariant_subscriptions_t22(fixture: &mut SubscriptionsFixture) {
     check_all(fixture);
 }
+
+// Against a Token-2022 mint with a TransferHook extension: transfers forward the hook program
+// and its extra accounts, exercising the program's hook-forwarding path. The hook only bumps a
+// counter, so token conservation still holds and all invariants apply unchanged.
+#[invariant_test]
+fn invariant_subscriptions_hook(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
+}

--- a/fuzz/subscriptions/src/main.rs
+++ b/fuzz/subscriptions/src/main.rs
@@ -11,10 +11,21 @@ use crate::invariants::{
     check_token_conservation,
 };
 
-#[invariant_test]
-fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
+fn check_all(fixture: &mut SubscriptionsFixture) {
     check_subscriptions_decodable_and_capped(fixture);
     check_recurring_delegation_caps(fixture);
     check_token_conservation(fixture);
     check_dead_authority_inert(fixture);
+}
+
+#[invariant_test]
+fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
+}
+
+// Same actions and invariants against a Token-2022 mint; the token program is selected at
+// build time by the matching feature (see helpers::TOKEN_PROGRAM).
+#[invariant_test]
+fn invariant_subscriptions_t22(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
 }


### PR DESCRIPTION
Stacked on #223 (base branch `test/crucible-fuzz-harness`). The advanced fuzzing cases, kept separate from the core harness so #223 stays small and reviewable.

## What's here (4 commits)

### Token-2022 mint variant
- New `invariant_subscriptions_t22` test: the same 16 actions and all 4 invariants run against a **Token-2022** mint, exercising the program's token-program dispatch and Token-2022 CPI paths (cold on classic-only)
- Token program selected at build time by feature (`helpers::TOKEN_PROGRAM`); fixture/actions/invariants shared verbatim
- Base Token-2022 mints/accounts share the classic SPL layout, packed via the already-resolved `spl-token-2022-interface` (no dependency conflict) with the Token-2022 owner
- One unified `create_mint`/`create_ata` pair for both token programs (differ only by owner)
- CI smoke + nightly matrix over both mints, per-mint corpus caches

### Adversarial wrong-approval subscribe
- `action_subscribe_wrong_approval` reads the current approval, corrupts one `expected_*` field, and sends — forcing a compare-and-swap mismatch on each guarded field in turn (amount, period, created_at, init_id, mint)
- Drives the `StaleSubscriptionAuthority` and `PlanTermsMismatch` reject branches (the #214/#221-era audit fixes) that honest actions almost never reach
- **No new invariant** — the existing caps/conservation/dead-authority checks verify a rejected attempt leaves no partial state, which is the property that matters if a guard ever fails to fire (encoding "stale must fail" directly is the same trap that produced a false positive with the removed expiry-monotonicity check)

## Test plan
- `crucible run subscriptions invariant_subscriptions --timeout 60` and `... invariant_subscriptions_t22 --timeout 60` → 0 crashes on both mints
- Token-2022 branch coverage lands above classic (dispatch/CPI paths now covered)
- Instrumented adversarial check: all 5 corrupted-field variants execute, 866 attempts, **every one rejected**, 0 wrongly accepted
- Both features `cargo check` clean; CI smoke matrix green

## Notes
- `CreatePlan`'s builder defaults `token_program` to classic SPL — must be set explicitly for a Token-2022 mint or it fails `InvalidTokenProgram` (fuzzer caught this)

Follow-ups (separate PRs): Token-2022 extensions (transfer-fee/hook); scoped test split.