### PR TITLE
test(fuzz): token-2022 transfer-hook variant

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [invariant_subscriptions, invariant_subscriptions_t22]
+        test: [invariant_subscriptions, invariant_subscriptions_t22, invariant_subscriptions_hook]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -53,6 +53,9 @@ jobs:
 
       - name: Install crucible CLI
         run: command -v crucible >/dev/null || just install-fuzzer
+
+      - name: Build transfer-hook program
+        run: just build-test-hook
 
       - name: Fuzz (smoke)
         run: just fuzz ${{ matrix.test }} 60
@@ -84,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [invariant_subscriptions, invariant_subscriptions_t22]
+        test: [invariant_subscriptions, invariant_subscriptions_t22, invariant_subscriptions_hook]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -112,7 +115,7 @@ jobs:
           restore-keys: fuzz-corpus-${{ matrix.test }}-
 
       - name: Build program and clients
-        run: just build-program && just generate-clients
+        run: just build-program && just generate-clients && just build-test-hook
 
       - name: Fuzz (deep)
         run: |

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4688,6 +4688,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-program-error"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4f6cf26cb6768110bf024bc7224326c720d711f7ad25d16f40f6cee40edb2d"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-msg",
+ "solana-program-error",
+ "spl-program-error-derive",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec8965aa4dc6c74701cbb48b9cad5af35b9a394514934949edbb357b78f840d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "spl-token"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,6 +4900,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-transfer-hook-interface"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-system-interface 2.0.0",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "spl-type-length-value"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,6 +4986,7 @@ dependencies = [
  "libafl",
  "libafl_bolts",
  "solana-clock",
+ "solana-instruction",
  "solana-keypair",
  "solana-program-pack",
  "solana-pubkey 3.0.0",
@@ -4919,8 +4994,10 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "spl-associated-token-account-interface",
+ "spl-tlv-account-resolution",
  "spl-token-2022-interface",
  "spl-token-interface 3.0.0",
+ "spl-transfer-hook-interface",
  "subscriptions",
 ]
 

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -15,6 +15,7 @@ ctrlc = "3.4"
 libafl = { version = "0.15.1", features = ["std", "cli", "prelude"] }
 libafl_bolts = { version = "0.15.1", features = ["std"] }
 solana-clock = "3.0"
+solana-instruction = "3.1"
 solana-keypair = "3.0"
 solana-pubkey = "3.0"
 solana-rent = "3.0"
@@ -24,6 +25,8 @@ solana-signer = "3.0"
 spl-associated-token-account-interface = "2.0.0"
 spl-token-interface = "3.0.0"
 spl-token-2022-interface = "2.1"
+spl-tlv-account-resolution = "0.11.1"
+spl-transfer-hook-interface = "2.1.0"
 
 [[bin]]
 name = "invariant_test"
@@ -32,3 +35,4 @@ path = "src/main.rs"
 [features]
 invariant_subscriptions = []
 invariant_subscriptions_t22 = []
+invariant_subscriptions_hook = []

--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -40,6 +40,9 @@ pub struct SubscriptionsFixture {
     // action runs between checks, so a balance drop observed while the flag was false means
     // tokens moved through a closed authority.
     pub prev_spend_state: Vec<(u64, bool)>,
+    // (hook program, extra-account-metas PDA, counter) when the mint carries a transfer hook;
+    // appended as remaining accounts on transfers so the Token-2022 hook CPI can resolve.
+    pub hook_accounts: Option<(Pubkey, Pubkey, Pubkey)>,
 }
 
 impl SubscriptionsFixture {
@@ -89,6 +92,14 @@ impl SubscriptionsFixture {
         let mint_authority = Keypair::new();
         let mint = Pubkey::new_unique();
         create_mint(&mut ctx, &mint, &mint_authority.pubkey(), MINT_DECIMALS);
+
+        #[cfg(feature = "invariant_subscriptions_hook")]
+        let hook_accounts = {
+            let (validation_pda, counter) = crate::helpers::setup_hook(&mut ctx, &mint);
+            Some((crate::helpers::HOOK_PROGRAM, validation_pda, counter))
+        };
+        #[cfg(not(feature = "invariant_subscriptions_hook"))]
+        let hook_accounts = None;
 
         let merchant = create_funded_wallet(&mut ctx);
         let merchant_ata = create_ata(&mut ctx, &merchant.pubkey(), &mint, 0);
@@ -141,6 +152,15 @@ impl SubscriptionsFixture {
             plan_bump,
             now_ts: GENESIS_TS,
             prev_spend_state: vec![(INITIAL_TOKENS, true); SUBSCRIBER_COUNT],
+            hook_accounts,
+        }
+    }
+
+    fn append_hook_accounts(&self, ix: &mut solana_instruction::Instruction) {
+        if let Some((program, validation, counter)) = self.hook_accounts {
+            ix.accounts.push(solana_instruction::AccountMeta::new_readonly(program, false));
+            ix.accounts.push(solana_instruction::AccountMeta::new_readonly(validation, false));
+            ix.accounts.push(solana_instruction::AccountMeta::new(counter, false));
         }
     }
 
@@ -274,6 +294,8 @@ impl SubscriptionsFixture {
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
+        let mut ix = ix;
+        self.append_hook_accounts(&mut ix);
         self.ctx
             .raw_call(ix)
             .signers(&[&self.merchant.clone()])
@@ -410,6 +432,8 @@ impl SubscriptionsFixture {
             .event_authority(EventAuthority::find_pda().0)
             .transfer_data(TransferData { amount, delegator: subscriber.pubkey(), mint: self.mint })
             .instruction();
+        let mut ix = ix;
+        self.append_hook_accounts(&mut ix);
         self.ctx
             .raw_call(ix)
             .signers(&[&self.merchant.clone()])

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -3,11 +3,12 @@ use std::rc::Rc;
 use crucible_fuzzer::{AccountBuilderBase, TestContext};
 use solana_clock::Clock;
 use solana_keypair::Keypair;
-#[cfg(not(feature = "invariant_subscriptions_hook"))]
 use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+use spl_token_2022_interface::extension::transfer_hook::{TransferHook, TransferHookAccount};
+use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
 use spl_token_2022_interface::state::{Account, AccountState, Mint};
 use subscriptions::accounts::Plan;
 use subscriptions::SUBSCRIPTIONS_ID;
@@ -19,8 +20,18 @@ pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
 #[cfg(any(feature = "invariant_subscriptions_t22", feature = "invariant_subscriptions_hook"))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_2022_interface::ID;
 
-#[cfg(feature = "invariant_subscriptions_hook")]
 pub const HOOK_PROGRAM: Pubkey = Pubkey::new_from_array([42u8; 32]);
+
+// Mint / token-account extensions applied per feature. Empty for classic and plain Token-2022;
+// the hook variant carries the paired TransferHook / TransferHookAccount extensions.
+#[cfg(feature = "invariant_subscriptions_hook")]
+const MINT_EXTENSIONS: &[ExtensionType] = &[ExtensionType::TransferHook];
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
+const MINT_EXTENSIONS: &[ExtensionType] = &[];
+#[cfg(feature = "invariant_subscriptions_hook")]
+const ATA_EXTENSIONS: &[ExtensionType] = &[ExtensionType::TransferHookAccount];
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
+const ATA_EXTENSIONS: &[ExtensionType] = &[];
 
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
@@ -59,19 +70,41 @@ pub fn token_amount(ctx: &TestContext, ata: &Pubkey) -> u64 {
     }
 }
 
-// The base mint (82 bytes) and token-account (165 bytes) layouts are identical for classic SPL
-// and Token-2022, so both mints are packed the same way and differ only in the owning program.
-#[cfg(not(feature = "invariant_subscriptions_hook"))]
+// One mint/token-account builder for all variants: the base 82/165-byte layout when no
+// extensions apply, otherwise the extension-packed layout. MINT_EXTENSIONS/ATA_EXTENSIONS select
+// the shape per feature, so classic, plain Token-2022, and the hook variant share this path.
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    let mut data = vec![0u8; Mint::LEN];
-    Mint {
+    let base = Mint {
         mint_authority: Some(*authority).into(),
         supply: 0,
         decimals,
         is_initialized: true,
         freeze_authority: None.into(),
-    }
-    .pack_into_slice(&mut data);
+    };
+    let data = if MINT_EXTENSIONS.is_empty() {
+        let mut data = vec![0u8; Mint::LEN];
+        base.pack_into_slice(&mut data);
+        data
+    } else {
+        let space = ExtensionType::try_calculate_account_len::<Mint>(MINT_EXTENSIONS).unwrap();
+        let mut data = vec![0u8; space];
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut data).unwrap();
+        state.base = base;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        for ext in MINT_EXTENSIONS {
+            match ext {
+                ExtensionType::TransferHook => {
+                    let hook = state.init_extension::<TransferHook>(true).unwrap();
+                    hook.authority = Some(*authority).try_into().unwrap();
+                    hook.program_id = Some(HOOK_PROGRAM).try_into().unwrap();
+                }
+                other => panic!("unsupported mint extension: {other:?}"),
+            }
+        }
+        drop(state);
+        data
+    };
     ctx.create_account()
         .pubkey(*mint)
         .lamports(INITIAL_LAMPORTS)
@@ -81,11 +114,9 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
         .expect("create mint");
 }
 
-#[cfg(not(feature = "invariant_subscriptions_hook"))]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     let ata = ata_address(owner, mint);
-    let mut data = vec![0u8; Account::LEN];
-    Account {
+    let base = Account {
         mint: *mint,
         owner: *owner,
         amount,
@@ -94,8 +125,29 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         is_native: None.into(),
         delegated_amount: 0,
         close_authority: None.into(),
-    }
-    .pack_into_slice(&mut data);
+    };
+    let data = if ATA_EXTENSIONS.is_empty() {
+        let mut data = vec![0u8; Account::LEN];
+        base.pack_into_slice(&mut data);
+        data
+    } else {
+        let space = ExtensionType::try_calculate_account_len::<Account>(ATA_EXTENSIONS).unwrap();
+        let mut data = vec![0u8; space];
+        let mut state = StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut data).unwrap();
+        state.base = base;
+        state.pack_base();
+        state.init_account_type().unwrap();
+        for ext in ATA_EXTENSIONS {
+            match ext {
+                ExtensionType::TransferHookAccount => {
+                    state.init_extension::<TransferHookAccount>(true).unwrap();
+                }
+                other => panic!("unsupported account extension: {other:?}"),
+            }
+        }
+        drop(state);
+        data
+    };
     ctx.create_account()
         .pubkey(ata)
         .lamports(INITIAL_LAMPORTS)
@@ -103,73 +155,6 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         .data(&data)
         .create()
         .expect("create ata");
-    ata
-}
-
-// Token-2022 mint carrying the TransferHook extension pointed at HOOK_PROGRAM.
-#[cfg(feature = "invariant_subscriptions_hook")]
-pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
-    use spl_token_2022_interface::extension::transfer_hook::TransferHook;
-    use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
-
-    let space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferHook]).unwrap();
-    let mut data = vec![0u8; space];
-    {
-        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut data).unwrap();
-        state.base = Mint {
-            mint_authority: Some(*authority).into(),
-            supply: 0,
-            decimals,
-            is_initialized: true,
-            freeze_authority: None.into(),
-        };
-        state.pack_base();
-        state.init_account_type().unwrap();
-        let ext = state.init_extension::<TransferHook>(true).unwrap();
-        ext.authority = Some(*authority).try_into().unwrap();
-        ext.program_id = Some(HOOK_PROGRAM).try_into().unwrap();
-    }
-    ctx.create_account()
-        .pubkey(*mint)
-        .lamports(INITIAL_LAMPORTS)
-        .owner(TOKEN_PROGRAM)
-        .data(&data)
-        .create()
-        .expect("create hook mint");
-}
-
-// Token account carrying the TransferHookAccount extension required by a hook mint.
-#[cfg(feature = "invariant_subscriptions_hook")]
-pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
-    use spl_token_2022_interface::extension::transfer_hook::TransferHookAccount;
-    use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
-
-    let ata = ata_address(owner, mint);
-    let space = ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::TransferHookAccount]).unwrap();
-    let mut data = vec![0u8; space];
-    {
-        let mut state = StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut data).unwrap();
-        state.base = Account {
-            mint: *mint,
-            owner: *owner,
-            amount,
-            delegate: None.into(),
-            state: AccountState::Initialized,
-            is_native: None.into(),
-            delegated_amount: 0,
-            close_authority: None.into(),
-        };
-        state.pack_base();
-        state.init_account_type().unwrap();
-        state.init_extension::<TransferHookAccount>(true).unwrap();
-    }
-    ctx.create_account()
-        .pubkey(ata)
-        .lamports(INITIAL_LAMPORTS)
-        .owner(TOKEN_PROGRAM)
-        .data(&data)
-        .create()
-        .expect("create hook ata");
     ata
 }
 

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use crucible_fuzzer::{AccountBuilderBase, TestContext};
 use solana_clock::Clock;
 use solana_keypair::Keypair;
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
 use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
@@ -13,10 +14,13 @@ use subscriptions::SUBSCRIPTIONS_ID;
 
 use crate::constants::{GENESIS_TS, INITIAL_LAMPORTS, SLOTS_PER_SECOND};
 
-#[cfg(not(feature = "invariant_subscriptions_t22"))]
+#[cfg(not(any(feature = "invariant_subscriptions_t22", feature = "invariant_subscriptions_hook")))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_interface::ID;
-#[cfg(feature = "invariant_subscriptions_t22")]
+#[cfg(any(feature = "invariant_subscriptions_t22", feature = "invariant_subscriptions_hook"))]
 pub const TOKEN_PROGRAM: Pubkey = spl_token_2022_interface::ID;
+
+#[cfg(feature = "invariant_subscriptions_hook")]
+pub const HOOK_PROGRAM: Pubkey = Pubkey::new_from_array([42u8; 32]);
 
 pub fn set_clock(ctx: &mut TestContext, ts: i64) {
     let slot = ((ts - GENESIS_TS).max(0) * SLOTS_PER_SECOND) as u64 + 1;
@@ -45,8 +49,19 @@ pub fn ata_address(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
     get_associated_token_address_with_program_id(owner, mint, &TOKEN_PROGRAM)
 }
 
+// Reads the SPL token `amount` from its fixed base offset (bytes 64..72). Unlike
+// TestContext::token_balance, this works for Token-2022 accounts carrying extensions, whose
+// length exceeds the classic 165-byte layout the unpack there requires.
+pub fn token_amount(ctx: &TestContext, ata: &Pubkey) -> u64 {
+    match ctx.get_account(ata) {
+        Ok(acc) if acc.data.len() >= 72 => u64::from_le_bytes(acc.data[64..72].try_into().unwrap()),
+        _ => 0,
+    }
+}
+
 // The base mint (82 bytes) and token-account (165 bytes) layouts are identical for classic SPL
 // and Token-2022, so both mints are packed the same way and differ only in the owning program.
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
 pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
     let mut data = vec![0u8; Mint::LEN];
     Mint {
@@ -66,6 +81,7 @@ pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, dec
         .expect("create mint");
 }
 
+#[cfg(not(feature = "invariant_subscriptions_hook"))]
 pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
     let ata = ata_address(owner, mint);
     let mut data = vec![0u8; Account::LEN];
@@ -88,6 +104,114 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
         .create()
         .expect("create ata");
     ata
+}
+
+// Token-2022 mint carrying the TransferHook extension pointed at HOOK_PROGRAM.
+#[cfg(feature = "invariant_subscriptions_hook")]
+pub fn create_mint(ctx: &mut TestContext, mint: &Pubkey, authority: &Pubkey, decimals: u8) {
+    use spl_token_2022_interface::extension::transfer_hook::TransferHook;
+    use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
+
+    let space = ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferHook]).unwrap();
+    let mut data = vec![0u8; space];
+    {
+        let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut data).unwrap();
+        state.base = Mint {
+            mint_authority: Some(*authority).into(),
+            supply: 0,
+            decimals,
+            is_initialized: true,
+            freeze_authority: None.into(),
+        };
+        state.pack_base();
+        state.init_account_type().unwrap();
+        let ext = state.init_extension::<TransferHook>(true).unwrap();
+        ext.authority = Some(*authority).try_into().unwrap();
+        ext.program_id = Some(HOOK_PROGRAM).try_into().unwrap();
+    }
+    ctx.create_account()
+        .pubkey(*mint)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
+        .create()
+        .expect("create hook mint");
+}
+
+// Token account carrying the TransferHookAccount extension required by a hook mint.
+#[cfg(feature = "invariant_subscriptions_hook")]
+pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: u64) -> Pubkey {
+    use spl_token_2022_interface::extension::transfer_hook::TransferHookAccount;
+    use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
+
+    let ata = ata_address(owner, mint);
+    let space = ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::TransferHookAccount]).unwrap();
+    let mut data = vec![0u8; space];
+    {
+        let mut state = StateWithExtensionsMut::<Account>::unpack_uninitialized(&mut data).unwrap();
+        state.base = Account {
+            mint: *mint,
+            owner: *owner,
+            amount,
+            delegate: None.into(),
+            state: AccountState::Initialized,
+            is_native: None.into(),
+            delegated_amount: 0,
+            close_authority: None.into(),
+        };
+        state.pack_base();
+        state.init_account_type().unwrap();
+        state.init_extension::<TransferHookAccount>(true).unwrap();
+    }
+    ctx.create_account()
+        .pubkey(ata)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(TOKEN_PROGRAM)
+        .data(&data)
+        .create()
+        .expect("create hook ata");
+    ata
+}
+
+// Loads the transfer-hook example program and installs its extra-account-metas list plus the
+// counter account it increments on each transfer. Returns (validation_pda, counter).
+#[cfg(feature = "invariant_subscriptions_hook")]
+pub fn setup_hook(ctx: &mut TestContext, mint: &Pubkey) -> (Pubkey, Pubkey) {
+    use spl_tlv_account_resolution::account::ExtraAccountMeta;
+    use spl_tlv_account_resolution::state::ExtraAccountMetaList;
+    use spl_transfer_hook_interface::instruction::ExecuteInstruction;
+
+    ctx.add_program(&HOOK_PROGRAM, "../../tests/transfer-hook-example/target/deploy/transfer_hook_example.so")
+        .expect("load hook program");
+
+    let (validation_pda, _) = Pubkey::find_program_address(&[b"extra-account-metas", mint.as_ref()], &HOOK_PROGRAM);
+    let counter = Pubkey::new_unique();
+
+    let meta = ExtraAccountMeta {
+        discriminator: 0,
+        address_config: counter.to_bytes(),
+        is_signer: false.into(),
+        is_writable: true.into(),
+    };
+    let mut validation_data = vec![0u8; ExtraAccountMetaList::size_of(1).unwrap()];
+    ExtraAccountMetaList::init::<ExecuteInstruction>(&mut validation_data, &[meta]).unwrap();
+
+    ctx.create_account()
+        .pubkey(validation_pda)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(HOOK_PROGRAM)
+        .data(&validation_data)
+        .create()
+        .expect("create validation pda");
+    ctx.create_account()
+        .pubkey(counter)
+        .lamports(INITIAL_LAMPORTS)
+        .owner(HOOK_PROGRAM)
+        .data(&[0u8])
+        .create()
+        .expect("create counter");
+
+    (validation_pda, counter)
 }
 
 // Plan::find_pda in the generated client encodes plan_id as a string; the program derives

--- a/fuzz/subscriptions/src/helpers.rs
+++ b/fuzz/subscriptions/src/helpers.rs
@@ -7,9 +7,15 @@ use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_tlv_account_resolution::account::ExtraAccountMeta;
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_tlv_account_resolution::state::ExtraAccountMetaList;
 use spl_token_2022_interface::extension::transfer_hook::{TransferHook, TransferHookAccount};
 use spl_token_2022_interface::extension::{BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut};
 use spl_token_2022_interface::state::{Account, AccountState, Mint};
+#[cfg(feature = "invariant_subscriptions_hook")]
+use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 use subscriptions::accounts::Plan;
 use subscriptions::SUBSCRIPTIONS_ID;
 
@@ -162,10 +168,6 @@ pub fn create_ata(ctx: &mut TestContext, owner: &Pubkey, mint: &Pubkey, amount: 
 // counter account it increments on each transfer. Returns (validation_pda, counter).
 #[cfg(feature = "invariant_subscriptions_hook")]
 pub fn setup_hook(ctx: &mut TestContext, mint: &Pubkey) -> (Pubkey, Pubkey) {
-    use spl_tlv_account_resolution::account::ExtraAccountMeta;
-    use spl_tlv_account_resolution::state::ExtraAccountMetaList;
-    use spl_transfer_hook_interface::instruction::ExecuteInstruction;
-
     ctx.add_program(&HOOK_PROGRAM, "../../tests/transfer-hook-example/target/deploy/transfer_hook_example.so")
         .expect("load hook program");
 

--- a/fuzz/subscriptions/src/invariants.rs
+++ b/fuzz/subscriptions/src/invariants.rs
@@ -4,7 +4,7 @@ use subscriptions::accounts::{RecurringDelegation, SubscriptionDelegation};
 
 use crate::constants::{INITIAL_TOKENS, SUBSCRIBER_COUNT};
 use crate::fixture::SubscriptionsFixture;
-use crate::helpers::ata_address;
+use crate::helpers::{ata_address, token_amount};
 
 const RECURRING_NONCES: [u64; 3] = [3, 4, 5];
 
@@ -47,7 +47,7 @@ pub fn check_recurring_delegation_caps(fixture: &SubscriptionsFixture) {
 pub fn check_dead_authority_inert(fixture: &mut SubscriptionsFixture) {
     for idx in 0..fixture.subscribers.len() {
         let subscriber = fixture.subscribers[idx].pubkey();
-        let balance = fixture.ctx.token_balance(&ata_address(&subscriber, &fixture.mint));
+        let balance = token_amount(&fixture.ctx, &ata_address(&subscriber, &fixture.mint));
         let alive = fixture.read_authority(&subscriber).is_some();
         let (prev_balance, prev_alive) = fixture.prev_spend_state[idx];
         if !prev_alive {
@@ -63,8 +63,8 @@ pub fn check_dead_authority_inert(fixture: &mut SubscriptionsFixture) {
 
 pub fn check_token_conservation(fixture: &SubscriptionsFixture) {
     let subscriber_total: u64 =
-        fixture.subscribers.iter().map(|s| fixture.ctx.token_balance(&ata_address(&s.pubkey(), &fixture.mint))).sum();
-    let merchant_balance = fixture.ctx.token_balance(&fixture.merchant_ata);
+        fixture.subscribers.iter().map(|s| token_amount(&fixture.ctx, &ata_address(&s.pubkey(), &fixture.mint))).sum();
+    let merchant_balance = token_amount(&fixture.ctx, &fixture.merchant_ata);
     fuzz_assert_eq!(
         subscriber_total + merchant_balance,
         INITIAL_TOKENS * SUBSCRIBER_COUNT as u64,

--- a/fuzz/subscriptions/src/main.rs
+++ b/fuzz/subscriptions/src/main.rs
@@ -29,3 +29,11 @@ fn invariant_subscriptions(fixture: &mut SubscriptionsFixture) {
 fn invariant_subscriptions_t22(fixture: &mut SubscriptionsFixture) {
     check_all(fixture);
 }
+
+// Against a Token-2022 mint with a TransferHook extension: transfers forward the hook program
+// and its extra accounts, exercising the program's hook-forwarding path. The hook only bumps a
+// counter, so token conservation still holds and all invariants apply unchanged.
+#[invariant_test]
+fn invariant_subscriptions_hook(fixture: &mut SubscriptionsFixture) {
+    check_all(fixture);
+}


### PR DESCRIPTION
Stacked on #225 (base branch `test/crucible-fuzz-adversarial`).

## Summary
- Adds `invariant_subscriptions_hook`: the full action set + all invariants run against a **Token-2022 mint with a TransferHook extension**
- The mint and token accounts are packed with their required extensions (TransferHook / TransferHookAccount); the transfer-hook example program is loaded and its extra-account-metas list + counter installed
- Transfers (`transfer_subscription`, `transfer_fixed`) append the hook program and its extra accounts as remaining accounts, so the program's hook-forwarding path (`transfer_hook_util.rs`) actually executes
- CI matrix and the `just build-test-hook` step extended to the new feature

## Why
The DWARF coverage report flagged `transfer_hook_util.rs` at **18% lines** — the single biggest program-logic gap. Plain mints never trigger the hook CPI. This variant does: verified the hook fires (its counter increments) on successful pulls, and branch coverage on the hook build reaches **~80%** (on a larger reachable-code denominator than the plain mints).

## Correctness notes
- Transfer-hook is **conservation-safe** — the example hook only bumps a counter, moves no tokens — so all four existing invariants apply unchanged. No new/weakened invariant.
- `TestContext::token_balance` unpacks the classic 165-byte layout and returns 0 for extension-bearing accounts, which broke token conservation at setup. Added `token_amount`, which reads the SPL `amount` field at its fixed base offset (works for plain and extended accounts); the fuzzer caught this immediately (near-100% crash rate before the fix).

## Test plan
- `crucible run subscriptions invariant_subscriptions_hook --timeout 60` → 0 crashes, hook counter increments, ~80% branch coverage
- Classic and t22 features re-verified: 0 crashes, unchanged
- All three features `cargo check` clean; workflow lints clean

Follow-up (separate PR): transfer-fee extension — needs a fee-aware conservation invariant, so kept out of this PR.