### PR TITLE
fix: keep deploy secrets out of untrusted setup code

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -60,14 +60,14 @@ runs:
   steps:
     - name: Setup Rust
       if: inputs.install-rust == 'true'
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
         toolchain: ${{ inputs.rust-toolchain }}
         components: ${{ inputs.rust-components }}
 
     - name: Rust cache
       if: inputs.install-rust == 'true' && inputs.enable-rust-cache == 'true'
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         workspaces: '. -> target'
         shared-key: ${{ inputs.rust-cache-key }}
@@ -88,7 +88,7 @@ runs:
     - name: Cache Solana CLI
       if: inputs.install-solana == 'true'
       id: solana-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ~/.local/share/solana
@@ -119,17 +119,17 @@ runs:
 
     - name: Install just
       if: inputs.install-just == 'true'
-      uses: extractions/setup-just@v4
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       with:
         just-version: '1.50.0'
 
     - name: Install pnpm
       if: inputs.install-pnpm == 'true'
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
     - name: Setup Node.js
       if: inputs.install-pnpm == 'true'
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version-file: '.nvmrc'
 
@@ -142,7 +142,7 @@ runs:
     - name: Cache pnpm store
       if: inputs.install-pnpm == 'true'
       id: pnpm-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
         key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -168,7 +168,7 @@ runs:
     - name: Cache surfpool
       if: inputs.install-surfpool == 'true'
       id: surfpool-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.local/bin/surfpool
         key: ${{ runner.os }}-surfpool-${{ steps.surfpool-release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup
+        with:
+          rust-cache-key: 'release-${{ inputs.network }}'
+          solana-version: 'v4.0.0'
+
+      - name: Install solana-verify
+        run: cargo install solana-verify --locked
+
+      # Fetch secrets only after all toolchain setup (third-party actions and the
+      # remote Solana installer) has run, so deploy credentials are never present
+      # in the environment while untrusted setup code executes.
       - name: Load deploy config from Doppler
         uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
         with:
@@ -44,14 +55,6 @@ jobs:
           doppler-project: subscriptions
           doppler-config: ${{ inputs.network == 'mainnet' && 'prd_github' || 'stg_github' }}
           inject-env-vars: true
-
-      - uses: ./.github/actions/setup
-        with:
-          rust-cache-key: 'release-${{ inputs.network }}'
-          solana-version: 'v4.0.0'
-
-      - name: Install solana-verify
-        run: cargo install solana-verify --locked
 
       - name: Materialize deployer keypair
         run: |


### PR DESCRIPTION
## Summary
- Pin every action in `.github/actions/setup/action.yml` to a full commit SHA (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `actions/cache`, `extractions/setup-just`, `pnpm/action-setup`, `actions/setup-node`) instead of mutable branch/tag refs.
- Reorder `release.yml` so `./.github/actions/setup` (mutable third-party actions + the remote Solana installer via `curl | sh`) runs before the Doppler secrets fetch, so `DEPLOYER_KEYPAIR` is never in the environment while that untrusted setup code executes.

Same pattern flagged by Greptile and fixed on [solana-foundation/dvp#6](https://github.com/solana-foundation/dvp/pull/6) (commit 39bf823) — this repo's setup action was copy-pasted from the same template and had the same order/pinning gap.

## Test Plan
- [ ] Trigger `Release` workflow manually against devnet and confirm it still builds/deploys successfully