### PR TITLE
ci: consolidate rust caches to one key per build config

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,13 +19,13 @@ inputs:
     required: false
     default: 'true'
   save-rust-cache:
-    description: 'Save the Rust cache after this job (only enable for the build job)'
+    description: 'Save the Rust cache after this job. Enable on exactly one producer job per cache key; saves only happen on main.'
     required: false
     default: 'false'
   rust-cache-key:
-    description: 'Key for the Rust cache'
+    description: 'Shared Rust cache key. One key per distinct build config: rust-dev, fuzz, miri, release.'
     required: false
-    default: 'build'
+    default: 'rust-dev'
   install-surfpool:
     description: 'Install surfpool (only needed for integration tests)'
     required: false
@@ -71,7 +71,7 @@ runs:
       with:
         workspaces: '. -> target'
         shared-key: ${{ inputs.rust-cache-key }}
-        save-if: ${{ inputs.save-rust-cache }}
+        save-if: ${{ inputs.save-rust-cache == 'true' && github.ref == 'refs/heads/main' }}
         cache-on-failure: true
 
     - name: Resolve Solana release

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'benchmark'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Run benchmark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,7 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'build'
-          save-rust-cache: 'true'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Build program and clients

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'format'
+          enable-rust-cache: 'false'
 
       - name: Check formatting
         run: just fmt-check

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust-cache-key: 'fuzz'
+          save-rust-cache: ${{ matrix.test == 'invariant_subscriptions' }}
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Cache crucible CLI

--- a/.github/workflows/idl-check.yml
+++ b/.github/workflows/idl-check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'idl-check'
+          rust-cache-key: 'rust-dev'
 
       - name: Check generated files
         run: just check-generated

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'lint'
+          rust-cache-key: 'rust-dev'
 
       - name: Check linting
         run: just lint-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'release-${{ inputs.network }}'
+          rust-cache-key: 'release'
+          save-rust-cache: 'true'
           solana-version: 'v4.0.0'
 
       - name: Install solana-verify

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
           install-solana: 'false'
           install-just: 'false'
           install-pnpm: 'false'
-          rust-cache-key: 'cargo-audit'
+          enable-rust-cache: 'false'
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-audit
@@ -55,6 +55,7 @@ jobs:
           install-just: 'false'
           install-pnpm: 'false'
           rust-cache-key: 'miri'
+          save-rust-cache: 'true'
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'unit-test'
-          save-rust-cache: 'true'
+          rust-cache-key: 'rust-dev'
 
       - name: Run unit tests
         run: just unit-test
@@ -45,7 +44,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'rust-integration-test'
+          rust-cache-key: 'rust-dev'
+          save-rust-cache: 'true'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Run Rust integration tests
@@ -61,9 +61,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          enable-rust-cache: 'false'
           install-surfpool: 'true'
-          rust-cache-key: 'typescript-integration-test'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
           surfpool-version: ${{ env.SURFPOOL_VERSION }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ solana-security-txt = "1.1.3"
 spl-token-interface = "3.0.0"
 thiserror = { version = "2", default-features = false }
 
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 overflow-checks = true
 opt-level = 3


### PR DESCRIPTION
## What and why

Every Rust job asked `Swatinem/rust-cache` for a different `shared-key`, but only two jobs
were allowed to save one. A `shared-key` is the whole restore namespace, so the other jobs
looked for a cache nobody had ever written and compiled from scratch on every run.

Measured on `main` before this change (Test run
[34502953771](https://github.com/solana-foundation/subscriptions/actions/runs/34502953771)):

```
unit-test               No cache found.
rust-integration-test   No cache found.
typescript-integration-test   (rust cache disabled entirely)
```

Not a single `Restored from` line for the Rust cache in the run.

Repository cache inventory the same day: 34 entries, 1.39 GiB of the 10 GB quota. Two of
those are Rust caches (`v0-rust-build-*` at 158 MB, `v0-rust-unit-test-*` at 150 MB), and
they were saved from pull-request refs as well as `main`. Cache scoping means a PR-ref entry
is only visible to that PR, so those saves cost quota and helped nobody.

Thirteen configured keys (`build`, `unit-test`, `rust-integration-test`,
`typescript-integration-test`, `lint`, `format`, `idl-check`, `benchmark`, `fuzz`,
`cargo-audit`, `miri`, `release-devnet`, `release-mainnet`) collapse to four, one per
distinct build config:

| Key | Producer (saves on `main`) | Consumers (restore only) |
| --- | --- | --- |
| `rust-dev` | `rust-integration-test` | `unit-test`, `lint`, `idl-check`, `benchmark`, `build`, `typescript-integration-test` |
| `fuzz` | `fuzz-smoke (invariant_subscriptions)` | other two smoke legs, `fuzz-nightly` |
| `miri` | `miri` | - |
| `release` | `release` | - |

`rust-integration-test` is the producer for `rust-dev` because `just integration-test`
compiles the superset: the host dev-profile dependency graph plus the SBF build of the
program and the test transfer-hook program. `save-if` is now
`inputs.save-rust-cache == 'true' && github.ref == 'refs/heads/main'`, so pull requests
restore but never write.

Two jobs lost the Rust cache because they never invoke rustc: `format` runs `cargo fmt
--check` and `cargo-audit` reads `Cargo.lock`. Both were restoring and unpacking a
~150 MB archive for nothing. `typescript-integration-test` gained it: it runs
`just test-client`, which builds the program and the test hook with `cargo build-sbf`
from an empty `target/` every run.

`[profile.dev] debug = "line-tables-only"` keeps file and line numbers in panics and
backtraces, drops the rest of the DWARF.

Docker `cache-to` is untouched; the repo has no image builds. `rust-toolchain.toml`
already pins 1.92 and the composite action installs that exact channel, so there is no
`@stable` install splitting the cache environment hash. `publish-rust.yml` and
`publish-typescript.yml` do install `dtolnay/rust-toolchain@stable` outside the composite
action; `rust-toolchain.toml` overrides it at every cargo invocation, so it is a wasted
download rather than a correctness problem, and those workflows are not cached. Left for a
separate change to keep release paths out of this PR.

## Cold build measurements

`CARGO_TARGET_DIR=$PWD/.timings-target cargo build --workspace --timings`, local macOS
(Apple Silicon), warm registry, empty target directory. Not a CI runner, so treat the
ratios rather than the absolute seconds as transferable.

- 476 units, 1083 s of unit CPU time, **120.5 s wall** (two runs, both 2m00s).
- The first workspace crate does not start compiling until **102.9 s** of those 120.5 s.

Critical path to the last workspace unit:

```
 34.3 ->  34.7  ( 0.4s)  subtle v2.6.1
 36.8 ->  40.4  ( 3.6s)  libsecp256k1-core v0.2.2
 65.3 ->  65.5  ( 0.1s)  libsecp256k1-gen-ecmult v0.2.1
 65.5 ->  66.2  ( 0.8s)  libsecp256k1 v0.6.0
 73.9 -> 114.6  (40.7s)  libsecp256k1 v0.6.0        run-custom-build
114.6 -> 116.3  ( 1.8s)  libsecp256k1 v0.6.0
116.3 -> 116.8  ( 0.5s)  agave-syscalls v3.1.14
116.7 -> 117.4  ( 0.8s)  solana-bpf-loader-program v3.1.14
117.2 -> 117.6  ( 0.3s)  solana-loader-v4-program v3.1.14
117.5 -> 117.8  ( 0.3s)  solana-builtins-default-costs v3.1.14
117.8 -> 118.0  ( 0.2s)  solana-compute-budget-instruction v3.1.14
117.9 -> 119.3  ( 1.4s)  litesvm v0.12.0
118.8 -> 119.4  ( 0.6s)  litesvm-token v0.12.0
119.2 -> 120.5  ( 1.2s)  tests-subscriptions v0.5.0
```

One single-threaded build script, `libsecp256k1` generating its ecmult tables, is 40.7 s
of a 120.5 s build (34%), and it gates the entire litesvm chain. It arrives through
`litesvm -> agave-syscalls` and cannot be dropped without dropping litesvm, so the only
lever available here is not paying for it twice: a warm `rust-dev` cache skips it.

Top units by duration, for the record:

```
40.7s  libsecp256k1 v0.6.0 (build script)
29.0s  syn v2.0.117
26.6s  syn v2.0.117
24.6s  ark-ff v0.5.0
24.3s  ark-ff v0.4.2
23.0s  syn v1.0.109
22.2s  zerocopy v0.8.39
19.3s  combine v3.8.1
19.2s  solana-sbpf v0.13.1
18.2s  toml_edit v0.22.27
```

With `debug = "line-tables-only"`, same command and machine: **67.5 s wall** (best of two
runs 50.6 s) and `target/` drops from **1.2 GB to 990 MB** (-18%). The smaller target is
also a smaller cache upload and download for every job on `rust-dev`.

Job durations on `main` today, for comparison after this lands: build 111 s,
unit-test 75 s, rust-integration-test 147 s, typescript-integration-test 348 s, lint 92 s,
format 48 s, idl-check 65 s, fuzz-smoke ~270 s per leg, cargo-audit 38 s, miri 73 s.

## Follow-up after merge

The old keys are dead the moment this merges. They should be deleted with
`gh cache delete <id>` so they are not occupying quota, and the next `main` run checked for
`Restored from` on the consumer jobs.

## Testing

- `just unit-test` and `just lint-check` pass with the new dev profile.
- Cold `cargo build --workspace --timings` before and after the profile change, numbers above.
- Cache keys and `save-if` verified by reading the rendered inputs; the real proof is the
  next `main` run writing one `rust-dev` entry and PR runs writing none.

## AI disclosure

- [x] AI tooling was used. Tool and extent: Claude Code took the measurements, wrote the
  workflow and profile changes and drafted this description; I reviewed the diff and the
  numbers. marzipan
