### PR TITLE
test(fuzz): fixed-delegation spend-cap invariant

### DIFF
--- a/fuzz/subscriptions/src/fixture.rs
+++ b/fuzz/subscriptions/src/fixture.rs
@@ -26,6 +26,9 @@ use crate::helpers::{
     TOKEN_PROGRAM,
 };
 
+// Nonces action_create_fixed_delegation draws from; recurring uses a disjoint range.
+pub const FIXED_NONCES: [u64; 3] = [0, 1, 2];
+
 #[derive(Clone)]
 pub struct SubscriptionsFixture {
     pub ctx: TestContext,
@@ -40,6 +43,10 @@ pub struct SubscriptionsFixture {
     // action runs between checks, so a balance drop observed while the flag was false means
     // tokens moved through a closed authority.
     pub prev_spend_state: Vec<(u64, bool)>,
+    // Last observed remaining budget of each fixed delegation (per subscriber, per fixed nonce);
+    // None while the delegation account does not exist. transfer_fixed only decrements this budget,
+    // so it must never increase while the account stays live.
+    pub prev_fixed_amount: Vec<[Option<u64>; FIXED_NONCES.len()]>,
     // (hook program, extra-account-metas PDA, counter) when the mint carries a transfer hook;
     // appended as remaining accounts on transfers so the Token-2022 hook CPI can resolve.
     pub hook_accounts: Option<(Pubkey, Pubkey, Pubkey)>,
@@ -71,7 +78,7 @@ impl SubscriptionsFixture {
         SubscriptionDelegation::from_bytes(&account.data).ok()
     }
 
-    pub fn recurring_delegation_pda(&self, subscriber: &Pubkey, nonce: u64) -> Pubkey {
+    pub fn delegation_pda_for(&self, subscriber: &Pubkey, nonce: u64) -> Pubkey {
         let (authority_pda, _) = SubscriptionAuthority::find_pda(subscriber, &self.mint);
         delegation_pda_address(&authority_pda, subscriber, &self.merchant.pubkey(), nonce).0
     }
@@ -152,6 +159,7 @@ impl SubscriptionsFixture {
             plan_bump,
             now_ts: GENESIS_TS,
             prev_spend_state: vec![(INITIAL_TOKENS, true); SUBSCRIBER_COUNT],
+            prev_fixed_amount: vec![[None; FIXED_NONCES.len()]; SUBSCRIBER_COUNT],
             hook_accounts,
         }
     }

--- a/fuzz/subscriptions/src/invariants.rs
+++ b/fuzz/subscriptions/src/invariants.rs
@@ -1,9 +1,9 @@
 use crucible_fuzzer::*;
 use solana_signer::Signer;
-use subscriptions::accounts::{RecurringDelegation, SubscriptionDelegation};
+use subscriptions::accounts::{FixedDelegation, RecurringDelegation, SubscriptionDelegation};
 
 use crate::constants::{INITIAL_TOKENS, SUBSCRIBER_COUNT};
-use crate::fixture::SubscriptionsFixture;
+use crate::fixture::{SubscriptionsFixture, FIXED_NONCES};
 use crate::helpers::{ata_address, token_amount};
 
 const RECURRING_NONCES: [u64; 3] = [3, 4, 5];
@@ -29,7 +29,7 @@ pub fn check_subscriptions_decodable_and_capped(fixture: &SubscriptionsFixture) 
 pub fn check_recurring_delegation_caps(fixture: &SubscriptionsFixture) {
     for subscriber in &fixture.subscribers {
         for nonce in RECURRING_NONCES {
-            let pda = fixture.recurring_delegation_pda(&subscriber.pubkey(), nonce);
+            let pda = fixture.delegation_pda_for(&subscriber.pubkey(), nonce);
             if !fixture.ctx.account_has_data(&pda, 1) {
                 continue;
             }
@@ -40,6 +40,29 @@ pub fn check_recurring_delegation_caps(fixture: &SubscriptionsFixture) {
                 delegation.amount_per_period,
                 "recurring delegation pulled more than the authorized per-period amount"
             );
+        }
+    }
+}
+
+pub fn check_fixed_delegation_cap(fixture: &mut SubscriptionsFixture) {
+    for idx in 0..fixture.subscribers.len() {
+        let subscriber = fixture.subscribers[idx].pubkey();
+        for (slot, &nonce) in FIXED_NONCES.iter().enumerate() {
+            let pda = fixture.delegation_pda_for(&subscriber, nonce);
+            let current = if fixture.ctx.account_has_data(&pda, 1) {
+                fixture
+                    .ctx
+                    .get_account(&pda)
+                    .ok()
+                    .and_then(|a| FixedDelegation::from_bytes(&a.data).ok())
+                    .map(|d| d.amount)
+            } else {
+                None
+            };
+            if let (Some(prev), Some(cur)) = (fixture.prev_fixed_amount[idx][slot], current) {
+                fuzz_assert_le!(cur, prev, "fixed delegation remaining budget increased while the account stayed live");
+            }
+            fixture.prev_fixed_amount[idx][slot] = current;
         }
     }
 }

--- a/fuzz/subscriptions/src/main.rs
+++ b/fuzz/subscriptions/src/main.rs
@@ -7,13 +7,14 @@ use crucible_fuzzer::*;
 
 use crate::fixture::{SubscriptionsFixture, __subscriptions_fixture_fuzz};
 use crate::invariants::{
-    check_dead_authority_inert, check_recurring_delegation_caps, check_subscriptions_decodable_and_capped,
-    check_token_conservation,
+    check_dead_authority_inert, check_fixed_delegation_cap, check_recurring_delegation_caps,
+    check_subscriptions_decodable_and_capped, check_token_conservation,
 };
 
 fn check_all(fixture: &mut SubscriptionsFixture) {
     check_subscriptions_decodable_and_capped(fixture);
     check_recurring_delegation_caps(fixture);
+    check_fixed_delegation_cap(fixture);
     check_token_conservation(fixture);
     check_dead_authority_inert(fixture);
 }


### PR DESCRIPTION
Stacked on the merged fuzz harness (`test/crucible-fuzz-harness`).

## Summary
- Adds `check_fixed_delegation_cap`: a fixed delegation's remaining `amount` must never increase while its account stays live
- Runs on all three mint variants (classic / Token-2022 / hook)
- Generalizes the delegation-PDA helper (`recurring_delegation_pda` → `delegation_pda_for`) now that both fixed and recurring caps use it

## Why
We already assert the subscription and *recurring*-delegation per-period caps, but not the *fixed*-delegation one — and `transfer_fixed` moves money. The program decrements a fixed delegation's `amount` on each transfer (`checked_sub`, underflow-guarded), so the stored value is the remaining budget and can only go down. Asserting it never increases while the account lives is the bounded-spend / single-use guarantee: no operation may secretly refill an allowance, which together with the underflow guard bounds total spend to the amount authorized at creation.

Same structure as the existing dead-authority-inertness check: exactly one action runs between invariant checks, so a continuously-live account can't close and reopen in a single step. A close-then-recreate shows up as a `None` gap and resets tracking, so legitimate recreation is not flagged — deliberately avoiding the false-positive trap that the earlier (removed) expiry-monotonicity check fell into.

## Test plan
- All three features `cargo check` clean, 0 crashes over 45s each
- Instrumented run confirmed the invariant is not a no-op: it observed 16 live fixed-delegation draw-downs in 30s, each passing the `<=` assertion