### PR TITLE
chore(release): v0.5.0 program and clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-10
+
+_Target mainnet deploy 2026-08-10. Reproducible via `solana-verify`. **Includes breaking changes vs the deployed v0.4.0 — see Security.** Audit status: [`audits/AUDIT_STATUS.md`](audits/AUDIT_STATUS.md). The deployed binary and on-chain IDL report `0.5.0-beta.1`: they were built at the release commit `364a419`, which predates this version bump._
+
 ### Added
 
 - `CancelSubscriptionNow` (discriminator 17) immediately expires a subscription when both the subscriber and current plan owner sign. It can shorten a pending cancellation, leaves the shared `SubscriptionAuthority` intact, and allows immediate subscription revocation without creating a unilateral skip-payment path. Emits a `SubscriptionCancelledEvent` — indexers now also see this event from dual-signed immediate cancels, with `expires_at_ts` set to the cancellation time instead of the end of the current billing period. The instruction data carries `expected_current_period_start_ts`, binding the dual approval to the subscription incarnation; a signed cancellation replayed against a later re-subscription at the same PDA is rejected with `StaleSubscriptionApproval` (521). ([#221])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,7 +5431,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "borsh",
  "num-derive",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "subscriptions-program"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "codama",
  "const-crypto",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "tests-subscriptions"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "dtor",
  "litesvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/subscriptions"

--- a/clients/rust/CHANGELOG.md
+++ b/clients/rust/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-10
+
+_Matches on-chain program `program-v0.5.0`. Supersedes prerelease `0.5.0-beta.1`._
+
 ### Added
 
 - Generated `CancelSubscriptionNow` instruction and CPI builders for merchant-approved immediate cancellation. Builders take `cancel_subscription_now_data` with `expected_current_period_start_ts`, the period start observed when signing. ([#221])

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subscriptions"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2021"
 description = "Rust client for the Subscriptions Solana program"
 license = { workspace = true }

--- a/clients/typescript/CHANGELOG.md
+++ b/clients/typescript/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-10
+
+_Matches on-chain program `program-v0.5.0`. Supersedes prereleases `0.5.0-beta.1` and `0.5.0-beta.2`._
+
 ### Added
 
 - `cancelSubscriptionNow` generated builder, overlay, and plugin instruction. The plugin defaults the subscriber to `client.identity` and the approving plan owner to `client.payer` for sponsored cancellation flows. Requires `expectedCurrentPeriodStartTs`, the period start observed when signing. ([#221])

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/subscriptions",
-    "version": "0.5.0-beta.2",
+    "version": "0.5.0",
     "description": "TypeScript SDK and @solana/kit plugin for the Subscriptions Solana program: token delegations, recurring payments, and subscription plans.",
     "type": "module",
     "license": "MIT",

--- a/idl/subscriptions.json
+++ b/idl/subscriptions.json
@@ -4050,7 +4050,7 @@
       }
     ],
     "publicKey": "De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44",
-    "version": "0.5.0-beta.1"
+    "version": "0.5.0"
   },
   "standard": "codama",
   "version": "1.0.0"


### PR DESCRIPTION
## Summary
- Bump workspace/program and Rust client `0.5.0-beta.1` → `0.5.0`, TypeScript client `0.5.0-beta.2` → `0.5.0`
- Regenerate IDL (`program.version` → `0.5.0`) and clients; only the version string changed
- Finalize all three changelogs for the 2026-08-10 mainnet deploy

## Notes
- The deployed binary and on-chain IDL report `0.5.0-beta.1`: they were built at release commit `364a419`, which predates this bump. Noted in the program changelog.
- Merge after the mainnet upgrade executes, then run the trusted-publishing workflows (dry-run first) to ship clients 0.5.0.

## Test Plan
- CI (fmt, lint, tests, idl-check)
- `just generate-idl && git diff`: version-only IDL change