### PR TITLE
feat(webapp): enable plan editing on mainnet and testnet

### DIFF
--- a/webapp/src/config/networks.ts
+++ b/webapp/src/config/networks.ts
@@ -63,7 +63,7 @@ const STABLE_FEATURES: Features = {
     revokeAbandonedDelegation: true,
     revokeSubscriptionAuthority: true,
     startNowRecurringDelegation: true,
-    updatePlan: false,
+    updatePlan: true,
 };
 
 export const FEATURES: Record<Network, Features> = {


### PR DESCRIPTION
## Summary
- Flip `STABLE_FEATURES.updatePlan` to `true`, enabling the plan-editing UI (gated in #232) on mainnet and testnet
- Merge after the v0.5.0 mainnet upgrade executes; the on-chain `UpdatePlan` instruction format ships with that deploy

## Test Plan
- Existing webapp build + lint (green on this branch)
- Post-deploy: edit a plan on mainnet via the demo webapp