### PR TITLE
fix(webapp): ignore trailing
  zeros beyond token decimals in parseTokenAmount

### DIFF
--- a/webapp/src/lib/token-display.ts
+++ b/webapp/src/lib/token-display.ts
@@ -51,7 +51,7 @@ export function parseTokenAmount(value: string, decimals: number): bigint {
 
     const divisor = 10n ** BigInt(decimals);
     const wholeUnits = BigInt(whole) * divisor;
-    const fractionUnits = fraction.length === 0 ? 0n : BigInt(fraction.padEnd(decimals, '0') || '0');
+    const fractionUnits = fraction.length === 0 ? 0n : BigInt(fraction.slice(0, decimals).padEnd(decimals, '0') || '0');
 
     return wholeUnits + fractionUnits;
 }

--- a/webapp/test/token-display.test.ts
+++ b/webapp/test/token-display.test.ts
@@ -48,4 +48,10 @@ describe('token display', () => {
         assert.equal(parseTokenAmount('10', 0), 10n);
         assert.throws(() => parseTokenAmount('1.2345678', 6), /more than 6 decimal places/);
     });
+
+    test('ignores trailing zeroes beyond the token decimals', () => {
+        assert.equal(parseTokenAmount('1.5000000', 6), 1_500_000n);
+        assert.equal(parseTokenAmount('1.2300000', 6), 1_230_000n);
+        assert.equal(parseTokenAmount('2.5000000000', 6), 2_500_000n);
+    });
 });


### PR DESCRIPTION
parseTokenAmount validates by stripping trailing zeros from the fraction, so 1.5000000 for a
  6-decimal token passes the decimal-place check. But the amount is computed from the raw fraction: when it is longer than decimals, padEnd is a no-op and
  BigInt reads the full string, scaling by 10^(len - decimals). So parseTokenAmount(1.5000000, 6) returns 6000000n instead of 1500000n, and 2.5000000000
  returns 5002000000n instead of 2500000n. This value feeds amountInSmallestUnits in the plan and delegation dialogs, so a padded amount authorizes an
  inflated on-chain pull. Fix: truncate the fraction to decimals before scaling via fraction.slice(0, decimals); the strip-zeros validation guarantees the
  dropped digits are zeros, so it stays exact. Adds a regression test; the suite stays green at 5 of 5.