### PR TITLE
chore(release): bump program and clients to v0.5.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.4.0"
+version = "0.5.0-beta.1"
 dependencies = [
  "borsh",
  "num-derive",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "subscriptions-program"
-version = "0.4.0"
+version = "0.5.0-beta.1"
 dependencies = [
  "codama",
  "const-crypto",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "tests-subscriptions"
-version = "0.4.0"
+version = "0.5.0-beta.1"
 dependencies = [
  "dtor",
  "litesvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0-beta.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/subscriptions"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.4.0"
+version = "0.5.0-beta.1"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/subscriptions",
-    "version": "0.4.0",
+    "version": "0.5.0-beta.1",
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -4050,7 +4050,7 @@
       }
     ],
     "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44",
-    "version": "0.4.0"
+    "version": "0.5.0-beta.1"
   },
   "standard": "codama",
   "version": "1.0.0"


### PR DESCRIPTION
## Summary
- Bump workspace/program version and both SDK clients from 0.4.0 to 0.5.0-beta.1
- Regenerate the IDL so it reports 0.5.0-beta.1
- Prerelease suffix routes publishing to the npm `beta` dist-tag and a crates.io prerelease, with prerelease GitHub releases (`ts-client-v0.5.0-beta.1` / `rust-client-v0.5.0-beta.1` tags)

## Test Plan
- `just generate-idl` reproduces the committed IDL (version field only)
- Publish workflows in dry-run resolve the beta dist-tag from the prerelease version