### PR TITLE
feat(webapp): gate plan editing behind network feature flag

### DIFF
--- a/webapp/src/components/plan/plan-card.tsx
+++ b/webapp/src/components/plan/plan-card.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/dialog';
 import { ZERO_ADDRESS, PlanStatus } from '@solana/subscriptions';
 import { cn, ellipsify, fmtDate, fmtDateTime, formatPeriod, formatPeriodLabel } from '@/lib/utils';
+import { useFeatures } from '@/hooks/use-features';
 import { useSubscriptionsMutations } from '@/hooks/use-subscriptions-mutations';
 import { useSubscriptionAuthorityStatus } from '@/hooks/use-subscription-authority-status';
 import { useTimeTravel } from '@/hooks/use-time-travel';
@@ -700,6 +701,7 @@ export function PlanCard({
     isExpanded?: boolean;
     onToggleExpand?: () => void;
 }) {
+    const features = useFeatures();
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
     const [subscribeOpen, setSubscribeOpen] = useState(false);
@@ -1012,7 +1014,7 @@ export function PlanCard({
 
                     {variant === 'owner' && (
                         <div className="flex items-center gap-2 pt-2 border-t border-sand-200">
-                            {!planExpired && (
+                            {!planExpired && features.updatePlan && (
                                 <Button
                                     variant="outline"
                                     size="sm"
@@ -1046,7 +1048,9 @@ export function PlanCard({
 
             {variant === 'owner' && (
                 <>
-                    <EditPlanDialog plan={plan} meta={meta} open={editOpen} onOpenChange={setEditOpen} />
+                    {features.updatePlan && (
+                        <EditPlanDialog plan={plan} meta={meta} open={editOpen} onOpenChange={setEditOpen} />
+                    )}
                     <DeletePlanDialog plan={plan} meta={meta} open={deleteOpen} onOpenChange={setDeleteOpen} />
                 </>
             )}

--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -49,18 +49,21 @@ export interface Features {
     revokeAbandonedDelegation: boolean;
     revokeSubscriptionAuthority: boolean;
     startNowRecurringDelegation: boolean;
+    updatePlan: boolean;
 }
 
 const SOAK_FEATURES: Features = {
     revokeAbandonedDelegation: true,
     revokeSubscriptionAuthority: true,
     startNowRecurringDelegation: true,
+    updatePlan: true,
 };
 
 const STABLE_FEATURES: Features = {
     revokeAbandonedDelegation: true,
     revokeSubscriptionAuthority: true,
     startNowRecurringDelegation: true,
+    updatePlan: false,
 };
 
 export const FEATURES: Record<Network, Features> = {


### PR DESCRIPTION
## Summary
- Add an `updatePlan` feature flag to `FEATURES`: enabled on soak networks (devnet/localnet), disabled on stable networks (mainnet/testnet)
- Hide the plan Edit button and `EditPlanDialog` when the flag is off

## Why
The `update_plan` mutation now sends the compare-and-swap `expected_*` payload, which the deployed v0.4.0 program rejects with `InvalidInstructionData` (strict instruction-data length check). Gating keeps the mainnet webapp on working flows during the v0.5.0-beta devnet soak; flip `STABLE_FEATURES.updatePlan` after the mainnet deploy (same pattern as #201).

Resume and create-plan stay ungated: v0.4.0 dispatches `ResumeSubscription` as a unit variant and ignores the trailing expiry payload, and the webapp never sends a distinct `create_plan` payer.

## Test Plan
- `tsc --noEmit` and `eslint` pass on the touched files
- Localnet/devnet: Edit button renders and plan updates work
- Mainnet/testnet cluster selected: Edit button hidden, delete/subscribe flows unaffected