### PR TITLE
chore: drop unused dependencies and dead serde feature

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,13 +19,13 @@ inputs:
     required: false
     default: 'true'
   save-rust-cache:
-    description: 'Save the Rust cache after this job (only enable for the build job)'
+    description: 'Save the Rust cache after this job. Enable on exactly one producer job per cache key; saves only happen on main.'
     required: false
     default: 'false'
   rust-cache-key:
-    description: 'Key for the Rust cache'
+    description: 'Shared Rust cache key. One key per distinct build config: rust-dev, fuzz, miri, release.'
     required: false
-    default: 'build'
+    default: 'rust-dev'
   install-surfpool:
     description: 'Install surfpool (only needed for integration tests)'
     required: false
@@ -71,7 +71,7 @@ runs:
       with:
         workspaces: '. -> target'
         shared-key: ${{ inputs.rust-cache-key }}
-        save-if: ${{ inputs.save-rust-cache }}
+        save-if: ${{ inputs.save-rust-cache == 'true' && github.ref == 'refs/heads/main' }}
         cache-on-failure: true
 
     - name: Resolve Solana release

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'benchmark'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Run benchmark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,7 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'build'
-          save-rust-cache: 'true'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Build program and clients

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'format'
+          enable-rust-cache: 'false'
 
       - name: Check formatting
         run: just fmt-check

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust-cache-key: 'fuzz'
+          save-rust-cache: ${{ matrix.test == 'invariant_subscriptions' }}
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Cache crucible CLI

--- a/.github/workflows/idl-check.yml
+++ b/.github/workflows/idl-check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'idl-check'
+          rust-cache-key: 'rust-dev'
 
       - name: Check generated files
         run: just check-generated

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'lint'
+          rust-cache-key: 'rust-dev'
 
       - name: Check linting
         run: just lint-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'release-${{ inputs.network }}'
+          rust-cache-key: 'release'
+          save-rust-cache: 'true'
           solana-version: 'v4.0.0'
 
       - name: Install solana-verify

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
           install-solana: 'false'
           install-just: 'false'
           install-pnpm: 'false'
-          rust-cache-key: 'cargo-audit'
+          enable-rust-cache: 'false'
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-audit
@@ -55,6 +55,7 @@ jobs:
           install-just: 'false'
           install-pnpm: 'false'
           rust-cache-key: 'miri'
+          save-rust-cache: 'true'
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install-solana: 'false'
-          rust-cache-key: 'unit-test'
-          save-rust-cache: 'true'
+          rust-cache-key: 'rust-dev'
 
       - name: Run unit tests
         run: just unit-test
@@ -45,7 +44,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          rust-cache-key: 'rust-integration-test'
+          rust-cache-key: 'rust-dev'
+          save-rust-cache: 'true'
           solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Run Rust integration tests
@@ -61,9 +61,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         with:
-          enable-rust-cache: 'false'
           install-surfpool: 'true'
-          rust-cache-key: 'typescript-integration-test'
+          rust-cache-key: 'rust-dev'
           solana-version: ${{ env.SOLANA_VERSION }}
           surfpool-version: ${{ env.SURFPOOL_VERSION }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,15 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,18 +700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-link",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,12 +931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,16 +1095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
-dependencies = [
- "powerfmt",
- "serde_core",
-]
-
-[[package]]
 name = "derivation-path"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,12 +1171,6 @@ checksum = "e2137ce22f50d4c43ce098daf41c904cc700de1ce8bc2daf53ed4e702180a464"
 dependencies = [
  "linktime-proc-macro",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eager"
@@ -1607,12 +1564,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -1640,12 +1591,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1752,30 +1697,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1889,25 +1810,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2155,7 +2063,7 @@ dependencies = [
  "agave-syscalls",
  "ansi_term",
  "bincode",
- "indexmap 2.13.0",
+ "indexmap",
  "itertools 0.14.0",
  "log",
  "serde",
@@ -2206,29 +2114,6 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "litesvm-token"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00114e5646f39f0e9202ce4e6fc0035975a959321dc4b10baf35907220d4dc19"
-dependencies = [
- "litesvm",
- "smallvec",
- "solana-account",
- "solana-address 2.6.0",
- "solana-keypair",
- "solana-program-option",
- "solana-program-pack",
- "solana-rent 3.1.0",
- "solana-signer",
- "solana-system-interface 3.2.0",
- "solana-transaction",
- "solana-transaction-error",
- "spl-associated-token-account-interface",
- "spl-token-2022-interface 2.1.0",
- "spl-token-interface 2.0.0",
 ]
 
 [[package]]
@@ -2335,12 +2220,6 @@ dependencies = [
  "autocfg",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -2608,12 +2487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,26 +2735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,30 +2946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,18 +3060,8 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64 0.22.1",
- "bs58",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.13.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
  "serde_core",
- "serde_json",
  "serde_with_macros",
- "time",
 ]
 
 [[package]]
@@ -5436,8 +5255,6 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "serde",
- "serde_with",
  "solana-account",
  "solana-account-info",
  "solana-address 2.6.0",
@@ -5552,7 +5369,6 @@ version = "0.5.0"
 dependencies = [
  "dtor",
  "litesvm",
- "litesvm-token",
  "pinocchio",
  "pinocchio-associated-token-account",
  "pinocchio-system",
@@ -5618,37 +5434,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -5763,7 +5548,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -5777,7 +5562,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -6128,63 +5913,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ solana-security-txt = "1.1.3"
 spl-token-interface = "3.0.0"
 thiserror = { version = "2", default-features = false }
 
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 overflow-checks = true
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,7 @@ pinocchio-token = "0.6.0"
 pinocchio-token-2022 = "0.3.1"
 serde_json = "1"
 solana-address = { version = "2", features = ["curve25519"] }
-solana-program-pack = "3"
 solana-security-txt = "1.1.3"
-spl-token-interface = "3.0.0"
 thiserror = { version = "2", default-features = false }
 
 [profile.dev]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -25,11 +25,9 @@ solana-instruction = "3.1"
 solana-program-error = "~3.0"
 solana-rpc-client = { version = "3.1.8", optional = true }
 
-# Serde support
-serde = { version = "1.0", features = ["derive"], optional = true }
-serde_with = { version = "3.20", optional = true }
-
 [features]
 default = []
-serde = ["dep:serde", "dep:serde_with"]
 fetch = ["dep:solana-account", "dep:solana-rpc-client"]
+
+[package.metadata.cargo-machete]
+ignored = ["num-traits"]

--- a/fuzz/subscriptions/Cargo.lock
+++ b/fuzz/subscriptions/Cargo.lock
@@ -4962,7 +4962,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subscriptions"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "borsh",
  "num-derive",

--- a/fuzz/subscriptions/Cargo.toml
+++ b/fuzz/subscriptions/Cargo.toml
@@ -28,6 +28,9 @@ spl-token-2022-interface = "2.1"
 spl-tlv-account-resolution = "0.11.1"
 spl-transfer-hook-interface = "2.1.0"
 
+[package.metadata.cargo-machete]
+ignored = ["arbitrary", "crucible-test-context", "ctrlc", "libafl", "libafl_bolts"]
+
 [[bin]]
 name = "invariant_test"
 path = "src/main.rs"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["lib", "cdylib"]
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["serde_json", "solana-address"]
+
 [features]
 no-entrypoint = []
 

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -16,7 +16,6 @@ pinocchio-system = { workspace = true }
 pinocchio-token = { workspace = true }
 pinocchio-token-2022 = { workspace = true }
 litesvm = "^0.12"
-litesvm-token = { version = "^0.12", features = ["token-2022"] }
 solana-account = "~3.4"
 solana-clock = "^3"
 solana-instruction = "^3"


### PR DESCRIPTION
## What and why

Stacked on #249; base retargets to `main` when that merges. The two are independent, but
both touch the root `Cargo.toml` and stacking keeps the diff clean.

`cargo machete --with-metadata` (v0.9, installed into a throwaway `CARGO_INSTALL_ROOT`)
flagged nine dependencies across four manifests. Every one was treated as a candidate and
confirmed or refuted by removing it and rebuilding, not by grep, because two of them are
invisible to a text search.

### Removed (6)

| Crate | Manifest | Evidence |
| --- | --- | --- |
| `litesvm-token` | `tests/integration-tests` | zero references anywhere under `tests/` |
| `serde` | `clients/rust` | zero references in `src/`, including `src/generated` |
| `serde_with` | `clients/rust` | same |
| `solana-program-pack` | `[workspace.dependencies]` | no member uses `{ workspace = true }` for it; the integration tests declare their own `"^3"` |
| `spl-token-interface` | `[workspace.dependencies]` | same, tests declare `"3.0.0"` directly |
| feature `serde` | `clients/rust` | it only existed to gate the two crates above |

The client's `serde` feature is a published feature of the `subscriptions` crate, so this
is worth a callout: `scripts/generate-clients.ts` calls `renderRustVisitor` without any
serde option, and `src/generated` contains no `#[cfg_attr(feature = "serde", ...)]`
anywhere. Enabling the feature today compiles two extra crates and changes no behavior.
Anyone depending on `subscriptions` with `features = ["serde"]` will need to drop it.

### Kept, with `[package.metadata.cargo-machete] ignored`, and why (3 + 5)

**`solana-address` in `program/`.** The source never writes `solana_address`, so machete is
right about the text and wrong about the build. `pinocchio::Address` is a re-export of
`solana_address::Address`, and `find_program_address` / `create_program_address` are behind
that crate's `curve25519` feature. The program depends on `solana-address` purely to turn
that feature on. Removing it builds fine under `cargo build --workspace` because
`clients/rust` enables the same feature and cargo unifies it, and then fails the moment a
job builds the program alone:

```
error[E0599]: no function or associated item named `create_program_address`
              found for struct `pinocchio::Address` in the current scope
   --> program/src/instructions/helpers/token.rs:362:37
```

Ten errors of that shape from `just unit-test`. This is the same trap as a dependency that
exists only to select a feature, and it is the reason the workspace build is not a
sufficient check on its own.

**`serde_json` in `program/`.** Build-dependency, used in `build.rs` to post-process the
generated IDL. Machete does not credit build-script usage here.

**`arbitrary`, `crucible-test-context`, `ctrlc`, `libafl`, `libafl_bolts` in
`fuzz/subscriptions`.** Never named in `fuzz/subscriptions/src`; all five are emitted by
crucible's proc macros, e.g. `crucible-fuzz-macro/src/codegen.rs` expands to
`ctrlc::set_handler`, `libafl::generators::Generator` and `libafl_bolts::Named`, and
`crucible-invariant-macro` expands to `arbitrary::Arbitrary`. Verified by reading the macro
codegen in the pinned crucible checkout rather than by building, since the fuzz crate is a
separate workspace that only builds under the crucible CLI.

## Not applicable to this repo

The recipe's TLS and mockall items have nothing to remove here:

- No `aws-lc-sys`, `aws-lc-rs`, `native-tls`, `openssl`, `hyper-tls` or `tokio-native-tls`
  in `Cargo.lock`. `rustls` is present exactly once and already resolves through `ring`
  (via quinn, through the Solana client stack). There is one TLS stack and it is the
  intended one.
- No `mockall` anywhere in the tree.
- No member declares `tokio`, `tower` or `tower-http`, so there are no `full` features to
  trim; they arrive transitively through `solana-rpc-client`.

`cargo tree -d` still reports 83 duplicate-version lines: `ark-*` 0.4 and 0.5,
`getrandom` 0.1/0.2/0.3, four `itertools`, three `hashbrown`. Every one of them is pulled
transitively by the Solana and agave crates that `litesvm` pins; no workspace member names
any of them, so there is nothing to collapse from this side. Upstream-blocked.

Same for the cold-build critical path measured in #249: 40.7 s of a 120.5 s build is the
`libsecp256k1` build script, reached through `litesvm -> agave-syscalls`. Nothing in this
PR moves it, and nothing can without dropping litesvm.

## Numbers

- `Cargo.lock`: 573 -> 548 packages (-25). Dropped: `litesvm-token`, `schemars` x2,
  `chrono`, `time`, `time-core`, `time-macros`, `deranged`, `num-conv`, `powerfmt`,
  `indexmap`, `hashbrown`, `hex`, `dyn-clone`, `ref-cast`, `ref-cast-impl`,
  `iana-time-zone`, `iana-time-zone-haiku`, `android_system_properties`,
  `core-foundation-sys`, `windows-core`, `windows-implement`, `windows-interface`,
  `windows-result`, `windows-strings`.
- `cargo build --workspace`: 476 -> 468 compile units, `target/` 990 MB -> 977 MB.
- Wall time is inside run-to-run noise on this machine and I am not going to claim a
  number for it. `serde`/`serde_with` were optional and off by default, so they were
  costing lockfile and resolver weight, not compile time; the only unit that actually
  stopped being built is `litesvm-token` and its exclusive dependencies.

`fuzz/subscriptions/Cargo.lock` picks up a one-line refresh: it still recorded the local
`subscriptions` path dependency at 0.4.0, and cargo corrected it to 0.5.0 when the manifest
changed.

## Testing

- `just unit-test`: 59 passed, 0 failed.
- `just integration-test`: 274 passed, 0 failed.
- `just lint-check`: passes.
- `just build-program`: SBF build succeeds, IDL unchanged.
- `cargo test -p tests-subscriptions --no-run` and `cargo build -p subscriptions
  --all-features` build per package, which is what caught the `solana-address` removal.
- `cargo machete --with-metadata`: clean.

## AI disclosure

- [x] AI tooling was used. Tool and extent: Claude Code ran the dependency analysis and the
  removal-and-rebuild confirmations, made the manifest edits and drafted this description;
  I reviewed the diff and the test output. marzipan
