### PR TITLE
fix(webapp): remove BigInt toJSON patch that corrupts RPC requests

### DIFF
--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -11,14 +11,3 @@ createRoot(document.getElementById('root')!).render(
         </BrowserRouter>
     </StrictMode>,
 );
-
-// Patch BigInt so we can log it using JSON.stringify without any errors
-declare global {
-    interface BigInt {
-        toJSON(): string;
-    }
-}
-
-BigInt.prototype.toJSON = function () {
-    return this.toString();
-};


### PR DESCRIPTION
## Summary
- Remove the global `BigInt.prototype.toJSON` patch from `webapp/src/main.tsx`
- `JSON.stringify` invokes `toJSON` before the replacer runs, so @solana/kit v7 (upgraded in #234) serialized every bigint RPC param as a string (`dataSize: "491"` instead of `491`); public RPC nodes reject this with `-32602 invalid type: string "491", expected u64`
- Broke all `getProgramAccounts`-backed lists in the webapp against devnet: Plans, Marketplace search, Subscriptions, Delegations

## Test Plan
- Reproduced: browser request body carried `"dataSize":"491"`, devnet RPC returned -32602
- After removal, `fetchPlansForOwner` via the app's module graph returns 5 plans for a devnet merchant
- Audited remaining `JSON.stringify` call sites in webapp: none serialize bigints (localStorage caches already store amounts as strings)